### PR TITLE
Add SQL parameter scanning and local-scope analysis

### DIFF
--- a/src/Verso.Ado/Helpers/ParameterReference.cs
+++ b/src/Verso.Ado/Helpers/ParameterReference.cs
@@ -1,0 +1,11 @@
+namespace Verso.Ado.Helpers;
+
+/// <summary>
+/// A reference to a parameter token (e.g. <c>@name</c>) found in SQL text by
+/// <see cref="SqlParameterScanner"/>. Offsets are character positions in the
+/// scanned string.
+/// </summary>
+/// <param name="Name">Parameter name without the leading <c>@</c>.</param>
+/// <param name="Offset">Character offset of the leading <c>@</c> in the scanned string.</param>
+/// <param name="Length">Total length of the token including the leading <c>@</c>.</param>
+internal sealed record ParameterReference(string Name, int Offset, int Length);

--- a/src/Verso.Ado/Helpers/SqlDialect.cs
+++ b/src/Verso.Ado/Helpers/SqlDialect.cs
@@ -1,0 +1,15 @@
+namespace Verso.Ado.Helpers;
+
+/// <summary>
+/// SQL dialect identifier used to drive dialect-conditional behavior such as
+/// parameter scanning and local-name introduction rules.
+/// </summary>
+internal enum SqlDialect
+{
+    Unknown,
+    SqlServer,
+    Sqlite,
+    Postgres,
+    MySql,
+    Oracle,
+}

--- a/src/Verso.Ado/Helpers/SqlDialectResolver.cs
+++ b/src/Verso.Ado/Helpers/SqlDialectResolver.cs
@@ -1,0 +1,32 @@
+namespace Verso.Ado.Helpers;
+
+/// <summary>
+/// Maps ADO.NET provider invariant names to the corresponding <see cref="SqlDialect"/>.
+/// </summary>
+internal static class SqlDialectResolver
+{
+    /// <summary>
+    /// Returns the <see cref="SqlDialect"/> for the given provider invariant name,
+    /// or <see cref="SqlDialect.Unknown"/> if the name is null/empty or unrecognized.
+    /// </summary>
+    internal static SqlDialect FromProviderName(string? providerName)
+    {
+        if (string.IsNullOrWhiteSpace(providerName))
+            return SqlDialect.Unknown;
+
+        // Order matters: MySql.Data.MySqlClient contains both "MySql" and
+        // "SqlClient", so MySql must be checked before SqlClient.
+        if (providerName.Contains("MySql", StringComparison.OrdinalIgnoreCase))
+            return SqlDialect.MySql;
+        if (providerName.Contains("SqlClient", StringComparison.OrdinalIgnoreCase))
+            return SqlDialect.SqlServer;
+        if (providerName.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
+            return SqlDialect.Sqlite;
+        if (providerName.Contains("Npgsql", StringComparison.OrdinalIgnoreCase))
+            return SqlDialect.Postgres;
+        if (providerName.Contains("Oracle", StringComparison.OrdinalIgnoreCase))
+            return SqlDialect.Oracle;
+
+        return SqlDialect.Unknown;
+    }
+}

--- a/src/Verso.Ado/Helpers/SqlLocalScopeAnalyzer.cs
+++ b/src/Verso.Ado/Helpers/SqlLocalScopeAnalyzer.cs
@@ -78,7 +78,11 @@ internal static class SqlLocalScopeAnalyzer
             // DECLARE syntax is never parenthesized at the top level; each
             // comma-separated item is a single local declaration whose name
             // is the first @token. Subsequent @tokens are initializer references.
-            ExtractFirstAtPerItem(m.Groups["list"].Value, names);
+            // Trim first to guard against the capture spilling past an
+            // unterminated DECLARE into a following statement (T-SQL semicolons
+            // are optional).
+            var list = TrimDeclareCaptureToStatement(m.Groups["list"].Value);
+            ExtractFirstAtPerItem(list, names);
         }
 
         foreach (Match m in ProcedurePattern.Matches(sanitized))
@@ -141,9 +145,46 @@ internal static class SqlLocalScopeAnalyzer
     }
 
     /// <summary>
+    /// Trims a DECLARE list capture to its actual statement boundary. Because
+    /// <see cref="DeclarePattern"/> grabs everything up to the next <c>;</c>
+    /// and T-SQL semicolons are optional, the raw capture can spill into a
+    /// following statement. A DECLARE that continues onto a new line always
+    /// ends the preceding line with a top-level <c>,</c>; once a non-comma
+    /// line ending appears at depth 0, the statement has ended and any
+    /// further input belongs to the next statement.
+    /// </summary>
+    private static string TrimDeclareCaptureToStatement(string capture)
+    {
+        int depth = 0;
+        char lastSignificantAtDepth0 = ',';
+
+        for (int i = 0; i < capture.Length; i++)
+        {
+            char c = capture[i];
+            if (c == '(') depth++;
+            else if (c == ')') depth = Math.Max(0, depth - 1);
+
+            if (c == '\n')
+            {
+                if (lastSignificantAtDepth0 != ',')
+                    return capture.Substring(0, i);
+            }
+            else if (!char.IsWhiteSpace(c) && depth == 0)
+            {
+                lastSignificantAtDepth0 = c;
+            }
+        }
+
+        return capture;
+    }
+
+    /// <summary>
     /// Splits <paramref name="list"/> on commas at paren-depth 0 and, for each item,
     /// extracts the first <c>@name</c> token. Initializer references that appear
     /// after the name (e.g. <c>= @other</c> or <c>= @@SERVERNAME</c>) are ignored.
+    /// Stops at the first item whose first non-whitespace character is not <c>@</c>.
+    /// This guards against DECLARE captures that spill into a following statement
+    /// when the DECLARE is not semicolon-terminated (T-SQL terminators are optional).
     /// </summary>
     private static void ExtractFirstAtPerItem(string list, HashSet<string> names)
     {
@@ -157,20 +198,30 @@ internal static class SqlLocalScopeAnalyzer
             else if (c == ')') depth = Math.Max(0, depth - 1);
             else if (c == ',' && depth == 0)
             {
-                AddFirstAtName(list, itemStart, i, names);
+                if (!TryAddFirstAtName(list, itemStart, i, names))
+                    return;
                 itemStart = i + 1;
             }
         }
-        AddFirstAtName(list, itemStart, list.Length, names);
+        TryAddFirstAtName(list, itemStart, list.Length, names);
     }
 
-    private static void AddFirstAtName(string list, int start, int end, HashSet<string> names)
+    /// <summary>
+    /// Reads the first <c>@name</c> token in <c>[start, end)</c> and adds the
+    /// bare name to <paramref name="names"/>. Returns <c>false</c> when the
+    /// first non-whitespace character is not <c>@</c>, signaling to the caller
+    /// that the item (and any subsequent items) does not belong to the
+    /// declaration list and iteration should stop. Empty/whitespace-only items
+    /// (e.g. a trailing comma) return <c>true</c> so iteration continues.
+    /// </summary>
+    private static bool TryAddFirstAtName(string list, int start, int end, HashSet<string> names)
     {
         int i = start;
         while (i < end && char.IsWhiteSpace(list[i])) i++;
-        if (i >= end || list[i] != '@') return;
-        // Skip the @@global form — it's not a local introduction.
-        if (i + 1 < end && list[i + 1] == '@') return;
+        if (i >= end) return true;
+        if (list[i] != '@') return false;
+        // Skip the @@global form: it's not a local introduction.
+        if (i + 1 < end && list[i + 1] == '@') return true;
 
         int nameStart = i + 1;
         int nameEnd = nameStart;
@@ -179,6 +230,7 @@ internal static class SqlLocalScopeAnalyzer
 
         if (nameEnd > nameStart)
             names.Add(list.Substring(nameStart, nameEnd - nameStart));
+        return true;
     }
 
     /// <summary>

