### PR TITLE
Add PowerShell cancellation and stop controls

### DIFF
--- a/src/Verso.Blazor.Shared/Components/Notebook/Cell.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/Cell.razor
@@ -9,11 +9,22 @@
         <div class="verso-cell-gutter-actions">
             @if (IsEditable)
             {
-                <button class="verso-cell-btn verso-cell-btn--run verso-cell-gutter-btn"
-                        @onclick="() => OnRunCell.InvokeAsync(CellData.Id)"
-                        title="Run" disabled="@IsExecuting">
-                    @if (IsExecuting) { <span class="verso-spinner"></span> } else { <span>&#x25B6;</span> }
-                </button>
+                @if (CanStopExecution)
+                {
+                    <button class="verso-cell-btn verso-cell-btn--stop verso-cell-gutter-btn"
+                            @onclick="() => OnCancelCell.InvokeAsync(CellData.Id)"
+                            title="Stop">
+                        <span>&#x25A0;</span>
+                    </button>
+                }
+                else
+                {
+                    <button class="verso-cell-btn verso-cell-btn--run verso-cell-gutter-btn"
+                            @onclick="() => OnRunCell.InvokeAsync(CellData.Id)"
+                            title="Run" disabled="@IsExecuting">
+                        @if (IsExecuting) { <span class="verso-spinner"></span> } else { <span>&#x25B6;</span> }
+                    </button>
+                }
             }
             @if (IsHeadingCell)
             {
@@ -245,6 +256,7 @@
     [Parameter] public int Index { get; set; }
     [Parameter] public bool IsLast { get; set; }
     [Parameter] public EventCallback<Guid> OnRunCell { get; set; }
+    [Parameter] public EventCallback<Guid> OnCancelCell { get; set; }
     [Parameter] public EventCallback<Guid> OnDeleteCell { get; set; }
     [Parameter] public EventCallback<Guid> OnSelect { get; set; }
     [Parameter] public EventCallback<Guid> OnMoveUp { get; set; }
@@ -279,6 +291,9 @@
     private string EditorLanguage => CellData.Type == "markdown" ? "markdown" : (CellData.Language ?? "csharp");
 
     private bool HasErrorOutput => CellData.Outputs.Any(o => o.IsError);
+
+    private bool CanStopExecution => IsExecuting &&
+        string.Equals(CellData.Language, "powershell", StringComparison.OrdinalIgnoreCase);
 
     private string EffectiveStatus => HasErrorOutput
         ? "failed"

--- a/src/Verso.Blazor.Shared/Components/Notebook/DashboardCell.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/DashboardCell.razor
@@ -6,12 +6,23 @@
      style="grid-column:@((int)Position.X + 1)/span @((int)Position.Width);grid-row:@((int)Position.Y + 1)/span @((int)Position.Height);">
 
     <div class="verso-dashboard-cell-toolbar verso-dashboard-drag-handle">
-        <button class="verso-cell-btn verso-cell-btn--run"
-                @onclick="() => OnRunCell.InvokeAsync(CellData.Id)"
-                disabled="@IsExecuting"
-                title="Run">
-            @if (IsExecuting) { <span class="verso-spinner"></span> } else { <span>&#x25B6;</span> }
-        </button>
+        @if (CanStopExecution)
+        {
+            <button class="verso-cell-btn verso-cell-btn--stop"
+                    @onclick="() => OnCancelCell.InvokeAsync(CellData.Id)"
+                    title="Stop">
+                <span>&#x25A0;</span>
+            </button>
+        }
+        else
+        {
+            <button class="verso-cell-btn verso-cell-btn--run"
+                    @onclick="() => OnRunCell.InvokeAsync(CellData.Id)"
+                    disabled="@IsExecuting"
+                    title="Run">
+                @if (IsExecuting) { <span class="verso-spinner"></span> } else { <span>&#x25B6;</span> }
+            </button>
+        }
         <button class="verso-dashboard-edit-toggle"
                 @onclick="ToggleEdit"
                 title="Toggle Code">
@@ -77,6 +88,7 @@
     [Parameter] public CellContainerInfo Position { get; set; } = default!;
     [Parameter] public bool IsExecuting { get; set; }
     [Parameter] public EventCallback<Guid> OnRunCell { get; set; }
+    [Parameter] public EventCallback<Guid> OnCancelCell { get; set; }
     [Parameter] public EventCallback<(Guid CellId, string Source)> OnSourceChanged { get; set; }
     [Parameter] public EventCallback<(Guid CellId, int ColSpan, int RowSpan)> OnResized { get; set; }
     [Parameter] public EventCallback<(Guid CellId, int Col, int Row)> OnMoved { get; set; }
@@ -88,6 +100,8 @@
 
     private string _elementId => $"verso-cell-{CellData.Id}";
     private string EditorLanguage => CellData.Type == "markdown" ? "markdown" : (CellData.Language ?? "csharp");
+    private bool CanStopExecution => IsExecuting &&
+        string.Equals(CellData.Language, "powershell", StringComparison.OrdinalIgnoreCase);
 
     private void ToggleEdit() => _showCode = !_showCode;
 

--- a/src/Verso.Blazor.Shared/Components/Notebook/DashboardGrid.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/DashboardGrid.razor
@@ -6,6 +6,7 @@
                        Position="pos"
                        IsExecuting="cell.Id == ExecutingCellId"
                        OnRunCell="OnRunCell"
+                       OnCancelCell="OnCancelCell"
                        OnSourceChanged="OnSourceChanged"
                        OnResized="HandleCellResized"
                        OnMoved="HandleCellMoved" />
@@ -17,6 +18,7 @@
     [Parameter] public IReadOnlyList<CellModel> Cells { get; set; } = Array.Empty<CellModel>();
     [Parameter] public Guid? ExecutingCellId { get; set; }
     [Parameter] public EventCallback<Guid> OnRunCell { get; set; }
+    [Parameter] public EventCallback<Guid> OnCancelCell { get; set; }
     [Parameter] public EventCallback<(Guid CellId, string Source)> OnSourceChanged { get; set; }
 
     private Dictionary<Guid, CellContainerInfo> _positions = new();

--- a/src/Verso.Blazor.Shared/Services/INotebookService.cs
+++ b/src/Verso.Blazor.Shared/Services/INotebookService.cs
@@ -166,6 +166,9 @@ public interface INotebookService
     /// <summary>Execute all cells in order.</summary>
     Task<IReadOnlyList<ExecutionResultDto>> ExecuteAllAsync();
 
+    /// <summary>Cancel the current notebook execution, if one is running.</summary>
+    Task CancelExecutionAsync();
+
     /// <summary>Restart the active kernel.</summary>
     Task RestartKernelAsync();
 

--- a/src/Verso.Blazor.Shared/wwwroot/app.css
+++ b/src/Verso.Blazor.Shared/wwwroot/app.css
@@ -732,6 +732,10 @@ html, body {
     color: var(--verso-status-success, #28A745);
 }
 
+.verso-cell-btn--stop {
+    color: var(--verso-status-error, #DC3545);
+}
+
 .verso-cell-btn--delete {
     color: var(--verso-status-error, #DC3545);
 }

--- a/src/Verso.Blazor.Wasm/Pages/NotebookPage.razor
+++ b/src/Verso.Blazor.Wasm/Pages/NotebookPage.razor
@@ -59,6 +59,7 @@
                                    Cells="GetLayoutFilteredCells()"
                                    ExecutingCellId="_executingCellId"
                                    OnRunCell="HandleRunCell"
+                                   OnCancelCell="HandleCancelCell"
                                    OnSourceChanged="HandleSourceChanged" />
                 }
                 else if (Service.ActiveLayoutId == "presentation")
@@ -108,6 +109,7 @@
                                       IsSectionCollapsed="isSectionCollapsed"
                                       OnToggleSection="HandleToggleSection"
                                       OnRunCell="HandleRunCell"
+                                      OnCancelCell="HandleCancelCell"
                                       OnDeleteCell="HandleDeleteCell"
                                       OnSelect="HandleSelectCell"
                                       OnMoveUp="HandleMoveUp"
@@ -650,6 +652,18 @@
         catch (Exception ex)
         {
             _error = $"Execution error: {ex.Message}";
+        }
+    }
+
+    private async Task HandleCancelCell(Guid cellId)
+    {
+        try
+        {
+            await Service.CancelExecutionAsync();
+        }
+        catch (Exception ex)
+        {
+            _error = $"Cancel failed: {ex.Message}";
         }
     }
 

--- a/src/Verso.Blazor.Wasm/Services/RemoteNotebookService.cs
+++ b/src/Verso.Blazor.Wasm/Services/RemoteNotebookService.cs
@@ -410,6 +410,11 @@ public sealed class RemoteNotebookService : INotebookService, IAsyncDisposable
         return dtos;
     }
 
+    public async Task CancelExecutionAsync()
+    {
+        await _bridge.RequestVoidAsync("execution/cancel", null);
+    }
+
     public async Task RestartKernelAsync()
     {
         await _bridge.RequestVoidAsync("kernel/restart", null);

--- a/src/Verso.Blazor/Components/Pages/NotebookPage.razor
+++ b/src/Verso.Blazor/Components/Pages/NotebookPage.razor
@@ -95,6 +95,7 @@
                                    Cells="GetLayoutFilteredCells()"
                                    ExecutingCellId="_executingCellId"
                                    OnRunCell="HandleRunCell"
+                                   OnCancelCell="HandleCancelCell"
                                    OnSourceChanged="HandleSourceChanged" />
                 }
                 else if (Service.ActiveLayoutId == "presentation")
@@ -144,6 +145,7 @@
                                       IsSectionCollapsed="isSectionCollapsed"
                                       OnToggleSection="HandleToggleSection"
                                       OnRunCell="HandleRunCell"
+                                      OnCancelCell="HandleCancelCell"
                                       OnDeleteCell="HandleDeleteCell"
                                       OnSelect="HandleSelectCell"
                                       OnMoveUp="HandleMoveUp"
@@ -924,6 +926,18 @@
         catch (Exception ex)
         {
             _error = $"Execution error: {ex.Message}";
+        }
+    }
+
+    private async Task HandleCancelCell(Guid cellId)
+    {
+        try
+        {
+            await Service.CancelExecutionAsync();
+        }
+        catch (Exception ex)
+        {
+            _error = $"Cancel failed: {ex.Message}";
         }
     }
 

--- a/src/Verso.Blazor/Services/ServerNotebookService.cs
+++ b/src/Verso.Blazor/Services/ServerNotebookService.cs
@@ -435,6 +435,11 @@ public sealed class ServerNotebookService : INotebookService, IAsyncDisposable
             new ExecutionResultDto(r.CellId, r.Status.ToString(), r.ExecutionCount, r.Elapsed)).ToList();
     }
 
+    public Task CancelExecutionAsync()
+    {
+        return Task.CompletedTask;
+    }
+
     public async Task RestartKernelAsync()
     {
         if (_scaffold is null) return;

--- a/src/Verso.Blazor/wwwroot/app.css
+++ b/src/Verso.Blazor/wwwroot/app.css
@@ -731,6 +731,10 @@ html, body {
     color: var(--verso-status-success, #28A745);
 }
 
+.verso-cell-btn--stop {
+    color: var(--verso-status-error, #DC3545);
+}
+
 .verso-cell-btn--delete {
     color: var(--verso-status-error, #DC3545);
 }

--- a/src/Verso.Host/Program.cs
+++ b/src/Verso.Host/Program.cs
@@ -22,9 +22,10 @@ SendLine(JsonRpcMessage.Notification(MethodNames.HostReady, new { version = "1.0
 var requests = Channel.CreateUnbounded<(object id, string method, JsonElement? @params)>();
 
 // Background task: continuously read stdin.
-// Consent responses are resolved immediately (they just complete a TCS) to prevent
-// deadlocks when a handler is blocked waiting for consent approval.  All other
-// requests are forwarded to the main loop via the channel.
+// Consent responses and cancellation are resolved immediately to prevent
+// deadlocks when a handler is blocked waiting for consent approval or a
+// running execution needs to be interrupted.
+// All other requests are forwarded to the main loop via the channel.
 _ = Task.Run(async () =>
 {
     try
@@ -41,9 +42,10 @@ _ = Task.Run(async () =>
                 if (id is null || method is null)
                     continue;
 
-                if (method == MethodNames.ExtensionConsentResponse)
+                if (method == MethodNames.ExtensionConsentResponse ||
+                    method == MethodNames.ExecutionCancel)
                 {
-                    // Handle inline — resolves a TCS, no heavy work.
+                    // Handle inline: these paths only resolve pending state.
                     var response = await session.DispatchAsync(id, method, @params);
                     SendLine(response, stdoutLock);
                     continue;

--- a/src/Verso.PowerShell/Kernel/PowerShellKernel.cs
+++ b/src/Verso.PowerShell/Kernel/PowerShellKernel.cs
@@ -73,6 +73,8 @@ public sealed class PowerShellKernel : ILanguageKernel
             }
 
             var result = _runspaceManager!.Invoke(code, context.CancellationToken);
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             var outputs = new List<CellOutput>();
 
             // Output stream (objects)

--- a/tests/Verso.Blazor.Shared.Tests/CellTests.cs
+++ b/tests/Verso.Blazor.Shared.Tests/CellTests.cs
@@ -121,6 +121,46 @@ public sealed class CellTests : BunitTestContext
     }
 
     [TestMethod]
+    public void StopButton_VisibleForExecutingPowerShellCell()
+    {
+        var cell = CreateCodeCell("Start-Sleep -Seconds 120");
+        cell.Language = "powershell";
+
+        var cut = RenderCell(cell, isExecuting: true);
+
+        Assert.AreEqual(1, cut.FindAll("button[title='Stop']").Count);
+        Assert.AreEqual(0, cut.FindAll("button[title='Run']").Count);
+    }
+
+    [TestMethod]
+    public void StopButton_HiddenForExecutingNonPowerShellCell()
+    {
+        var cell = CreateCodeCell("await Task.Delay(120000);");
+
+        var cut = RenderCell(cell, isExecuting: true);
+
+        Assert.AreEqual(0, cut.FindAll("button[title='Stop']").Count);
+        Assert.AreEqual(1, cut.FindAll("button[title='Run']").Count);
+    }
+
+    [TestMethod]
+    public void StopButton_ClickInvokesCancelCallback()
+    {
+        var cell = CreateCodeCell("Start-Sleep -Seconds 120");
+        cell.Language = "powershell";
+        Guid? cancelledCellId = null;
+
+        var cut = RenderCell(
+            cell,
+            isExecuting: true,
+            onCancelCell: id => cancelledCellId = id);
+
+        cut.Find("button[title='Stop']").Click();
+
+        Assert.AreEqual(cell.Id, cancelledCellId);
+    }
+
+    [TestMethod]
     public void Outputs_Rendered_WhenPresent()
     {
         var cell = CreateCodeCell("print('hello')");
@@ -207,7 +247,8 @@ public sealed class CellTests : BunitTestContext
         bool isSelected = false,
         bool isExecuting = false,
         int index = 0,
-        bool isLast = false)
+        bool isLast = false,
+        Action<Guid>? onCancelCell = null)
     {
         // Set up JS interop stub for MonacoEditor
         TestContext!.JSInterop.SetupVoid("versoMonaco.create", _ => true);
@@ -220,6 +261,7 @@ public sealed class CellTests : BunitTestContext
             .Add(c => c.IsSelected, isSelected)
             .Add(c => c.IsExecuting, isExecuting)
             .Add(c => c.Index, index)
-            .Add(c => c.IsLast, isLast));
+            .Add(c => c.IsLast, isLast)
+            .Add(c => c.OnCancelCell, id => onCancelCell?.Invoke(id)));
     }
 }

--- a/tests/Verso.Blazor.Shared.Tests/Fakes/FakeNotebookService.cs
+++ b/tests/Verso.Blazor.Shared.Tests/Fakes/FakeNotebookService.cs
@@ -83,6 +83,7 @@ public sealed class FakeNotebookService : INotebookService
     public List<string> AddCellCalls { get; } = new();
     public List<Guid> ExecutedCellIds { get; } = new();
     public int ExecuteAllCallCount { get; private set; }
+    public int CancelExecutionCallCount { get; private set; }
     public int RestartKernelCallCount { get; private set; }
     public int NewNotebookCallCount { get; private set; }
     public int SaveCallCount { get; private set; }
@@ -165,6 +166,12 @@ public sealed class FakeNotebookService : INotebookService
     {
         ExecuteAllCallCount++;
         return Task.FromResult<IReadOnlyList<ExecutionResultDto>>(new List<ExecutionResultDto>());
+    }
+
+    public Task CancelExecutionAsync()
+    {
+        CancelExecutionCallCount++;
+        return Task.CompletedTask;
     }
 
     public Task RestartKernelAsync()

--- a/tests/Verso.PowerShell.Tests/Kernel/ExecutionTests.cs
+++ b/tests/Verso.PowerShell.Tests/Kernel/ExecutionTests.cs
@@ -51,6 +51,29 @@ public class ExecutionTests
     }
 
     [TestMethod]
+    [Timeout(10000)]
+    public async Task Cancellation_StopsLongRunningCommandAndKeepsKernelUsable()
+    {
+        using var cts = new CancellationTokenSource();
+        _context.CancellationToken = cts.Token;
+
+        var execution = Task.Run(() => _kernel.ExecuteAsync(
+            "Start-Sleep -Seconds 30",
+            _context));
+
+        await Task.Delay(500);
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await execution);
+
+        var nextContext = new StubExecutionContext();
+        var outputs = await _kernel.ExecuteAsync("1 + 1", nextContext);
+        var allText = string.Join(" ", outputs.Select(o => o.Content));
+        Assert.IsTrue(allText.Contains("2"), $"Expected kernel to remain usable, got: {allText}");
+    }
+
+    [TestMethod]
     public async Task WriteError_ReturnsErrorOutput()
     {
         var outputs = await _kernel.ExecuteAsync("Write-Error 'something failed'", _context);


### PR DESCRIPTION
## Problem

PowerShell execution could be long-running, but the UI did not have a reliable way to stop an in-flight execution. Cancellation also needed to bypass the host's sequential request queue, otherwise a cancel request could wait behind the execution it is trying to interrupt.

## Approach

Add notebook-level cancellation APIs and route `execution/cancel` immediately in the host input loop. The Blazor UI can then show stop controls while PowerShell cells are running and send cancellation without waiting for the normal queued request path.

## Notable changes

- Handle `execution/cancel` outside the host's sequential request queue.
- Add cancellation methods to the notebook service surface for server and WASM front ends.
- Wire WASM cancellation through the VS Code bridge/host protocol.
- Show stop controls for running PowerShell cells in notebook and dashboard views.
- Keep the kernel usable after a cancelled execution.
- Add PowerShell cancellation coverage.

## Validation

- `dotnet test tests/Verso.PowerShell.Tests/Verso.PowerShell.Tests.csproj --no-restore`
- `dotnet build Verso.sln --no-restore`

## Manual check

Start a long-running PowerShell cell, then press the stop control:

```powershell
Start-Sleep -Seconds 30
"after"
```

The cell should stop without waiting for the sleep to finish, and a later PowerShell cell should still execute successfully.

## Review notes

This PR depends conceptually on the PowerShell execution path but is separated from host UI streaming/input so cancellation can be reviewed independently.
