### PR TITLE
Do not auto-run notebooks when switching to presentation layout

### DIFF
--- a/src/Verso.Blazor.Wasm/Pages/NotebookPage.razor
+++ b/src/Verso.Blazor.Wasm/Pages/NotebookPage.razor
@@ -439,18 +439,7 @@
         if (_activePanel == "properties" && !Service.ActiveLayoutSupportsPropertiesPanel)
             _activePanel = null;
 
-        if (Service.ActiveLayoutId == "presentation")
-        {
-            await InvokeAsync(async () =>
-            {
-                await HandleRunAll();
-                StateHasChanged();
-            });
-        }
-        else
-        {
-            await InvokeAsync(StateHasChanged);
-        }
+        await InvokeAsync(StateHasChanged);
     }
 
     private async void HandleThemeChanged()

--- a/src/Verso.Blazor/Components/Pages/NotebookPage.razor
+++ b/src/Verso.Blazor/Components/Pages/NotebookPage.razor
@@ -553,18 +553,7 @@
         if (_activePanel == "properties" && !Service.ActiveLayoutSupportsPropertiesPanel)
             _activePanel = null;
 
-        if (Service.ActiveLayoutId == "presentation")
-        {
-            await InvokeAsync(async () =>
-            {
-                await HandleRunAll();
-                StateHasChanged();
-            });
-        }
-        else
-        {
-            await InvokeAsync(StateHasChanged);
-        }
+        await InvokeAsync(StateHasChanged);
     }
 
     private async void HandleThemeChanged()


### PR DESCRIPTION
## Problem

Switching to Presentation mode automatically ran all notebook cells. Layout changes should be view-only operations, but the previous behavior called `HandleRunAll()` when the active layout became `presentation`.

That could unexpectedly rerun expensive cells, mutate external systems, or overwrite outputs just because the user changed how the notebook is displayed.

## Approach

Remove the implicit Run All call from both notebook page implementations. Presentation mode now renders whatever outputs already exist, and execution only happens when the user explicitly runs a cell or chooses Run All.

## Notable changes

- Remove automatic `HandleRunAll()` from the WASM notebook page layout-change handler.
- Remove automatic `HandleRunAll()` from the Blazor Server notebook page layout-change handler.
- Keep explicit Run/Run All behavior unchanged.
- Keep presentation rendering behavior unchanged, other than no longer triggering execution on layout switch.

## Validation

- `dotnet build src/Verso.Blazor.Wasm/Verso.Blazor.Wasm.csproj --no-restore`
- `dotnet build src/Verso.Blazor/Verso.Blazor.csproj --no-restore`
- `npm run build:all`

## Manual check

Switching to Presentation mode no longer starts notebook execution. Existing outputs remain visible, and cells only execute after an explicit Run or Run All action.

## Review notes

This PR intentionally changes only the layout switch side effect. It does not alter presentation layout rendering or toolbar command behavior.