--- a/src/Verso.Ado/Helpers/SqlLocalScopeAnalyzer.cs
+++ b/src/Verso.Ado/Helpers/SqlLocalScopeAnalyzer.cs
@@ -1,0 +1,313 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Verso.Ado.Helpers;
+
+/// <summary>
+/// Extracts names that are introduced locally by the SQL itself (and therefore
+/// must not be treated as references to the kernel variable store):
+/// <list type="bullet">
+///   <item>T-SQL <c>DECLARE @x</c> locals (single, multi-var, TABLE, CURSOR variants)</item>
+///   <item>T-SQL <c>CREATE</c>/<c>ALTER PROCEDURE</c> and <c>CREATE</c>/<c>ALTER FUNCTION</c> parameter lists</item>
+///   <item>MySQL session user variables introduced by <c>SET @x = …</c> or <c>SELECT @x := …</c></item>
+/// </list>
+/// </summary>
+internal static class SqlLocalScopeAnalyzer
+{
+    private static readonly Regex DeclarePattern = new(
+        @"\bDECLARE\b(?<list>[^;]*)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline);
+
+    private static readonly Regex ProcedurePattern = new(
+        @"\b(?:CREATE|ALTER)\s+PROC(?:EDURE)?\s+\S+(?<list>[\s\S]*?)\bAS\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex FunctionPattern = new(
+        @"\b(?:CREATE|ALTER)\s+FUNCTION\s+\S+(?<list>[\s\S]*?)\bRETURNS\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex MySqlSetPattern = new(
+        @"\bSET\s+@(\w+)\s*=",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex MySqlAssignPattern = new(
+        @"@(\w+)\s*:=",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns the set of locally-introduced parameter names (without leading <c>@</c>)
+    /// for the given SQL text and dialect. The set uses ordinal case-insensitive
+    /// comparison, matching how the binder looks up names.
+    /// </summary>
+    internal static HashSet<string> FindLocalNames(string sql, SqlDialect dialect)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrEmpty(sql))
+            return names;
+
+        // Strip comments and quoted contents so DECLARE-in-comment or
+        // DECLARE-in-string-literal doesn't pollute the local set.
+        var sanitized = StripNonCode(sql);
+
+        switch (dialect)
+        {
+            case SqlDialect.SqlServer:
+            case SqlDialect.Sqlite:
+            case SqlDialect.Unknown:
+                AddTSqlLocals(sanitized, names);
+                break;
+
+            case SqlDialect.MySql:
+                AddMySqlLocals(sanitized, names);
+                break;
+
+            case SqlDialect.Postgres:
+            case SqlDialect.Oracle:
+            default:
+                // No introduction rules for these dialects at the notebook-cell level.
+                break;
+        }
+
+        return names;
+    }
+
+    private static void AddTSqlLocals(string sanitized, HashSet<string> names)
+    {
+        foreach (Match m in DeclarePattern.Matches(sanitized))
+        {
+            // DECLARE syntax is never parenthesized at the top level; each
+            // comma-separated item is a single local declaration whose name
+            // is the first @token. Subsequent @tokens are initializer references.
+            ExtractFirstAtPerItem(m.Groups["list"].Value, names);
+        }
+
+        foreach (Match m in ProcedurePattern.Matches(sanitized))
+        {
+            ExtractParameterListNames(m.Groups["list"].Value, names);
+        }
+
+        foreach (Match m in FunctionPattern.Matches(sanitized))
+        {
+            ExtractParameterListNames(m.Groups["list"].Value, names);
+        }
+    }
+
+    private static void AddMySqlLocals(string sanitized, HashSet<string> names)
+    {
+        foreach (Match m in MySqlSetPattern.Matches(sanitized))
+            names.Add(m.Groups[1].Value);
+
+        foreach (Match m in MySqlAssignPattern.Matches(sanitized))
+            names.Add(m.Groups[1].Value);
+    }
+
+    /// <summary>
+    /// Locates the parameter list in a stored-procedure or function header capture
+    /// (which may or may not be enclosed in parens) and extracts each parameter
+    /// name (the first <c>@token</c> in each top-level comma-separated item).
+    /// </summary>
+    private static void ExtractParameterListNames(string list, HashSet<string> names)
+    {
+        // Find the first non-whitespace character. If it's '(', the param list is
+        // parenthesized — extract the balanced contents. Otherwise treat the entire
+        // capture as the param list (T-SQL PROC supports both forms).
+        int firstNonWs = 0;
+        while (firstNonWs < list.Length && char.IsWhiteSpace(list[firstNonWs]))
+            firstNonWs++;
+
+        if (firstNonWs < list.Length && list[firstNonWs] == '(')
+        {
+            int depth = 0;
+            int close = -1;
+            for (int i = firstNonWs; i < list.Length; i++)
+            {
+                if (list[i] == '(') depth++;
+                else if (list[i] == ')')
+                {
+                    depth--;
+                    if (depth == 0) { close = i; break; }
+                }
+            }
+            if (close > firstNonWs)
+            {
+                ExtractFirstAtPerItem(
+                    list.Substring(firstNonWs + 1, close - firstNonWs - 1),
+                    names);
+                return;
+            }
+        }
+
+        ExtractFirstAtPerItem(list, names);
+    }
+
+    /// <summary>
+    /// Splits <paramref name="list"/> on commas at paren-depth 0 and, for each item,
+    /// extracts the first <c>@name</c> token. Initializer references that appear
+    /// after the name (e.g. <c>= @other</c> or <c>= @@SERVERNAME</c>) are ignored.
+    /// </summary>
+    private static void ExtractFirstAtPerItem(string list, HashSet<string> names)
+    {
+        int depth = 0;
+        int itemStart = 0;
+
+        for (int i = 0; i < list.Length; i++)
+        {
+            char c = list[i];
+            if (c == '(') depth++;
+            else if (c == ')') depth = Math.Max(0, depth - 1);
+            else if (c == ',' && depth == 0)
+            {
+                AddFirstAtName(list, itemStart, i, names);
+                itemStart = i + 1;
+            }
+        }
+        AddFirstAtName(list, itemStart, list.Length, names);
+    }
+
+    private static void AddFirstAtName(string list, int start, int end, HashSet<string> names)
+    {
+        int i = start;
+        while (i < end && char.IsWhiteSpace(list[i])) i++;
+        if (i >= end || list[i] != '@') return;
+        // Skip the @@global form — it's not a local introduction.
+        if (i + 1 < end && list[i + 1] == '@') return;
+
+        int nameStart = i + 1;
+        int nameEnd = nameStart;
+        while (nameEnd < end && (char.IsLetterOrDigit(list[nameEnd]) || list[nameEnd] == '_'))
+            nameEnd++;
+
+        if (nameEnd > nameStart)
+            names.Add(list.Substring(nameStart, nameEnd - nameStart));
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="sql"/> with comments and the contents of
+    /// string literals / quoted identifiers replaced by spaces. Character positions
+    /// are preserved so regex offsets remain meaningful relative to the original.
+    /// Delimiters themselves are preserved so word boundaries outside the literal
+    /// stay intact.
+    /// </summary>
+    private static string StripNonCode(string sql)
+    {
+        var sb = new StringBuilder(sql.Length);
+        int i = 0;
+        int len = sql.Length;
+
+        while (i < len)
+        {
+            char c = sql[i];
+
+            if (c == '-' && i + 1 < len && sql[i + 1] == '-')
+            {
+                while (i < len && sql[i] != '\n')
+                {
+                    sb.Append(' ');
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < len && sql[i + 1] == '*')
+            {
+                sb.Append("  ");
+                i += 2;
+                while (i < len)
+                {
+                    if (sql[i] == '*' && i + 1 < len && sql[i + 1] == '/')
+                    {
+                        sb.Append("  ");
+                        i += 2;
+                        break;
+                    }
+                    sb.Append(sql[i] == '\n' ? '\n' : ' ');
+                    i++;
+                }
+                continue;
+            }
+
+            if ((c == 'N' || c == 'n')
+                && i + 1 < len && sql[i + 1] == '\''
+                && (i == 0 || !IsWordChar(sql[i - 1])))
+            {
+                sb.Append(c);
+                sb.Append('\'');
+                i += 2;
+                EraseSingleQuotedTo(sql, ref i, sb);
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                sb.Append('\'');
+                i++;
+                EraseSingleQuotedTo(sql, ref i, sb);
+                continue;
+            }
+
+            if (c == '"')
+            {
+                sb.Append('"');
+                i++;
+                while (i < len && sql[i] != '"')
+                {
+                    sb.Append(sql[i] == '\n' ? '\n' : ' ');
+                    i++;
+                }
+                if (i < len)
+                {
+                    sb.Append('"');
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '[')
+            {
+                sb.Append('[');
+                i++;
+                while (i < len && sql[i] != ']')
+                {
+                    sb.Append(sql[i] == '\n' ? '\n' : ' ');
+                    i++;
+                }
+                if (i < len)
+                {
+                    sb.Append(']');
+                    i++;
+                }
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    private static void EraseSingleQuotedTo(string sql, ref int i, StringBuilder sb)
+    {
+        int len = sql.Length;
+        while (i < len)
+        {
+            if (sql[i] == '\'')
+            {
+                if (i + 1 < len && sql[i + 1] == '\'')
+                {
+                    sb.Append("  ");
+                    i += 2;
+                    continue;
+                }
+                sb.Append('\'');
+                i++;
+                return;
+            }
+            sb.Append(sql[i] == '\n' ? '\n' : ' ');
+            i++;
+        }
+    }
+
+    private static bool IsWordChar(char c) =>
+        char.IsLetterOrDigit(c) || c == '_';
+}

--- a/src/Verso.Ado/Helpers/SqlParameterScanner.cs
+++ b/src/Verso.Ado/Helpers/SqlParameterScanner.cs
@@ -1,0 +1,200 @@
+namespace Verso.Ado.Helpers;
+
+/// <summary>
+/// Single-pass character walker that finds <c>@name</c> parameter references
+/// in SQL text while correctly skipping comments, string literals, and quoted
+/// identifiers. Recognized contexts:
+/// <list type="bullet">
+///   <item><c>-- single-line</c> comments through end of line</item>
+///   <item><c>/* block */</c> comments</item>
+///   <item><c>'…'</c> and <c>N'…'</c> string literals (including doubled-quote escapes)</item>
+///   <item><c>"…"</c> double-quoted identifiers (ANSI / Postgres / Sqlite)</item>
+///   <item><c>[…]</c> bracketed identifiers (T-SQL)</item>
+/// </list>
+/// The leading <c>@</c> of a T-SQL global like <c>@@SPID</c> is not emitted as a
+/// reference (the lookbehind on the previous character mirrors the prior regex).
+/// Oracle uses <c>:name</c> binds, so this scanner emits no references for
+/// <see cref="SqlDialect.Oracle"/>.
+/// </summary>
+internal static class SqlParameterScanner
+{
+    private enum CharContext
+    {
+        Code,
+        SingleLineComment,
+        BlockComment,
+        SingleQuotedString,
+        DoubleQuotedIdentifier,
+        BracketedIdentifier,
+    }
+
+    /// <summary>
+    /// Scans <paramref name="sql"/> and returns parameter references found in code context.
+    /// </summary>
+    internal static IReadOnlyList<ParameterReference> Scan(string sql, SqlDialect dialect)
+    {
+        if (string.IsNullOrEmpty(sql) || dialect == SqlDialect.Oracle)
+            return Array.Empty<ParameterReference>();
+
+        var results = new List<ParameterReference>();
+        var context = CharContext.Code;
+        int i = 0;
+        int len = sql.Length;
+
+        while (i < len)
+        {
+            char c = sql[i];
+
+            switch (context)
+            {
+                case CharContext.Code:
+                    // Comment: --
+                    if (c == '-' && i + 1 < len && sql[i + 1] == '-')
+                    {
+                        context = CharContext.SingleLineComment;
+                        i += 2;
+                        continue;
+                    }
+
+                    // Comment: /*
+                    if (c == '/' && i + 1 < len && sql[i + 1] == '*')
+                    {
+                        context = CharContext.BlockComment;
+                        i += 2;
+                        continue;
+                    }
+
+                    // Unicode literal: N'...'
+                    if ((c == 'N' || c == 'n')
+                        && i + 1 < len && sql[i + 1] == '\''
+                        && (i == 0 || !IsWordChar(sql[i - 1])))
+                    {
+                        context = CharContext.SingleQuotedString;
+                        i += 2;
+                        continue;
+                    }
+
+                    // Single-quoted string
+                    if (c == '\'')
+                    {
+                        context = CharContext.SingleQuotedString;
+                        i++;
+                        continue;
+                    }
+
+                    // Double-quoted identifier
+                    if (c == '"')
+                    {
+                        context = CharContext.DoubleQuotedIdentifier;
+                        i++;
+                        continue;
+                    }
+
+                    // Bracketed identifier
+                    if (c == '[')
+                    {
+                        context = CharContext.BracketedIdentifier;
+                        i++;
+                        continue;
+                    }
+
+                    // Parameter candidate: @name
+                    if (c == '@')
+                    {
+                        // Skip the second @ in @@globals (e.g. @@SPID)
+                        bool precededByAt = i > 0 && sql[i - 1] == '@';
+                        // Skip the @ itself if the next char is also @ (we'll see it as
+                        // the second @ on the next iteration and won't emit).
+                        bool followedByAt = i + 1 < len && sql[i + 1] == '@';
+
+                        if (precededByAt || followedByAt)
+                        {
+                            i++;
+                            continue;
+                        }
+
+                        int nameStart = i + 1;
+                        int nameEnd = nameStart;
+                        while (nameEnd < len && IsNameChar(sql[nameEnd]))
+                            nameEnd++;
+
+                        if (nameEnd > nameStart)
+                        {
+                            results.Add(new ParameterReference(
+                                Name: sql.Substring(nameStart, nameEnd - nameStart),
+                                Offset: i,
+                                Length: nameEnd - i));
+                        }
+
+                        i = nameEnd > nameStart ? nameEnd : i + 1;
+                        continue;
+                    }
+
+                    i++;
+                    break;
+
+                case CharContext.SingleLineComment:
+                    if (c == '\n')
+                        context = CharContext.Code;
+                    i++;
+                    break;
+
+                case CharContext.BlockComment:
+                    if (c == '*' && i + 1 < len && sql[i + 1] == '/')
+                    {
+                        context = CharContext.Code;
+                        i += 2;
+                    }
+                    else
+                    {
+                        i++;
+                    }
+                    break;
+
+                case CharContext.SingleQuotedString:
+                    if (c == '\'')
+                    {
+                        // Doubled single quote = escaped quote, stay in string.
+                        if (i + 1 < len && sql[i + 1] == '\'')
+                        {
+                            i += 2;
+                        }
+                        else
+                        {
+                            context = CharContext.Code;
+                            i++;
+                        }
+                    }
+                    else
+                    {
+                        i++;
+                    }
+                    break;
+
+                case CharContext.DoubleQuotedIdentifier:
+                    if (c == '"')
+                    {
+                        context = CharContext.Code;
+                    }
+                    i++;
+                    break;
+
+                case CharContext.BracketedIdentifier:
+                    if (c == ']')
+                    {
+                        context = CharContext.Code;
+                    }
+                    i++;
+                    break;
+            }
+        }
+
+        return results;
+    }
+
+    private static bool IsNameChar(char c) =>
+        char.IsLetterOrDigit(c) || c == '_';
+
+    private static bool IsWordChar(char c) =>
+        char.IsLetterOrDigit(c) || c == '_';
+}

--- a/src/Verso.Ado/Kernel/SqlKernel.cs
+++ b/src/Verso.Ado/Kernel/SqlKernel.cs
@@ -2,7 +2,6 @@ using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Text;
-using System.Text.RegularExpressions;
 using Verso.Abstractions;
 using Verso.Ado.Formatters;
 using Verso.Ado.Helpers;
@@ -18,8 +17,6 @@ namespace Verso.Ado.Kernel;
 /// </summary>
 public sealed class SqlKernel : ILanguageKernel
 {
-    // Negative lookbehind avoids matching the second @ in T-SQL/MySQL globals like @@SPID, @@VERSION.
-    private static readonly Regex ParamPattern = new(@"(?<!@)@(\w+)", RegexOptions.Compiled);
     private readonly SemaphoreSlim _executionLock = new(1, 1);
 
     internal const int DefaultMaxFetchRows = 10_000;
@@ -76,8 +73,9 @@ public sealed class SqlKernel : ILanguageKernel
             return outputs;
         }
 
-        // Determine if this is a SQL Server provider (for GO batch handling)
-        bool isSqlServer = connInfo.ProviderName?.Contains("SqlClient", StringComparison.OrdinalIgnoreCase) ?? false;
+        // Resolve dialect for parameter scanning and GO batch handling
+        var dialect = SqlDialectResolver.FromProviderName(connInfo.ProviderName);
+        bool isSqlServer = dialect == SqlDialect.SqlServer;
 
         // Split statements
         var statements = SqlStatementSplitter.Split(sqlCode, handleGoBatches: isSqlServer);
@@ -103,7 +101,7 @@ public sealed class SqlKernel : ILanguageKernel
                 cmd.CommandText = statement;
 
                 // Bind parameters
-                BindParameters(cmd, statement, context.Variables, outputs);
+                BindParameters(cmd, statement, dialect, context.Variables, outputs);
 
                 using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken).ConfigureAwait(false);
 
@@ -290,10 +288,12 @@ public sealed class SqlKernel : ILanguageKernel
 
         var (directives, sqlCode) = SqlDirectives.Parse(code);
 
-        // Check for missing connection
+        // Resolve connection (and dialect for parameter scanning)
+        SqlConnectionInfo? connInfo = null;
+        var dialect = SqlDialect.Unknown;
         if (_lastVariableStore is not null)
         {
-            var connInfo = ConnectionResolver.Resolve(directives.ConnectionName, _lastVariableStore);
+            connInfo = ConnectionResolver.Resolve(directives.ConnectionName, _lastVariableStore);
             if (connInfo is null)
             {
                 diagnostics.Add(new Diagnostic(
@@ -302,6 +302,10 @@ public sealed class SqlKernel : ILanguageKernel
                         ? $"Connection '{directives.ConnectionName}' not found. Use #!sql-connect to establish a connection."
                         : "No database connection. Use #!sql-connect to establish a connection.",
                     0, 0, 0, 0));
+            }
+            else
+            {
+                dialect = SqlDialectResolver.FromProviderName(connInfo.ProviderName);
             }
         }
         else
@@ -312,14 +316,19 @@ public sealed class SqlKernel : ILanguageKernel
                 0, 0, 0, 0));
         }
 
-        // Check for unresolved @parameters
-        var matches = ParamPattern.Matches(code);
+        // Scan for unresolved @parameters in the post-directive-strip SQL,
+        // then translate offsets back to the original cell's line numbering.
+        int lineOffset = sqlCode.Length < code.Length ? 1 : 0;
+
+        var localNames = SqlLocalScopeAnalyzer.FindLocalNames(sqlCode, dialect);
+        var references = SqlParameterScanner.Scan(sqlCode, dialect);
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (Match match in matches)
+        foreach (var reference in references)
         {
-            var paramName = match.Groups[1].Value;
-            if (!seen.Add(paramName))
+            if (localNames.Contains(reference.Name))
+                continue;
+            if (!seen.Add(reference.Name))
                 continue;
 
             bool resolved = false;
@@ -327,18 +336,18 @@ public sealed class SqlKernel : ILanguageKernel
             {
                 var allVars = _lastVariableStore.GetAll();
                 resolved = allVars.Any(v =>
-                    string.Equals(v.Name, paramName, StringComparison.OrdinalIgnoreCase));
+                    string.Equals(v.Name, reference.Name, StringComparison.OrdinalIgnoreCase));
             }
 
             if (!resolved)
             {
-                var (startLine, startCol) = OffsetToLineCol(code, match.Index);
-                var (endLine, endCol) = OffsetToLineCol(code, match.Index + match.Length);
+                var (startLine, startCol) = OffsetToLineCol(sqlCode, reference.Offset);
+                var (endLine, endCol) = OffsetToLineCol(sqlCode, reference.Offset + reference.Length);
 
                 diagnostics.Add(new Diagnostic(
                     DiagnosticSeverity.Warning,
-                    $"Unresolved parameter '@{paramName}'. No matching variable found in the variable store.",
-                    startLine, startCol, endLine, endCol));
+                    $"Unresolved parameter '@{reference.Name}'. No matching variable found in the variable store.",
+                    startLine + lineOffset, startCol, endLine + lineOffset, endCol));
             }
         }
 
