### PR TITLE
Render image outputs in presentation and dashboard layouts

### DIFF
--- a/src/Verso.Blazor.Shared/Components/Notebook/DashboardCell.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/DashboardCell.razor
@@ -65,7 +65,7 @@
                         @((MarkupString)output.Content)
                     </div>
                 }
-                else if (output.MimeType.StartsWith("image/"))
+                else if (output.MimeType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
                 {
                     <div class="verso-output verso-output--html">
                         <img src="@($"data:{output.MimeType};base64,{output.Content}")" style="max-width:100%" />

--- a/src/Verso.Blazor.Shared/Components/Notebook/DashboardCell.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/DashboardCell.razor
@@ -65,6 +65,12 @@
                         @((MarkupString)output.Content)
                     </div>
                 }
+                else if (output.MimeType.StartsWith("image/"))
+                {
+                    <div class="verso-output verso-output--html">
+                        <img src="@($"data:{output.MimeType};base64,{output.Content}")" style="max-width:100%" />
+                    </div>
+                }
                 else
                 {
                     <div class="verso-output verso-output--text">

--- a/src/Verso.Blazor.Shared/Components/Notebook/PresentationView.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/PresentationView.razor
@@ -31,6 +31,12 @@
                             @((MarkupString)output.Content)
                         </div>
                     }
+                    else if (output.MimeType.StartsWith("image/"))
+                    {
+                        <div class="verso-output verso-output--html">
+                            <img src="@($"data:{output.MimeType};base64,{output.Content}")" style="max-width:100%" />
+                        </div>
+                    }
                     else
                     {
                         <div class="verso-output verso-output--text">

--- a/src/Verso.Blazor.Shared/Components/Notebook/PresentationView.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/PresentationView.razor
@@ -31,7 +31,7 @@
                             @((MarkupString)output.Content)
                         </div>
                     }
-                    else if (output.MimeType.StartsWith("image/"))
+                    else if (output.MimeType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
                     {
                         <div class="verso-output verso-output--html">
                             <img src="@($"data:{output.MimeType};base64,{output.Content}")" style="max-width:100%" />

--- a/src/Verso/Extensions/Layouts/PresentationLayout.cs
+++ b/src/Verso/Extensions/Layouts/PresentationLayout.cs
@@ -86,6 +86,16 @@ public sealed class PresentationLayout : ILayoutEngine
                     sb.Append(output.Content);
                     sb.Append("</div>");
                 }
+                else if (output.MimeType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+                {
+                    sb.Append("<div class=\"verso-output verso-output--html\">");
+                    sb.Append("<img src=\"data:")
+                      .Append(WebUtility.HtmlEncode(output.MimeType))
+                      .Append(";base64,")
+                      .Append(WebUtility.HtmlEncode(output.Content))
+                      .Append("\" style=\"max-width:100%\" />");
+                    sb.Append("</div>");
+                }
                 else
                 {
                     sb.Append("<div class=\"verso-output verso-output--text\"><pre style=\"margin:0;white-space:pre-wrap;\">");


### PR DESCRIPTION
## Problem

Notebook cells can produce raster image outputs such as `image/png`, but presentation and dashboard rendering paths did not handle image MIME types. In those layouts, image output could appear as raw base64 text instead of an image.

This is especially visible when plotting libraries save or display generated charts as image output and the notebook is switched into presentation mode.

## Approach

Teach every presentation/dashboard output rendering path to treat `image/*` MIME types as data URI images, matching the behavior users already get in the regular notebook cell renderer.

## Notable changes

- Render `image/*` outputs as `<img>` elements in `PresentationView.razor`.
- Render `image/*` outputs as `<img>` elements in `DashboardCell.razor`.
- Add equivalent image output rendering to the HTML-producing `PresentationLayout`.
- Preserve the existing handling for HTML, Markdown, plain text, and fallback MIME types.

## Validation

- `dotnet build src/Verso.Blazor.Shared/Verso.Blazor.Shared.csproj --no-restore`
- `dotnet build src/Verso/Verso.csproj --no-restore`

## Manual check

A notebook cell that outputs `image/png` now displays the image in presentation mode and dashboard cells instead of showing the base64 payload.

## Review notes

This PR is scoped to rendering existing image outputs. It does not change execution, serialization, or output generation.
