### PR TITLE
Target PowerShell host to .NET 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ The CLI includes six commands:
 ### Run in VS Code
 
 ```bash
-dotnet build src/Verso.Host
+dotnet build src/Verso.Host -f net10.0
 cd vscode
 npm install
 npm run build:all

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -7,10 +7,10 @@ The original copyright notices and license texts are provided for each component
 
 | Component | Version | License | Project |
 |---|---|---|---|
-| Microsoft.CodeAnalysis (Roslyn) | 4.12.0 | MIT | [dotnet/roslyn](https://github.com/dotnet/roslyn) |
+| Microsoft.CodeAnalysis (Roslyn) | 4.12.0 / 5.0.0 | MIT | [dotnet/roslyn](https://github.com/dotnet/roslyn) |
 | NuGet.Protocol | 6.9.1 | Apache-2.0 | [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) |
 | Microsoft.AspNetCore.Components | 8.0.0 | MIT | [dotnet/aspnetcore](https://github.com/dotnet/aspnetcore) |
-| Microsoft.PowerShell.SDK | 7.4.7 | MIT | [PowerShell/PowerShell](https://github.com/PowerShell/PowerShell) |
+| Microsoft.PowerShell.SDK | 7.4.15 / 7.6.1 | MIT | [PowerShell/PowerShell](https://github.com/PowerShell/PowerShell) |
 | FSharp.Compiler.Service | 43.9.100 | MIT | [dotnet/fsharp](https://github.com/dotnet/fsharp) |
 | Jint | 4.6.4 | BSD-2-Clause | [sebastienros/jint](https://github.com/sebastienros/jint) |
 | pythonnet | 3.1.0-rc.0 | MIT | [pythonnet/pythonnet](https://github.com/pythonnet/pythonnet) |

--- a/src/Verso.Host/Verso.Host.csproj
+++ b/src/Verso.Host/Verso.Host.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/Verso.PowerShell/Verso.PowerShell.csproj
+++ b/src/Verso.PowerShell/Verso.PowerShell.csproj
@@ -19,8 +19,12 @@
     <InternalsVisibleTo Include="Verso.PowerShell.Tests" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.7" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.15" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Verso/Verso.csproj
+++ b/src/Verso/Verso.csproj
@@ -21,11 +21,21 @@
 
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.37.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.9.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.12.0" />
-    <PackageReference Include="NuGet.Protocol" Version="6.9.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Verso.Host.Tests/Verso.Host.Tests.csproj
+++ b/tests/Verso.Host.Tests/Verso.Host.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/Verso.PowerShell.Tests/Verso.PowerShell.Tests.csproj
+++ b/tests/Verso.PowerShell.Tests/Verso.PowerShell.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -386,7 +386,7 @@
   },
   "scripts": {
     "build": "node esbuild.mjs",
-    "build:host": "dotnet publish ../src/Verso.Host -c Release -o host",
+    "build:host": "dotnet publish ../src/Verso.Host -c Release -f net10.0 -o host",
     "build:wasm": "dotnet publish ../src/Verso.Blazor.Wasm -c Release -o blazor-wasm",
     "build:all": "npm run build:host && npm run build:wasm && npm run build",
     "watch": "node esbuild.mjs --watch",

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -80,18 +80,21 @@ export function resolveHostPath(
 
   // Search workspace folders for the Verso.Host.dll (check Release first, then Debug)
   const configs = ["Release", "Debug"];
+  const hostTargetFrameworks = ["net10.0", "net8.0"];
   const workspaceFolders = options.workspaceFolders ?? vscode.workspace.workspaceFolders ?? [];
   for (const folder of workspaceFolders) {
     for (const cfg of configs) {
-      const candidates = [
-        // Direct workspace is the Verso project
-        path.join(folder.uri.fsPath, "src", "Verso.Host", "bin", cfg, "net8.0", "Verso.Host.dll"),
-        // Workspace is a parent (e.g., Datafication.DataIntegration)
-        path.join(folder.uri.fsPath, "tools", "Verso", "src", "Verso.Host", "bin", cfg, "net8.0", "Verso.Host.dll"),
-      ];
-      for (const candidate of candidates) {
-        if (existsSync(candidate)) {
-          return candidate;
+      for (const tfm of hostTargetFrameworks) {
+        const candidates = [
+          // Direct workspace is the Verso project
+          path.join(folder.uri.fsPath, "src", "Verso.Host", "bin", cfg, tfm, "Verso.Host.dll"),
+          // Workspace is a parent (e.g., Datafication.DataIntegration)
+          path.join(folder.uri.fsPath, "tools", "Verso", "src", "Verso.Host", "bin", cfg, tfm, "Verso.Host.dll"),
+        ];
+        for (const candidate of candidates) {
+          if (existsSync(candidate)) {
+            return candidate;
+          }
         }
       }
     }
@@ -99,9 +102,11 @@ export function resolveHostPath(
 
   // Fallback: relative to extension path (works in dev host / local install)
   for (const cfg of configs) {
-    const extensionRelative = path.join(context.extensionPath, "..", "src", "Verso.Host", "bin", cfg, "net8.0", "Verso.Host.dll");
-    if (existsSync(extensionRelative)) {
-      return extensionRelative;
+    for (const tfm of hostTargetFrameworks) {
+      const extensionRelative = path.join(context.extensionPath, "..", "src", "Verso.Host", "bin", cfg, tfm, "Verso.Host.dll");
+      if (existsSync(extensionRelative)) {
+        return extensionRelative;
+      }
     }
   }
 

--- a/vscode/test/suite/extension.test.ts
+++ b/vscode/test/suite/extension.test.ts
@@ -89,9 +89,7 @@ suite("Extension Activation", () => {
 
   test("Workspace host resolution prefers net10 over net8", () => {
     const extensionPath = path.join("repo", "vscode");
-    const workspacePath = path.join("repo", "Verso");
-    const net10Host = path.join(workspacePath, "src", "Verso.Host", "bin", "Debug", "net10.0", "Verso.Host.dll");
-    const net8Host = path.join(workspacePath, "src", "Verso.Host", "bin", "Debug", "net8.0", "Verso.Host.dll");
+    const workspacePath = path.resolve("repo", "Verso");
     const context = {
       extensionPath,
       extensionMode: vscode.ExtensionMode.Production,
@@ -101,6 +99,9 @@ suite("Extension Activation", () => {
       name: "Verso",
       index: 0,
     };
+    const workspaceFsPath = workspaceFolder.uri.fsPath;
+    const net10Host = path.join(workspaceFsPath, "src", "Verso.Host", "bin", "Debug", "net10.0", "Verso.Host.dll");
+    const net8Host = path.join(workspaceFsPath, "src", "Verso.Host", "bin", "Debug", "net8.0", "Verso.Host.dll");
 
     const resolved = resolveHostPath(context, {
       existsSync: candidate => candidate === net10Host || candidate === net8Host,

--- a/vscode/test/suite/extension.test.ts
+++ b/vscode/test/suite/extension.test.ts
@@ -86,4 +86,27 @@ suite("Extension Activation", () => {
 
     assert.strictEqual(resolved, configured);
   });
+
+  test("Workspace host resolution prefers net10 over net8", () => {
+    const extensionPath = path.join("repo", "vscode");
+    const workspacePath = path.join("repo", "Verso");
+    const net10Host = path.join(workspacePath, "src", "Verso.Host", "bin", "Debug", "net10.0", "Verso.Host.dll");
+    const net8Host = path.join(workspacePath, "src", "Verso.Host", "bin", "Debug", "net8.0", "Verso.Host.dll");
+    const context = {
+      extensionPath,
+      extensionMode: vscode.ExtensionMode.Production,
+    } as vscode.ExtensionContext;
+    const workspaceFolder = {
+      uri: vscode.Uri.file(workspacePath),
+      name: "Verso",
+      index: 0,
+    };
+
+    const resolved = resolveHostPath(context, {
+      existsSync: candidate => candidate === net10Host || candidate === net8Host,
+      workspaceFolders: [workspaceFolder],
+    });
+
+    assert.strictEqual(resolved, net10Host);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up after #48.

Moves the local/F5 Verso host path to .NET 10 while keeping the Verso.PowerShell package compatible with both runtime lines.

## Changes

- Target Verso.Host and Verso.Host.Tests to net10.0.
- Multi-target Verso.PowerShell for net8.0 and net10.0.
- Use TFM-specific PowerShell SDK versions:
  - net8.0 -> Microsoft.PowerShell.SDK 7.4.15
  - net10.0 -> Microsoft.PowerShell.SDK 7.6.1
- Use TFM-specific Roslyn versions to avoid dependency conflicts with PowerShell SDK 7.6.x.
- Publish the VS Code bundled host explicitly with -f net10.0.
- Prefer net10 host discovery in VS Code development mode, with net8 fallback.

## Base

#48 is merged. This branch has been rebuilt on current `main`, so the PR now contains only the .NET 10 follow-up changes.

## Validation

- `dotnet test tests/Verso.PowerShell.Tests/Verso.PowerShell.Tests.csproj -c Debug --no-restore`
- `dotnet test tests/Verso.Host.Tests/Verso.Host.Tests.csproj -c Debug --no-restore`
- `npm run lint`
- `npm run pretest`