@@ -541,53 +550,37 @@ public sealed class SqlKernel : ILanguageKernel
         return str.Length > maxLength ? str.Substring(0, maxLength) + "..." : str;
     }
 
-    private static bool IsInsideStringLiteral(string sql, int position)
-    {
-        bool inString = false;
-        for (int i = 0; i < position && i < sql.Length; i++)
-        {
-            if (sql[i] == '\'')
-            {
-                // Handle escaped single quotes ('')
-                if (inString && i + 1 < sql.Length && sql[i + 1] == '\'')
-                    i++; // skip the escaped quote
-                else
-                    inString = !inString;
-            }
-        }
-        return inString;
-    }
-
     private static void BindParameters(
-        DbCommand cmd, string sql, IVariableStore variables, List<CellOutput> outputs)
+        DbCommand cmd, string sql, SqlDialect dialect,
+        IVariableStore variables, List<CellOutput> outputs)
     {
-        var matches = ParamPattern.Matches(sql);
+        var localNames = SqlLocalScopeAnalyzer.FindLocalNames(sql, dialect);
+        var references = SqlParameterScanner.Scan(sql, dialect);
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (Match match in matches)
+        foreach (var reference in references)
         {
-            // Skip @params that appear inside single-quoted string literals
-            if (IsInsideStringLiteral(sql, match.Index))
+            // Skip names introduced by the SQL itself (T-SQL DECLARE / proc params, etc.)
+            if (localNames.Contains(reference.Name))
                 continue;
 
-            var paramName = match.Groups[1].Value;
-            if (!seen.Add(paramName))
+            if (!seen.Add(reference.Name))
                 continue;
 
             var allVars = variables.GetAll();
             var descriptor = allVars.FirstOrDefault(v =>
-                string.Equals(v.Name, paramName, StringComparison.OrdinalIgnoreCase));
+                string.Equals(v.Name, reference.Name, StringComparison.OrdinalIgnoreCase));
 
             if (descriptor is null || descriptor.Value is null)
             {
                 outputs.Add(new CellOutput("text/plain",
-                    $"Warning: No variable '@{paramName}' found for parameter binding.",
+                    $"Warning: No variable '@{reference.Name}' found for parameter binding.",
                     IsError: false));
                 continue;
             }
 
             var param = cmd.CreateParameter();
-            param.ParameterName = $"@{paramName}";
+            param.ParameterName = $"@{reference.Name}";
 
             if (DbTypeMapper.TryMapDbType(descriptor.Type, out var dbType))
             {
@@ -597,7 +590,7 @@ public sealed class SqlKernel : ILanguageKernel
             else
             {
                 outputs.Add(new CellOutput("text/plain",
-                    $"Warning: Type '{descriptor.Type.Name}' for '@{paramName}' is not a supported DbType. Passing as-is.",
+                    $"Warning: Type '{descriptor.Type.Name}' for '@{reference.Name}' is not a supported DbType. Passing as-is.",
                     IsError: false));
                 param.Value = descriptor.Value;
             }

--- a/tests/Verso.Ado.Tests/Helpers/SqlDialectResolverTests.cs
+++ b/tests/Verso.Ado.Tests/Helpers/SqlDialectResolverTests.cs
@@ -1,0 +1,78 @@
+using Verso.Ado.Helpers;
+
+namespace Verso.Ado.Tests.Helpers;
+
+[TestClass]
+public sealed class SqlDialectResolverTests
+{
+    [TestMethod]
+    public void FromProviderName_SqlClient_ReturnsSqlServer()
+    {
+        Assert.AreEqual(SqlDialect.SqlServer,
+            SqlDialectResolver.FromProviderName("Microsoft.Data.SqlClient"));
+    }
+
+    [TestMethod]
+    public void FromProviderName_Sqlite_ReturnsSqlite()
+    {
+        Assert.AreEqual(SqlDialect.Sqlite,
+            SqlDialectResolver.FromProviderName("Microsoft.Data.Sqlite"));
+    }
+
+    [TestMethod]
+    public void FromProviderName_Npgsql_ReturnsPostgres()
+    {
+        Assert.AreEqual(SqlDialect.Postgres,
+            SqlDialectResolver.FromProviderName("Npgsql"));
+    }
+
+    [TestMethod]
+    public void FromProviderName_MySqlData_ReturnsMySql()
+    {
+        Assert.AreEqual(SqlDialect.MySql,
+            SqlDialectResolver.FromProviderName("MySql.Data.MySqlClient"));
+    }
+
+    [TestMethod]
+    public void FromProviderName_MySqlConnector_ReturnsMySql()
+    {
+        Assert.AreEqual(SqlDialect.MySql,
+            SqlDialectResolver.FromProviderName("MySqlConnector"));
+    }
+
+    [TestMethod]
+    public void FromProviderName_Oracle_ReturnsOracle()
+    {
+        Assert.AreEqual(SqlDialect.Oracle,
+            SqlDialectResolver.FromProviderName("Oracle.ManagedDataAccess.Client"));
+    }
+
+    [TestMethod]
+    public void FromProviderName_Null_ReturnsUnknown()
+    {
+        Assert.AreEqual(SqlDialect.Unknown, SqlDialectResolver.FromProviderName(null));
+    }
+
+    [TestMethod]
+    public void FromProviderName_Empty_ReturnsUnknown()
+    {
+        Assert.AreEqual(SqlDialect.Unknown, SqlDialectResolver.FromProviderName(""));
+        Assert.AreEqual(SqlDialect.Unknown, SqlDialectResolver.FromProviderName("   "));
+    }
+
+    [TestMethod]
+    public void FromProviderName_Unrecognized_ReturnsUnknown()
+    {
+        Assert.AreEqual(SqlDialect.Unknown,
+            SqlDialectResolver.FromProviderName("SomeOther.Provider"));
+    }
+
+    [TestMethod]
+    public void FromProviderName_CaseInsensitive()
+    {
+        Assert.AreEqual(SqlDialect.SqlServer,
+            SqlDialectResolver.FromProviderName("microsoft.data.sqlclient"));
+        Assert.AreEqual(SqlDialect.MySql,
+            SqlDialectResolver.FromProviderName("MYSQLCONNECTOR"));
+    }
+}

--- a/tests/Verso.Ado.Tests/Helpers/SqlLocalScopeAnalyzerTests.cs
+++ b/tests/Verso.Ado.Tests/Helpers/SqlLocalScopeAnalyzerTests.cs
@@ -199,8 +199,56 @@ public sealed class SqlLocalScopeAnalyzerTests
         Assert.IsTrue(names.Contains("rows"), "Expected 'rows' in local names");
         Assert.IsTrue(names.Contains("waitDelay"), "Expected 'waitDelay' in local names");
         Assert.IsTrue(names.Contains("serverName"), "Expected 'serverName' in local names");
-        // @waitTime is REFERENCED from a kernel variable, not declared — must stay out.
+        // @waitTime is REFERENCED from a kernel variable, not declared, so it must stay out.
         Assert.IsFalse(names.Contains("waitTime"),
             "'waitTime' is a kernel variable reference, not a local declaration");
+    }
+
+    [TestMethod]
+    public void FindLocalNames_UnterminatedDeclareFollowedByStatement_DoesNotConsumeFollowing()
+    {
+        // T-SQL statement terminators are optional. When a DECLARE has no trailing
+        // semicolon and is followed by another statement that contains @-prefixed
+        // references, the DECLARE capture spills into the follow-on statement.
+        // The first-@-per-item walker must stop at the first item whose first
+        // non-whitespace character is not '@', so kernel variable references in
+        // the follow-on statement are not silently registered as locals (which
+        // would suppress binding and cause silent execution failures).
+        var sql = @"
+            DECLARE @local INT
+            SELECT 1, @kernelVar, @anotherKernel";
+
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(sql, SqlDialect.SqlServer);
+
+        Assert.IsTrue(names.Contains("local"), "Expected 'local' in local names");
+        Assert.IsFalse(names.Contains("kernelVar"),
+            "'kernelVar' belongs to a following SELECT, not the DECLARE list");
+        Assert.IsFalse(names.Contains("anotherKernel"),
+            "'anotherKernel' belongs to a following SELECT, not the DECLARE list");
+    }
+
+    [TestMethod]
+    public void FindLocalNames_ReportedUserScenarioUnterminated_NoLeakIntoWhile()
+    {
+        // Same shape as ReportedUserScenario but with the trailing semicolon on
+        // DECLARE removed and a WHILE that references @rows. The WHILE's @rows
+        // must not be wrongly extended into the local set via a new item.
+        var sql = @"
+            DECLARE @rows INT = 1,
+                    @waitDelay CHAR(8) = '00:' + CAST(@waitTime AS VARCHAR(2)),
+                    @serverName SYSNAME = @@SERVERNAME
+            WHILE (@rows > 0)
+            BEGIN
+                WAITFOR DELAY @waitDelay;
+                SET @rows = @rows - 1;
+            END";
+
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(sql, SqlDialect.SqlServer);
+
+        Assert.IsTrue(names.Contains("rows"));
+        Assert.IsTrue(names.Contains("waitDelay"));
+        Assert.IsTrue(names.Contains("serverName"));
+        Assert.IsFalse(names.Contains("waitTime"),
+            "'waitTime' is a kernel variable reference inside an initializer");
     }
 }

--- a/tests/Verso.Ado.Tests/Helpers/SqlLocalScopeAnalyzerTests.cs
+++ b/tests/Verso.Ado.Tests/Helpers/SqlLocalScopeAnalyzerTests.cs
@@ -1,0 +1,206 @@
+using Verso.Ado.Helpers;
+
+namespace Verso.Ado.Tests.Helpers;
+
+[TestClass]
+public sealed class SqlLocalScopeAnalyzerTests
+{
+    [TestMethod]
+    public void FindLocalNames_DeclareSimple_Found()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "DECLARE @x INT", SqlDialect.SqlServer);
+
+        Assert.IsTrue(names.Contains("x"));
+        Assert.AreEqual(1, names.Count);
+    }
+
+    [TestMethod]
+    public void FindLocalNames_DeclareMultiVar_AllFound()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "DECLARE @a INT = 1, @b VARCHAR(10) = 'x', @c SYSNAME = @@SERVERNAME;",
+            SqlDialect.SqlServer);
+
+        Assert.IsTrue(names.Contains("a"));
+        Assert.IsTrue(names.Contains("b"));
+        Assert.IsTrue(names.Contains("c"));
+        Assert.AreEqual(3, names.Count);
+    }
+
+    [TestMethod]
+    public void FindLocalNames_DeclareTable_Found()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "DECLARE @t TABLE (Id INT, Name VARCHAR(50))", SqlDialect.SqlServer);
+
+        Assert.IsTrue(names.Contains("t"));
+    }
+
+    [TestMethod]
+    public void FindLocalNames_DeclareCursor_Found()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "DECLARE @c CURSOR FOR SELECT 1", SqlDialect.SqlServer);
+
+        Assert.IsTrue(names.Contains("c"));
+    }
+
+    [TestMethod]
+    public void FindLocalNames_CreateProcedureParams_Found()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "CREATE PROCEDURE dbo.MyProc @p1 INT, @p2 VARCHAR(100) AS BEGIN SELECT 1 END",
+            SqlDialect.SqlServer);
+
+        Assert.IsTrue(names.Contains("p1"));
+        Assert.IsTrue(names.Contains("p2"));
+    }
+
+    [TestMethod]
+    public void FindLocalNames_AlterProcedureParams_Found()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "ALTER PROCEDURE dbo.MyProc @p1 INT AS BEGIN SELECT 1 END",
+            SqlDialect.SqlServer);
+
+        Assert.IsTrue(names.Contains("p1"));
+    }
+
+    [TestMethod]
+    public void FindLocalNames_CreateProcShortKeyword_Found()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "CREATE PROC dbo.MyProc @p INT AS BEGIN SELECT 1 END",
+            SqlDialect.SqlServer);
+
+        Assert.IsTrue(names.Contains("p"));
+    }
+
+    [TestMethod]
+    public void FindLocalNames_CreateFunctionParams_Found()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "CREATE FUNCTION dbo.MyFn (@p INT) RETURNS INT AS BEGIN RETURN @p END",
+            SqlDialect.SqlServer);
+
+        Assert.IsTrue(names.Contains("p"));
+    }
+
+    [TestMethod]
+    public void FindLocalNames_CreateFunctionParamWithNestedParens_Found()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "CREATE FUNCTION dbo.MyFn (@p VARCHAR(50), @q INT) RETURNS INT AS BEGIN RETURN @q END",
+            SqlDialect.SqlServer);
+
+        Assert.IsTrue(names.Contains("p"));
+        Assert.IsTrue(names.Contains("q"));
+    }
+
+    [TestMethod]
+    public void FindLocalNames_DeclareInLineComment_NotFound()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "-- DECLARE @hidden INT\nSELECT 1", SqlDialect.SqlServer);
+
+        Assert.AreEqual(0, names.Count);
+    }
+
+    [TestMethod]
+    public void FindLocalNames_DeclareInBlockComment_NotFound()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "/* DECLARE @hidden INT */ SELECT 1", SqlDialect.SqlServer);
+
+        Assert.AreEqual(0, names.Count);
+    }
+
+    [TestMethod]
+    public void FindLocalNames_DeclareInsideStringLiteral_NotFound()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "INSERT INTO Logs VALUES ('DECLARE @hidden INT')", SqlDialect.SqlServer);
+
+        Assert.AreEqual(0, names.Count);
+    }
+
+    [TestMethod]
+    public void FindLocalNames_MySqlSet_Found()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "SET @userVar = 42", SqlDialect.MySql);
+
+        Assert.IsTrue(names.Contains("userVar"));
+    }
+
+    [TestMethod]
+    public void FindLocalNames_MySqlAssign_Found()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "SELECT @rowNum := @rowNum + 1 FROM t, (SELECT @rowNum := 0) r",
+            SqlDialect.MySql);
+
+        Assert.IsTrue(names.Contains("rowNum"));
+    }
+
+    [TestMethod]
+    public void FindLocalNames_MySqlDialect_DoesNotPickUpTSqlDeclare()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "DECLARE @x INT; SELECT @x", SqlDialect.MySql);
+
+        Assert.AreEqual(0, names.Count);
+    }
+
+    [TestMethod]
+    public void FindLocalNames_OracleDialect_AlwaysEmpty()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "DECLARE x INT := 1; BEGIN NULL; END;", SqlDialect.Oracle);
+
+        Assert.AreEqual(0, names.Count);
+    }
+
+    [TestMethod]
+    public void FindLocalNames_PostgresDialect_AlwaysEmpty()
+    {
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(
+            "DECLARE @x INT", SqlDialect.Postgres);
+
+        Assert.AreEqual(0, names.Count);
+    }
+
+    [TestMethod]
+    public void FindLocalNames_EmptyOrNullInput_Empty()
+    {
+        Assert.AreEqual(0, SqlLocalScopeAnalyzer.FindLocalNames("", SqlDialect.SqlServer).Count);
+        Assert.AreEqual(0, SqlLocalScopeAnalyzer.FindLocalNames(null!, SqlDialect.SqlServer).Count);
+    }
+
+    [TestMethod]
+    public void FindLocalNames_ReportedUserScenario_AllLocalsFound()
+    {
+        // The exact shape from the user issue: multi-var DECLARE with one
+        // initializer referencing a kernel variable (@waitTime) and a system
+        // global (@@SERVERNAME). The kernel variable should not be in the
+        // local set (it's used, not introduced); the locals should be.
+        var sql = @"
+            DECLARE @rows INT = 1,
+                    @waitDelay CHAR(8) = '00:' + RIGHT('0' + CAST(@waitTime AS VARCHAR(2)) + '', 2),
+                    @serverName SYSNAME = @@SERVERNAME;
+            WHILE (@rows > 0)
+            BEGIN
+                SELECT @rows = @@ROWCOUNT;
+            END;";
+
+        var names = SqlLocalScopeAnalyzer.FindLocalNames(sql, SqlDialect.SqlServer);
+
+        Assert.IsTrue(names.Contains("rows"), "Expected 'rows' in local names");
+        Assert.IsTrue(names.Contains("waitDelay"), "Expected 'waitDelay' in local names");
+        Assert.IsTrue(names.Contains("serverName"), "Expected 'serverName' in local names");
+        // @waitTime is REFERENCED from a kernel variable, not declared — must stay out.
+        Assert.IsFalse(names.Contains("waitTime"),
+            "'waitTime' is a kernel variable reference, not a local declaration");
+    }
+}

--- a/tests/Verso.Ado.Tests/Helpers/SqlParameterScannerTests.cs
+++ b/tests/Verso.Ado.Tests/Helpers/SqlParameterScannerTests.cs
@@ -1,0 +1,180 @@
+using Verso.Ado.Helpers;
+
+namespace Verso.Ado.Tests.Helpers;
+
+[TestClass]
+public sealed class SqlParameterScannerTests
+{
+    [TestMethod]
+    public void Scan_BasicParam_Found()
+    {
+        var refs = SqlParameterScanner.Scan("SELECT @x", SqlDialect.SqlServer);
+
+        Assert.AreEqual(1, refs.Count);
+        Assert.AreEqual("x", refs[0].Name);
+        Assert.AreEqual(7, refs[0].Offset);
+        Assert.AreEqual(2, refs[0].Length);
+    }
+
+    [TestMethod]
+    public void Scan_GlobalVariable_Excluded()
+    {
+        var refs = SqlParameterScanner.Scan("SELECT @@SPID", SqlDialect.SqlServer);
+
+        Assert.AreEqual(0, refs.Count);
+    }
+
+    [TestMethod]
+    public void Scan_MixedGlobalAndParam_OnlyParam()
+    {
+        var refs = SqlParameterScanner.Scan(
+            "WHERE id = @u AND @@SPID > 0", SqlDialect.SqlServer);
+
+        Assert.AreEqual(1, refs.Count);
+        Assert.AreEqual("u", refs[0].Name);
+    }
+
+    [TestMethod]
+    public void Scan_ParamInSingleLineComment_Excluded()
+    {
+        var refs = SqlParameterScanner.Scan(
+            "-- @ignored\nSELECT @keep", SqlDialect.SqlServer);
+
+        Assert.AreEqual(1, refs.Count);
+        Assert.AreEqual("keep", refs[0].Name);
+    }
+
+    [TestMethod]
+    public void Scan_ParamInBlockComment_Excluded()
+    {
+        var refs = SqlParameterScanner.Scan(
+            "/* @ignored */ SELECT @keep", SqlDialect.SqlServer);
+
+        Assert.AreEqual(1, refs.Count);
+        Assert.AreEqual("keep", refs[0].Name);
+    }
+
+    [TestMethod]
+    public void Scan_ParamInBlockCommentSpanningLines_Excluded()
+    {
+        var refs = SqlParameterScanner.Scan(
+            "/* line one\n@ignored\nline three */ SELECT @keep", SqlDialect.SqlServer);
+
+        Assert.AreEqual(1, refs.Count);
+        Assert.AreEqual("keep", refs[0].Name);
+    }
+
+    [TestMethod]
+    public void Scan_ParamInSingleQuote_Excluded()
+    {
+        var refs = SqlParameterScanner.Scan(
+            "INSERT INTO Emails VALUES ('alice@example.com')", SqlDialect.SqlServer);
+
+        Assert.AreEqual(0, refs.Count);
+    }
+
+    [TestMethod]
+    public void Scan_ParamInNUnicode_Excluded()
+    {
+        var refs = SqlParameterScanner.Scan(
+            "SELECT N'hello @world' AS msg", SqlDialect.SqlServer);
+
+        Assert.AreEqual(0, refs.Count);
+    }
+
+    [TestMethod]
+    public void Scan_ParamInDoubleQuotedIdentifier_Excluded()
+    {
+        var refs = SqlParameterScanner.Scan(
+            "SELECT \"@col\" FROM T", SqlDialect.SqlServer);
+
+        Assert.AreEqual(0, refs.Count);
+    }
+
+    [TestMethod]
+    public void Scan_ParamInBracketedIdentifier_Excluded()
+    {
+        var refs = SqlParameterScanner.Scan(
+            "SELECT [@col] FROM T", SqlDialect.SqlServer);
+
+        Assert.AreEqual(0, refs.Count);
+    }
+
+    [TestMethod]
+    public void Scan_DoubledSingleQuoteInString_Excluded()
+    {
+        // String contents: it's @local — the @local is inside the string.
+        var refs = SqlParameterScanner.Scan(
+            "SELECT 'it''s @local' AS phrase", SqlDialect.SqlServer);
+
+        Assert.AreEqual(0, refs.Count);
+    }
+
+    [TestMethod]
+    public void Scan_OracleDialect_AlwaysEmpty()
+    {
+        var refs = SqlParameterScanner.Scan(
+            "SELECT * FROM T WHERE Id = @x", SqlDialect.Oracle);
+
+        Assert.AreEqual(0, refs.Count);
+    }
+
+    [TestMethod]
+    public void Scan_MultipleParams_AllFound()
+    {
+        var refs = SqlParameterScanner.Scan(
+            "WHERE a = @a AND b = @b AND c = @c", SqlDialect.SqlServer);
+
+        Assert.AreEqual(3, refs.Count);
+        CollectionAssert.AreEqual(
+            new[] { "a", "b", "c" },
+            refs.Select(r => r.Name).ToArray());
+    }
+
+    [TestMethod]
+    public void Scan_EmptyString_Empty()
+    {
+        Assert.AreEqual(0, SqlParameterScanner.Scan("", SqlDialect.SqlServer).Count);
+        Assert.AreEqual(0, SqlParameterScanner.Scan(null!, SqlDialect.SqlServer).Count);
+    }
+
+    [TestMethod]
+    public void Scan_ParamFollowedByOperator_TerminatesName()
+    {
+        var refs = SqlParameterScanner.Scan("SELECT @x+1", SqlDialect.SqlServer);
+
+        Assert.AreEqual(1, refs.Count);
+        Assert.AreEqual("x", refs[0].Name);
+        Assert.AreEqual(2, refs[0].Length);
+    }
+
+    [TestMethod]
+    public void Scan_ParamAtEndOfInput_Found()
+    {
+        var refs = SqlParameterScanner.Scan("SELECT @final", SqlDialect.SqlServer);
+
+        Assert.AreEqual(1, refs.Count);
+        Assert.AreEqual("final", refs[0].Name);
+    }
+
+    [TestMethod]
+    public void Scan_AtWithNoName_NotEmitted()
+    {
+        var refs = SqlParameterScanner.Scan("SELECT @ FROM T", SqlDialect.SqlServer);
+
+        Assert.AreEqual(0, refs.Count);
+    }
+
+    [TestMethod]
+    public void Scan_WordPrefixBeforeApostrophe_NotTreatedAsNUnicode()
+    {
+        // FOO'bar' — the apostrophe is a regular string, the FOO is an identifier.
+        // Crucially the `O` directly before the quote must NOT be treated as the
+        // `N` prefix for a unicode literal.
+        var refs = SqlParameterScanner.Scan(
+            "SELECT FOO'@inside' AS @keep FROM T", SqlDialect.SqlServer);
+
+        Assert.AreEqual(1, refs.Count);
+        Assert.AreEqual("keep", refs[0].Name);
+    }
+}

--- a/tests/Verso.Ado.Tests/Kernel/SqlKernelDiagnosticTests.cs
+++ b/tests/Verso.Ado.Tests/Kernel/SqlKernelDiagnosticTests.cs
@@ -206,4 +206,116 @@ public sealed class SqlKernelDiagnosticTests
             d.Message.Contains("Unresolved")),
             "Should not warn for @@VERSION at start of query.");
     }
+
+    [TestMethod]
+    public async Task GetDiagnosticsAsync_DeclaredLocal_NoWarning()
+    {
+        var ctx = CreateContextWithConnection();
+        var kernel = new SqlKernel();
+        await kernel.ExecuteAsync("SELECT 1", ctx);
+
+        var diagnostics = await kernel.GetDiagnosticsAsync(
+            "DECLARE @x INT; SELECT @x");
+
+        Assert.IsFalse(diagnostics.Any(d =>
+            d.Severity == DiagnosticSeverity.Warning &&
+            d.Message.Contains("@x")),
+            "Should not warn about a locally DECLAREd variable.");
+    }
+
+    [TestMethod]
+    public async Task GetDiagnosticsAsync_DeclareMultiVarUserScenario_NoWarning()
+    {
+        var ctx = CreateContextWithConnection();
+        // The kernel variable @waitTime IS in the store and is referenced in the
+        // initializer; the locally declared @rows/@waitDelay/@serverName must
+        // not produce binding warnings.
+        ctx.Variables.Set("waitTime", 30);
+        var kernel = new SqlKernel();
+        await kernel.ExecuteAsync("SELECT 1", ctx);
+
+        var sql = @"DECLARE @rows INT = 1,
+        @waitDelay CHAR(8) = '00:' + RIGHT('0' + CAST(@waitTime AS VARCHAR(2)) + '', 2),
+        @serverName SYSNAME = @@SERVERNAME;
+SELECT @rows, @waitDelay, @serverName";
+
+        var diagnostics = await kernel.GetDiagnosticsAsync(sql);
+
+        Assert.IsFalse(diagnostics.Any(d =>
+            d.Severity == DiagnosticSeverity.Warning &&
+            (d.Message.Contains("@rows") || d.Message.Contains("@waitDelay")
+                || d.Message.Contains("@serverName"))),
+            "Should not warn about locally DECLAREd variables.");
+    }
+
+    [TestMethod]
+    public async Task GetDiagnosticsAsync_ParamInLineComment_NoWarning()
+    {
+        var ctx = CreateContextWithConnection();
+        var kernel = new SqlKernel();
+        await kernel.ExecuteAsync("SELECT 1", ctx);
+
+        var diagnostics = await kernel.GetDiagnosticsAsync(
+            "-- TODO: handle @legacy column\nSELECT 1");
+
+        Assert.IsFalse(diagnostics.Any(d =>
+            d.Severity == DiagnosticSeverity.Warning &&
+            d.Message.Contains("@legacy")),
+            "Should not warn about @x inside a -- single-line comment.");
+    }
+
+    [TestMethod]
+    public async Task GetDiagnosticsAsync_ParamInBlockComment_NoWarning()
+    {
+        var ctx = CreateContextWithConnection();
+        var kernel = new SqlKernel();
+        await kernel.ExecuteAsync("SELECT 1", ctx);
+
+        var diagnostics = await kernel.GetDiagnosticsAsync(
+            "/* uses @legacy column */ SELECT 1");
+
+        Assert.IsFalse(diagnostics.Any(d =>
+            d.Severity == DiagnosticSeverity.Warning &&
+            d.Message.Contains("@legacy")),
+            "Should not warn about @x inside a /* block comment */.");
+    }
+
+    [TestMethod]
+    public async Task GetDiagnosticsAsync_ParamInStringLiteral_NoWarning()
+    {
+        var ctx = CreateContextWithConnection();
+        var kernel = new SqlKernel();
+        await kernel.ExecuteAsync("SELECT 1", ctx);
+
+        var diagnostics = await kernel.GetDiagnosticsAsync(
+            "INSERT INTO Emails VALUES ('alice@example.com')");
+
+        Assert.IsFalse(diagnostics.Any(d =>
+            d.Severity == DiagnosticSeverity.Warning &&
+            d.Message.Contains("@example")),
+            "Should not warn about @x inside a single-quoted string literal.");
+    }
+
+    [TestMethod]
+    public async Task GetDiagnosticsAsync_DirectiveHeader_SpanRelativeToOriginal()
+    {
+        var ctx = CreateContextWithConnection();
+        var kernel = new SqlKernel();
+        await kernel.ExecuteAsync("SELECT 1", ctx);
+
+        // Line 0: directive header, Line 1: the query. The @missing token is at
+        // column 27 of line 1 (same column as in the bare-query span test, but
+        // shifted down by one line because of the directive header).
+        var code = "--connection testdb\nSELECT * FROM T WHERE Id = @missing";
+        var diagnostics = await kernel.GetDiagnosticsAsync(code);
+
+        var paramDiag = diagnostics.FirstOrDefault(d =>
+            d.Severity == DiagnosticSeverity.Warning &&
+            d.Message.Contains("@missing"));
+
+        Assert.IsNotNull(paramDiag);
+        Assert.AreEqual(1, paramDiag!.StartLine,
+            "@missing is on line 1 (after the directive header on line 0).");
+        Assert.AreEqual(27, paramDiag.StartColumn);
+    }
 }

--- a/tests/Verso.Ado.Tests/Kernel/SqlKernelTests.cs
+++ b/tests/Verso.Ado.Tests/Kernel/SqlKernelTests.cs
@@ -125,6 +125,40 @@ public sealed class SqlKernelTests
     }
 
     [TestMethod]
+    public async Task ExecuteAsync_DeclaredLocal_NoSpuriousBindingWarning()
+    {
+        // The reported bug: locally DECLAREd T-SQL variables triggered
+        // "No variable '@xxx' found for parameter binding" warnings even
+        // though the variable is introduced by the SQL itself. SQLite cannot
+        // execute DECLARE syntax so the statement itself fails — but the
+        // binding pass runs first, and that is where the spurious warning
+        // used to appear. Asserting on the warning text alone is enough to
+        // pin the fix.
+        var ctx = CreateContextWithConnection();
+        var kernel = new SqlKernel();
+
+        var outputs = await kernel.ExecuteAsync(
+            "DECLARE @rows INT = 1; SELECT @rows", ctx);
+
+        Assert.IsFalse(outputs.Any(o => o.Content.Contains("No variable '@rows'")),
+            "Locally DECLAREd @rows must not produce a binding warning.");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ParamInLineComment_NoBindingWarning()
+    {
+        var ctx = CreateContextWithConnection();
+        var kernel = new SqlKernel();
+
+        await kernel.ExecuteAsync("CREATE TABLE T9 (X INTEGER)", ctx);
+        var outputs = await kernel.ExecuteAsync(
+            "-- legacy: @oldparam was renamed\nSELECT * FROM T9", ctx);
+
+        Assert.IsFalse(outputs.Any(o => o.Content.Contains("No variable '@oldparam'")),
+            "@x inside a single-line comment must not produce a binding warning.");
+    }
+
+    [TestMethod]
     public async Task ExecuteAsync_NoDisplayDirective_SuppressesOutputButPublishesVariable()
     {
         var ctx = CreateContextWithConnection();


### PR DESCRIPTION
Introduce dialect-aware parameter scanning and local-scope detection to avoid spurious binding warnings and to ignore parameters inside comments/strings. Added internal helpers: ParameterReference, SqlDialect enum, SqlDialectResolver, SqlParameterScanner, and SqlLocalScopeAnalyzer. Updated SqlKernel to resolve dialects, use the scanner/analyzer for both binding and diagnostics (BindParameters now accepts dialect), and adjust diagnostic offsets when directive headers are present. Removed the previous regex-based detection and ad-hoc string-literal check in favor of the new single-pass scanner and local-name analysis. Added comprehensive unit tests for resolver, scanner, local-scope analyzer and updated kernel diagnostic/execution tests.