### PR TITLE
Enhance toolbar UI with icon-only actions, export features, and health tracking

### DIFF
--- a/docs/extensions/layouts.md
+++ b/docs/extensions/layouts.md
@@ -655,7 +655,7 @@ Layouts communicate with clients over a small set of JSON-RPC methods. Most exte
 | `layout/interact` | Client → Host | Dispatch an event to the layout's `ILayoutInteractionHandler`. |
 | `layout/updated` | Host → Client | Push notification triggered by `RequestRender` / `RequestCellRefresh`. Carries `scope` of `full`, `cell`, or `metadata`. |
 
-Two earlier methods, `layout/updateCell` and `layout/setEditMode`, remain in the protocol as deprecated forwarders. New code should use `layout/interact` with the corresponding `InteractionType` instead; the forwarders will be removed in a future major version.
+An earlier method, `layout/updateCell`, remains in the protocol as a deprecated forwarder. New code should use `layout/interact` with the corresponding `InteractionType` instead; the forwarder will be removed in a future major version.
 
 ## Migration from Legacy Notebooks
 

--- a/samples/showcase/form-studio/src/Verso.Showcase.FormStudio/DataBlockReader.cs
+++ b/samples/showcase/form-studio/src/Verso.Showcase.FormStudio/DataBlockReader.cs
@@ -22,11 +22,12 @@ internal sealed class BlockData
 }
 
 /// <summary>
-/// Reads a Datafication.Core <c>DataBlock</c> into a serializable shape entirely by reflection, so
-/// the extension takes no compile-time dependency on Datafication.Core and never fights assembly
-/// identity. Form Studio only ever reads DataBlocks (charts consume them); it writes scalar kernel
-/// variables, not DataBlocks, so there is no rebuild counterpart here. The only knowledge encoded
-/// is the small, stable public shape of <c>DataBlock</c> / <c>DataColumn</c> / <c>DataSchema</c>.
+/// Reads a chart source (a Datafication.Core <c>DataBlock</c> or a <see cref="System.Data.DataTable"/>)
+/// into a serializable shape for charting. DataBlock access is entirely reflection-based, so the
+/// extension takes no compile-time dependency on Datafication.Core and never fights assembly
+/// identity; DataTable is a BCL type read through its strongly-typed API. Form Studio only ever
+/// reads these sources (charts consume them); it writes scalar kernel variables, never structured
+/// data, so there is no rebuild counterpart here.
 /// </summary>
 internal static class DataBlockReader
 {
@@ -35,6 +36,23 @@ internal static class DataBlockReader
     /// <summary>True when the value looks like a DataBlock.</summary>
     public static bool IsDataBlock(object? value)
         => value is not null && value.GetType().FullName == DataBlockTypeName;
+
+    /// <summary>True when the value is a <see cref="System.Data.DataTable"/>.</summary>
+    public static bool IsDataTable(object? value) => value is System.Data.DataTable;
+
+    /// <summary>True when the value is a chart source we can project (DataBlock or DataTable).</summary>
+    public static bool IsSource(object? value) => IsDataBlock(value) || IsDataTable(value);
+
+    /// <summary>
+    /// Projects any supported chart source into a <see cref="BlockData"/>. Returns <c>null</c> when
+    /// the value is neither a DataBlock nor a DataTable (or its shape is not what we expect).
+    /// </summary>
+    public static BlockData? ReadSource(object? value) => value switch
+    {
+        System.Data.DataTable table => ReadDataTable(table),
+        not null when IsDataBlock(value) => Read(value),
+        _ => null,
+    };
 
     /// <summary>
     /// Projects a DataBlock instance into a <see cref="BlockData"/>. Returns <c>null</c> if the
@@ -86,6 +104,33 @@ internal static class DataBlockReader
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Projects a <see cref="System.Data.DataTable"/> into a <see cref="BlockData"/>. DataTable is
+    /// a BCL type, so this reads it through the strongly-typed API with no reflection.
+    /// </summary>
+    public static BlockData ReadDataTable(System.Data.DataTable table)
+    {
+        var data = new BlockData();
+        foreach (System.Data.DataColumn column in table.Columns)
+        {
+            data.Columns.Add(column.ColumnName);
+            data.Types.Add(HintFor(column.DataType));
+        }
+
+        foreach (System.Data.DataRow dataRow in table.Rows)
+        {
+            var row = new object?[table.Columns.Count];
+            for (var c = 0; c < table.Columns.Count; c++)
+            {
+                var cell = dataRow[c];
+                row[c] = cell is null or DBNull ? null : MapOut(cell);
+            }
+            data.Rows.Add(row);
+        }
+
+        return data;
     }
 
     // --- Type mapping -------------------------------------------------------

--- a/samples/showcase/form-studio/src/Verso.Showcase.FormStudio/FormStudioLayout.cs
+++ b/samples/showcase/form-studio/src/Verso.Showcase.FormStudio/FormStudioLayout.cs
@@ -9,7 +9,8 @@ namespace Verso.Showcase.FormStudio;
 /// <summary>
 /// "Form Studio" — an isolated (iframe) layout that turns a notebook into a live, parameterized
 /// app. The frame is a drag-and-drop canvas: input widgets (sliders, dropdowns, toggles, text)
-/// bind to kernel variables, and chart widgets visualize a kernel <c>DataBlock</c>. Moving an
+/// bind to kernel variables, and chart widgets visualize a kernel <c>DataBlock</c> or
+/// <c>DataTable</c>. Moving an
 /// input writes its bound variable and (when auto-run is on) re-runs the notebook, so downstream
 /// cells recompute and the charts refresh.
 /// </summary>
@@ -330,7 +331,7 @@ public sealed class FormStudioLayout
         }
     }
 
-    // --- Chart data (DataBlock -> frame) ------------------------------------
+    // --- Chart data (source -> frame) ---------------------------------------
 
     private void BindChart(LayoutInteractionContext context, IVariableStore variables)
     {
@@ -358,25 +359,27 @@ public sealed class FormStudioLayout
             return;
 
         BlockData? data = null;
-        if (variables.TryGet<object>(sourceVar, out var value) && value is not null && DataBlockReader.IsDataBlock(value))
-            data = DataBlockReader.Read(value);
+        if (variables.TryGet<object>(sourceVar, out var value))
+            data = DataBlockReader.ReadSource(value);
 
         _ = frame.PostMessageAsync("chart-data", new { id, sourceVar, data }, ct);
     }
 
-    // The names of every variable currently holding a DataBlock, for the chart source pickers.
+    // The names of every variable currently holding a chartable source (a DataBlock or a
+    // DataTable), for the chart source pickers.
     private object BuildVars(IVariableStore variables)
     {
-        var dataBlockVars = new List<string>();
+        var sourceVars = new List<string>();
         foreach (var descriptor in variables.GetAll())
         {
-            var isDataBlock = DataBlockReader.IsDataBlock(descriptor.Value)
-                || string.Equals(descriptor.Type?.FullName, "Datafication.Core.Data.DataBlock", StringComparison.Ordinal);
-            if (isDataBlock && !dataBlockVars.Contains(descriptor.Name))
-                dataBlockVars.Add(descriptor.Name);
+            var isSource = DataBlockReader.IsSource(descriptor.Value)
+                || string.Equals(descriptor.Type?.FullName, "Datafication.Core.Data.DataBlock", StringComparison.Ordinal)
+                || string.Equals(descriptor.Type?.FullName, "System.Data.DataTable", StringComparison.Ordinal);
+            if (isSource && !sourceVars.Contains(descriptor.Name))
+                sourceVars.Add(descriptor.Name);
         }
-        dataBlockVars.Sort(StringComparer.Ordinal);
-        return new { dataBlockVars };
+        sourceVars.Sort(StringComparer.Ordinal);
+        return new { sourceVars };
     }
 
     // --- Export -------------------------------------------------------------

--- a/samples/showcase/form-studio/src/Verso.Showcase.FormStudio/assets/form.js
+++ b/samples/showcase/form-studio/src/Verso.Showcase.FormStudio/assets/form.js
@@ -34,7 +34,6 @@ const Chart = window.Chart;
 // --- Icons (inline SVG, themed by currentColor) -----------------------------
 
 const SVG = (body) => `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">${body}</svg>`;
-const ICON_GRID = SVG('<rect x="2" y="2.5" width="5" height="5" rx="1"/><rect x="9" y="2.5" width="5" height="5" rx="1"/><rect x="2" y="9" width="5" height="4.5" rx="1"/><path d="M9.5 13.5v-3M11.5 13.5v-2M13.5 13.5V9.5"/>');
 const ICON_PLAY = SVG('<path d="M5 3.5l7 4.5-7 4.5z"/>');
 const ICON_SLIDER = SVG('<path d="M2 8h12"/><circle cx="6" cy="8" r="2.2" fill="var(--verso-bg-default,#14161c)"/>');
 const ICON_HASH = SVG('<path d="M6 2.5L4.5 13.5M11.5 2.5L10 13.5M3 5.5h11M2 10.5h11"/>');
@@ -51,7 +50,7 @@ const ICON_SCATTER = SVG('<path d="M2.5 13.5h11"/><circle cx="5" cy="9" r="1"/><
 
 // doc.widgets: [{ id, kind, x, y, w, h, label, bindVar, config }]
 let doc = { widgets: [], autoRun: true };
-let vars = { dataBlockVars: [] };
+let vars = { sourceVars: [] };
 let mode = "edit"; // "edit" | "preview"
 let selectedId = null;
 let saveTimer = 0;
@@ -78,7 +77,16 @@ const STYLE = `
     font-size: var(--verso-font-size-base, 13px);
     overflow: hidden;
   }
-  .app { display: grid; grid-template-rows: auto 1fr; height: 100%; }
+  /* Full-height left palette beside a top toolbar and the body. The palette spans both rows so
+     its top edge aligns with the toolbar; the toolbar and body fill the right column. */
+  .app { display: grid; grid-template-columns: 188px 1fr; grid-template-rows: auto 1fr; height: 100%; }
+  .app > .rail.left { grid-column: 1; grid-row: 1 / 3; }
+  .app > .top { grid-column: 2; grid-row: 1; }
+  .app > .body { grid-column: 2; grid-row: 2; }
+  /* Preview hides the palette and collapses to a single column. */
+  .app.preview { grid-template-columns: 1fr; }
+  .app.preview > .rail.left { display: none; }
+  .app.preview > .top, .app.preview > .body { grid-column: 1; }
 
   .top {
     display: flex; align-items: center; gap: 10px;
@@ -86,14 +94,6 @@ const STYLE = `
     background: var(--verso-bg-elevated, #1b1e26);
     border-bottom: 1px solid var(--verso-border-default, #2a2e38);
   }
-  .brand { display: flex; align-items: center; gap: 9px; font-weight: 700; letter-spacing: .2px; }
-  .brand .mark {
-    width: 22px; height: 22px; border-radius: 6px;
-    background: var(--verso-accent, #5b8def);
-    display: grid; place-items: center; color: #fff;
-  }
-  .brand .mark svg { width: 14px; height: 14px; }
-  .brand .sub { color: var(--verso-fg-muted, #9aa0ac); font-weight: 500; font-size: .85em; }
   .top .spacer { flex: 1; }
   .btn {
     appearance: none; border: 1px solid var(--verso-border-default, #2a2e38);
@@ -109,7 +109,7 @@ const STYLE = `
   .toggle { display: inline-flex; align-items: center; gap: 7px; color: var(--verso-fg-muted, #9aa0ac); cursor: pointer; user-select: none; }
   .toggle input { accent-color: var(--verso-accent, #5b8def); }
 
-  .body { display: grid; grid-template-columns: 188px 1fr 238px; min-height: 0; }
+  .body { display: grid; grid-template-columns: 1fr 238px; min-height: 0; }
   .body.preview { grid-template-columns: 1fr; }
   .body.preview .rail { display: none; }
 
@@ -184,12 +184,9 @@ const STYLE = `
 injectStyle(STYLE);
 
 document.body.innerHTML = `
-  <div class="app">
+  <div class="app" id="app">
+    <div class="rail left" id="palette"></div>
     <div class="top">
-      <div class="brand">
-        <span class="mark">${ICON_GRID}</span>
-        <span>Form Studio</span><span class="sub">dashboard builder</span>
-      </div>
       <div class="spacer"></div>
       <label class="toggle" title="Re-run the notebook automatically when an input changes">
         <input type="checkbox" id="autorun" checked> Auto-run
@@ -202,7 +199,6 @@ document.body.innerHTML = `
       </div>
     </div>
     <div class="body" id="body">
-      <div class="rail left" id="palette"></div>
       <div class="canvas-wrap" id="canvasWrap"><div class="canvas" id="canvas"></div></div>
       <div class="rail right" id="props"></div>
     </div>
@@ -211,6 +207,7 @@ document.body.innerHTML = `
 
 const canvasEl = document.getElementById("canvas");
 const canvasWrapEl = document.getElementById("canvasWrap");
+const appEl = document.getElementById("app");
 const bodyEl = document.getElementById("body");
 const propsEl = document.getElementById("props");
 const autorunEl = document.getElementById("autorun");
@@ -297,7 +294,7 @@ function applyDefaults(w, chartType) {
     case "dropdown":w.w = 210; w.h = 92;  w.config = { options: ["All", "A", "B", "C"] }; w.value = "All"; w.bindVar = nextVar("choice"); break;
     case "text":    w.w = 230; w.h = 90;  w.value = ""; w.bindVar = nextVar("text"); break;
     case "label":   w.w = 230; w.h = 56;  w.config = { text: "Heading" }; break;
-    case "chart":   w.w = 380; w.h = 270; w.config = { sourceVar: vars.dataBlockVars[0] || "", chartType: chartType || "bar", xColumn: "", yColumns: [], color: "" }; break;
+    case "chart":   w.w = 380; w.h = 270; w.config = { sourceVar: vars.sourceVars[0] || "", chartType: chartType || "bar", xColumn: "", yColumns: [], color: "" }; break;
   }
 }
 
@@ -420,7 +417,7 @@ function updateEmpty() {
   if (doc.widgets.length === 0) {
     if (!e) canvasEl.appendChild(el("div", { class: "empty" },
       el("div", {}, "Drag a widget from the left onto the canvas.", el("br"), el("br"),
-        el("span", { class: "hint" }, "Inputs write kernel variables. Charts plot a DataBlock. Switch to Preview to use the app."))));
+        el("span", { class: "hint" }, "Inputs write kernel variables. Charts plot a data source. Switch to Preview to use the app."))));
   } else if (e) {
     e.remove();
   }
@@ -499,9 +496,9 @@ function renderProps() {
       propsEl.appendChild(field("Text", textInput(w.config.text || "", (v) => cfg(w, "text", v))));
       break;
     case "chart":
-      propsEl.appendChild(field("DataBlock", selectInput(vars.dataBlockVars, w.config.sourceVar, (v) => {
+      propsEl.appendChild(field("Data", selectInput(vars.sourceVars, w.config.sourceVar, (v) => {
         w.config.sourceVar = v; w.config.xColumn = ""; w.config.yColumns = []; saveDoc(); requestChart(w);
-      }), "The kernel DataBlock to plot."));
+      }), "The kernel variable to plot (a DataBlock or DataTable)."));
       propsEl.appendChild(field("Chart type", selectInput(CHART_TYPES, w.config.chartType, (v) => { w.config.chartType = v; renderChart(w); saveDoc(); })));
       const cols = (chartCache.get(w.id) || {}).columns || [];
       propsEl.appendChild(field("X axis", selectInput(cols, w.config.xColumn, (v) => { w.config.xColumn = v; renderChart(w); saveDoc(); })));
@@ -537,7 +534,7 @@ function renderChart(w) {
   const data = chartCache.get(w.id);
   const cols = data ? data.columns : [];
   if (!data || cols.length === 0) {
-    paintPlaceholder(cv, w.config.sourceVar ? "Loading…" : "Pick a DataBlock");
+    paintPlaceholder(cv, w.config.sourceVar ? "Loading…" : "Pick a data source");
     return;
   }
 
@@ -651,6 +648,7 @@ document.getElementById("mode").addEventListener("click", (e) => {
   if (!b) return;
   mode = b.dataset.mode;
   document.querySelectorAll("#mode button").forEach((x) => x.classList.toggle("on", x === b));
+  appEl.classList.toggle("preview", mode === "preview");
   bodyEl.classList.toggle("preview", mode === "preview");
   canvasEl.classList.toggle("preview", mode === "preview");
   if (mode === "preview") select(null);
@@ -762,7 +760,7 @@ function multiSelect(options, selected, onChange) {
     lab.append(cb, document.createTextNode(o));
     wrap.appendChild(lab);
   }
-  if (!options || options.length === 0) wrap.appendChild(el("span", { class: "hint" }, "Pick a DataBlock first."));
+  if (!options || options.length === 0) wrap.appendChild(el("span", { class: "hint" }, "Pick a data source first."));
   return wrap;
 }
 

--- a/samples/showcase/grid-studio/src/Verso.Showcase.GridStudio/DataBlockInterop.cs
+++ b/samples/showcase/grid-studio/src/Verso.Showcase.GridStudio/DataBlockInterop.cs
@@ -39,6 +39,9 @@ internal static class DataBlockInterop
     public static bool IsDataBlock(object? value)
         => value is not null && value.GetType().FullName == DataBlockTypeName;
 
+    /// <summary>True when the value is a <see cref="System.Data.DataTable"/>.</summary>
+    public static bool IsDataTable(object? value) => value is System.Data.DataTable;
+
     /// <summary>
     /// Projects a DataBlock instance into a <see cref="GridData"/>. Returns <c>null</c> if the
     /// value is not a DataBlock or its shape is not what we expect.
@@ -89,6 +92,36 @@ internal static class DataBlockInterop
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Projects a <see cref="System.Data.DataTable"/> into a <see cref="GridData"/> for read-only
+    /// display. DataTable is a BCL type, so this reads it through the strongly-typed API with no
+    /// reflection and no assembly-identity concerns. The grid never writes a DataTable back, so
+    /// there is no matching builder: a DataTable can be wired to a data adapter, and mutating it
+    /// would prime an out-of-band database update the user did not ask for.
+    /// </summary>
+    public static GridData ReadDataTable(System.Data.DataTable table)
+    {
+        var data = new GridData();
+        foreach (System.Data.DataColumn column in table.Columns)
+        {
+            data.Columns.Add(column.ColumnName);
+            data.Types.Add(HintFor(column.DataType));
+        }
+
+        foreach (System.Data.DataRow dataRow in table.Rows)
+        {
+            var row = new object?[table.Columns.Count];
+            for (var c = 0; c < table.Columns.Count; c++)
+            {
+                var cell = dataRow[c];
+                row[c] = cell is null or DBNull ? null : MapOut(cell);
+            }
+            data.Rows.Add(row);
+        }
+
+        return data;
     }
 
     /// <summary>

--- a/samples/showcase/grid-studio/src/Verso.Showcase.GridStudio/GridStudioLayout.cs
+++ b/samples/showcase/grid-studio/src/Verso.Showcase.GridStudio/GridStudioLayout.cs
@@ -50,7 +50,7 @@ public sealed class GridStudioLayout
     public string Name => "Grid Studio Layout";
     public string Version => "1.0.0";
     public string? Author => "Datafication";
-    public string? Description => "Isolated layout that presents a kernel DataBlock as an editable spreadsheet.";
+    public string? Description => "Isolated layout that presents a kernel DataBlock as an editable spreadsheet, or a DataTable read-only.";
 
     public Task OnLoadedAsync(IExtensionHostContext context) => Task.CompletedTask;
     public Task OnUnloadedAsync() => Task.CompletedTask;
@@ -133,7 +133,8 @@ public sealed class GridStudioLayout
         var seed = new Dictionary<string, object>(StringComparer.Ordinal)
         {
             ["sourceVar"] = _doc.SourceVar,
-            ["variables"] = ListDataBlockVars(variables),
+            ["variables"] = ListSourceVars(variables),
+            ["readOnly"] = IsReadOnlySource(variables),
         };
         if (ReadGrid(variables) is { } grid)
             seed["data"] = grid;
@@ -186,6 +187,11 @@ public sealed class GridStudioLayout
     private void ApplyCommit(string payload, IVariableStore variables)
     {
         if (string.IsNullOrWhiteSpace(payload))
+            return;
+
+        // Never write back to a read-only source (a bound DataTable). The frame also disables its
+        // commit controls, but enforce it here too so a stale or crafted message cannot mutate it.
+        if (IsReadOnlySource(variables))
             return;
 
         var coreAssembly = ResolveCoreAssembly(variables);
@@ -268,26 +274,51 @@ public sealed class GridStudioLayout
     {
         if (variables.TryGet<object>(_doc.SourceVar, out var value) && value is not null)
         {
-            _lastSource = value;
-            return DataBlockInterop.IsDataBlock(value) ? DataBlockInterop.Read(value) : null;
+            if (DataBlockInterop.IsDataBlock(value))
+            {
+                // Only DataBlock bindings are editable, so _lastSource (the write-back assembly
+                // source) tracks DataBlocks only.
+                _lastSource = value;
+                return DataBlockInterop.Read(value);
+            }
+
+            // DataTable is shown read-only — see IsReadOnlySource.
+            if (DataBlockInterop.IsDataTable(value))
+                return DataBlockInterop.ReadDataTable((System.Data.DataTable)value);
         }
         return null;
     }
 
-    private object BuildDataPayload(IVariableStore variables)
-        => new { data = ReadGrid(variables), sourceVar = _doc.SourceVar, variables = ListDataBlockVars(variables) };
+    // A bound DataTable is presented read-only: it is an in-memory BCL type that can be wired to a
+    // data adapter, so writing to it could prime an out-of-band database update. The layout never
+    // commits to a DataTable; only DataBlock bindings are editable.
+    private bool IsReadOnlySource(IVariableStore variables)
+        => variables.TryGet<object>(_doc.SourceVar, out var value)
+            && DataBlockInterop.IsDataTable(value);
 
-    // The names of every variable currently holding a DataBlock, for the frame's source picker.
-    // Recomputed on each push, so it tracks cells being run (including Run All) while the layout
-    // is active, since executing cells raises the variable-store change event.
-    private List<string> ListDataBlockVars(IVariableStore variables)
+    private object BuildDataPayload(IVariableStore variables)
+        => new
+        {
+            data = ReadGrid(variables),
+            sourceVar = _doc.SourceVar,
+            variables = ListSourceVars(variables),
+            readOnly = IsReadOnlySource(variables),
+        };
+
+    // The names of every variable currently holding a DataBlock (editable) or a DataTable
+    // (read-only), for the frame's source picker. Recomputed on each push, so it tracks cells
+    // being run (including Run All) while the layout is active, since executing cells raises the
+    // variable-store change event.
+    private List<string> ListSourceVars(IVariableStore variables)
     {
         var names = new List<string>();
         foreach (var descriptor in variables.GetAll())
         {
-            var isDataBlock = DataBlockInterop.IsDataBlock(descriptor.Value)
-                || string.Equals(descriptor.Type?.FullName, "Datafication.Core.Data.DataBlock", StringComparison.Ordinal);
-            if (isDataBlock && !names.Contains(descriptor.Name))
+            var isSource = DataBlockInterop.IsDataBlock(descriptor.Value)
+                || DataBlockInterop.IsDataTable(descriptor.Value)
+                || string.Equals(descriptor.Type?.FullName, "Datafication.Core.Data.DataBlock", StringComparison.Ordinal)
+                || string.Equals(descriptor.Type?.FullName, "System.Data.DataTable", StringComparison.Ordinal);
+            if (isSource && !names.Contains(descriptor.Name))
                 names.Add(descriptor.Name);
         }
         names.Sort(StringComparer.Ordinal);

--- a/samples/showcase/grid-studio/src/Verso.Showcase.GridStudio/assets/grid.js
+++ b/samples/showcase/grid-studio/src/Verso.Showcase.GridStudio/assets/grid.js
@@ -55,6 +55,7 @@ let instance = null;     // the live Jspreadsheet worksheet
 let dirty = false;
 let commitTimer = 0;
 let selRange = null;     // [firstRow, lastRow] of the current selection, or null
+let readOnly = false;    // true when the bound source is a DataTable (view only, never committed)
 
 // --- Chrome (themed entirely via --verso-* tokens) --------------------------
 
@@ -78,15 +79,6 @@ const STYLE = `
     background: var(--verso-bg-elevated, #1b1e26);
     border-bottom: 1px solid var(--verso-border-default, #2a2e38);
   }
-  .brand { display: flex; align-items: center; gap: 9px; font-weight: 700; letter-spacing: .2px; }
-  .brand .mark {
-    width: 22px; height: 22px; border-radius: 6px;
-    background: var(--verso-accent, #5b8def);
-    display: grid; place-items: center; color: #fff;
-    box-shadow: 0 2px 8px rgba(0,0,0,.35);
-  }
-  .brand .mark svg { width: 14px; height: 14px; }
-  .brand .sub { color: var(--verso-fg-muted, #9aa0ac); font-weight: 500; font-size: .85em; }
   .top .spacer { flex: 1; }
 
   .bind { display: flex; align-items: center; gap: 6px; color: var(--verso-fg-muted, #9aa0ac); }
@@ -112,6 +104,7 @@ const STYLE = `
   }
   .btn:hover { background: color-mix(in srgb, var(--verso-fg-default, #fff) 12%, transparent); }
   .btn:active { transform: translateY(1px); }
+  .btn:disabled { opacity: .45; cursor: default; pointer-events: none; }
   .btn.accent { background: var(--verso-accent, #5b8def); border-color: transparent; color: #fff; }
   .btn.accent:hover { filter: brightness(1.08); }
   .btn svg { width: 14px; height: 14px; }
@@ -205,7 +198,6 @@ injectStyle(STYLE);
 // --- DOM scaffold -----------------------------------------------------------
 
 const ICON = {
-  logo: `<svg viewBox="0 0 16 16" fill="none"><rect x="2" y="2.5" width="12" height="11" rx="1.5" stroke="currentColor"/><path d="M2 6h12M2 9.5h12M6 6v7.5M10 6v7.5" stroke="currentColor"/></svg>`,
   addRow: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h10"/><path d="M18 15v6M15 18h6"/></svg>`,
   addCol: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M6 3v18M12 3v18M18 3v10"/><path d="M18 16v6M15 19h6"/></svg>`,
   delRow: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18M3 12h12M3 18h12"/><path d="M16 15l5 5M21 15l-5 5"/></svg>`,
@@ -218,20 +210,19 @@ document.documentElement.style.height = "100%";
 document.body.innerHTML = `
   <div class="app">
     <div class="top">
-      <div class="brand"><span class="mark">${ICON.logo}</span> Grid Studio <span class="sub">DataBlock spreadsheet</span></div>
-      <div class="spacer"></div>
       <button class="btn" id="addRow">${ICON.addRow} Row</button>
       <button class="btn" id="addCol">${ICON.addCol} Column</button>
       <button class="btn" id="delRow">${ICON.delRow} Delete</button>
       <button class="btn" id="export">${ICON.export} CSV</button>
       <button class="btn" id="reload">${ICON.reload} Reload</button>
       <button class="btn accent" id="commit">${ICON.commit} Commit</button>
-      <div class="bind"><label>DataBlock</label><select id="sourceVar"></select></div>
+      <div class="spacer"></div>
+      <div class="bind"><label>Data</label><select id="sourceVar"></select></div>
     </div>
     <div class="stage">
       <div class="grid-host" id="gridHost"></div>
       <div class="empty" id="empty">
-        <h2>No DataBlock bound</h2>
+        <h2>No data bound</h2>
         <div id="emptyMsg"></div>
       </div>
     </div>
@@ -293,13 +284,14 @@ function buildGrid() {
   instance = jspreadsheet(gridHostEl, {
     data: model.rows.length ? model.rows : [model.columns.map(() => "")],
     columns,
+    editable: !readOnly, // a bound DataTable is view-only
     columnSorting: true,
     filters: true,
-    allowInsertRow: true,
-    allowDeleteRow: true,
+    allowInsertRow: !readOnly,
+    allowDeleteRow: !readOnly,
     allowInsertColumn: false, // structural column edits go through our own toolbar
     allowDeleteColumn: false,
-    allowRenameColumn: true,
+    allowRenameColumn: !readOnly,
     contextMenu: false,
     about: false,
     onafterchanges: onGridEdited,
@@ -390,12 +382,14 @@ function syncRowsFromGrid() {
 }
 
 function scheduleCommit() {
+  if (readOnly) return;
   if (commitTimer) clearTimeout(commitTimer);
   commitTimer = setTimeout(commit, 500);
 }
 
 function commit() {
   if (commitTimer) { clearTimeout(commitTimer); commitTimer = 0; }
+  if (readOnly) return;
   if (!model || !model.columns || model.columns.length === 0) return;
   syncRowsFromGrid();
 
@@ -431,6 +425,8 @@ function applyData(payload) {
     sourceVar = payload.sourceVar;
   }
 
+  readOnly = !!(payload && payload.readOnly);
+  applyReadOnly();
   renderSourceOptions(payload && payload.variables);
 
   const data = payload && payload.data;
@@ -440,13 +436,22 @@ function applyData(payload) {
       rows: (data.rows || []).map((r) => r.slice()),
     };
     buildGrid();
-    setStatus("Bound to " + sourceVar);
+    setStatus(readOnly ? "Bound to " + sourceVar + " (read-only)" : "Bound to " + sourceVar);
   } else {
     model = null;
     buildGrid();
   }
   dirty = false;
   statusEl.classList.remove("dirty");
+}
+
+// Disable the editing controls when the bound source is read-only (a DataTable). Reload, CSV
+// export, and the source picker stay enabled.
+function applyReadOnly() {
+  ["addRow", "addCol", "delRow", "commit"].forEach((id) => {
+    const btn = document.getElementById(id);
+    if (btn) btn.disabled = readOnly;
+  });
 }
 
 // --- UI helpers -------------------------------------------------------------
@@ -459,8 +464,9 @@ function markDirty() {
 
 function setStatus(text) { statusTextEl.textContent = text; }
 
-// Populate the source dropdown with the DataBlock variable names the host reported. The bound
-// variable is always selectable even if it is not (yet) a DataBlock, so the binding is visible.
+// Populate the source dropdown with the variable names the host reported (DataBlock or DataTable).
+// The bound variable is always selectable even if it is not (yet) a recognized source, so the
+// binding stays visible.
 function renderSourceOptions(list) {
   const names = Array.isArray(list) ? list.slice() : [];
   if (sourceVar && names.indexOf(sourceVar) === -1) names.unshift(sourceVar);
@@ -469,7 +475,7 @@ function renderSourceOptions(list) {
   if (names.length === 0) {
     const opt = document.createElement("option");
     opt.value = "";
-    opt.textContent = "(no DataBlocks)";
+    opt.textContent = "(no data)";
     opt.disabled = true;
     opt.selected = true;
     sourceVarEl.appendChild(opt);
@@ -498,8 +504,8 @@ function updateDims() {
 function showEmpty() {
   emptyEl.classList.add("show");
   emptyMsgEl.innerHTML =
-    "Assign a DataBlock to <code>" + escapeHtml(sourceVar) + "</code> in a code cell and run it, " +
-    "then pick it from the <b>DataBlock</b> dropdown above.";
+    "Assign data to <code>" + escapeHtml(sourceVar) + "</code> in a code cell and run it, " +
+    "then pick it from the <b>Data</b> dropdown above.";
   dimsEl.textContent = "";
 }
 

--- a/samples/showcase/image-studio/README.md
+++ b/samples/showcase/image-studio/README.md
@@ -81,14 +81,21 @@ with no layout switch.
   Ctrl/Cmd + mouse wheel, or the `+` / `-` / `0` keys. "Fit" auto-scales the canvas to the
   viewport and keeps it fitted as the window or surrounding panels resize; click the percentage
   to reset to 100%. When zoomed past the viewport the stage scrolls (plain wheel pans).
-- **Export:** the "Export PNG" button asks the host to deliver the rasterized composite as a
-  download. "Export SVG" delivers the same composite as vector markup instead: because every
-  layer is a vector primitive, the frame re-emits the stack as SVG in the document's own
-  coordinate space, so it stays crisp at any size. Per-layer opacity maps to a group `opacity`
-  and blend modes to CSS `mix-blend-mode`. Text uses a generic system font fallback (the theme
-  font is not embedded), and `mix-blend-mode` renders in browsers though some standalone SVG
-  tools support it only partially. Hosts that do not support file downloads from a layout
-  simply ignore either request.
+- **Export:** while Image Studio is the active layout it contributes **PNG Image** and **SVG
+  Image** to the host's **Export** menu, alongside the notebook's other export formats. They are
+  layout-scoped, so they appear only in this layout and are absent everywhere else. **PNG Image**
+  asks the host to deliver the rasterized composite as a download. **SVG Image** delivers the same
+  composite as vector markup instead: because every layer is a vector primitive, the frame
+  re-emits the stack as SVG in the document's own coordinate space, so it stays crisp at any size.
+  Per-layer opacity maps to a group `opacity` and blend modes to CSS `mix-blend-mode`. Text uses a
+  generic system font fallback (the theme font is not embedded), and `mix-blend-mode` renders in
+  browsers though some standalone SVG tools support it only partially. Hosts that do not support
+  file downloads from a layout simply ignore either request.
+
+  The export buttons live in the host chrome rather than the frame: the menu action asks the
+  isolated frame to produce the bytes (only the frame can rasterize the canvas), and the frame
+  streams them back for the host to download. It is a small example of an isolated layout
+  contributing actions to the host toolbar through the `IToolbarAction` extension point.
 
 ## Licensing
 

--- a/samples/showcase/image-studio/src/Verso.Showcase.ImageStudio/ExportActions.cs
+++ b/samples/showcase/image-studio/src/Verso.Showcase.ImageStudio/ExportActions.cs
@@ -1,0 +1,90 @@
+using Verso.Abstractions;
+
+namespace Verso.Showcase.ImageStudio;
+
+/// <summary>
+/// Contributes the composite image exports ("PNG Image" and "SVG Image") to the host's Export
+/// menu. The compositor lives inside the isolated frame, so these actions do not produce bytes
+/// themselves: each asks the live <see cref="ImageStudioLayout"/> frame to render the requested
+/// format, and the frame streams the result back as an "export" interaction that the layout
+/// turns into a host file download.
+/// </summary>
+/// <remarks>
+/// The actions enable only while the Image Studio layout is the active layout, so they appear in
+/// the Export menu exactly in that layout and stay absent in every other. Enablement keys off the
+/// active layout (which flips synchronously on a layout switch) rather than a live-frame flag,
+/// because the frame mounts asynchronously and the toolbar would not re-check a frame flag after
+/// the mount completed; the layout is its frame, so "active layout" is the reliable signal. They
+/// reach the layout through the extension host: both the layout and these actions are singletons
+/// in the same host, so the action resolves the layout instance and drives it directly.
+/// </remarks>
+internal static class ImageStudioExport
+{
+    public const string LayoutId = "image-studio";
+
+    /// <summary>Resolves the live layout singleton, or null when it is not loaded.</summary>
+    public static ImageStudioLayout? ResolveLayout(IToolbarActionContext context)
+        => context.ExtensionHost.GetLayouts().OfType<ImageStudioLayout>().FirstOrDefault();
+
+    /// <summary>An export is offered only while Image Studio is the active layout.</summary>
+    public static bool CanExport(IToolbarActionContext context)
+        => string.Equals(context.ActiveLayoutId, LayoutId, StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary>Exports the composited canvas as a raster PNG.</summary>
+[VersoExtension]
+public sealed class ImageStudioExportPngAction : IToolbarAction
+{
+    public string ExtensionId => "com.verso.showcase.image-studio.export-png";
+    public string Name => "Image Studio: Export PNG";
+    public string Version => "1.0.0";
+    public string? Author => "Datafication";
+    public string? Description => "Exports the Image Studio composite as a PNG image.";
+
+    public Task OnLoadedAsync(IExtensionHostContext context) => Task.CompletedTask;
+    public Task OnUnloadedAsync() => Task.CompletedTask;
+
+    public string ActionId => "com.verso.showcase.image-studio.export-png";
+    public string DisplayName => "PNG Image";
+    public string? Icon => null;
+    public ToolbarPlacement Placement => ToolbarPlacement.ExportMenu;
+    public int Order => 10;
+
+    public Task<bool> IsEnabledAsync(IToolbarActionContext context)
+        => Task.FromResult(ImageStudioExport.CanExport(context));
+
+    public Task ExecuteAsync(IToolbarActionContext context)
+    {
+        ImageStudioExport.ResolveLayout(context)?.RequestFrameExport("png", context.CancellationToken);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>Exports the composite as resolution-independent SVG (the layers are vector primitives).</summary>
+[VersoExtension]
+public sealed class ImageStudioExportSvgAction : IToolbarAction
+{
+    public string ExtensionId => "com.verso.showcase.image-studio.export-svg";
+    public string Name => "Image Studio: Export SVG";
+    public string Version => "1.0.0";
+    public string? Author => "Datafication";
+    public string? Description => "Exports the Image Studio composite as an SVG image.";
+
+    public Task OnLoadedAsync(IExtensionHostContext context) => Task.CompletedTask;
+    public Task OnUnloadedAsync() => Task.CompletedTask;
+
+    public string ActionId => "com.verso.showcase.image-studio.export-svg";
+    public string DisplayName => "SVG Image";
+    public string? Icon => null;
+    public ToolbarPlacement Placement => ToolbarPlacement.ExportMenu;
+    public int Order => 20;
+
+    public Task<bool> IsEnabledAsync(IToolbarActionContext context)
+        => Task.FromResult(ImageStudioExport.CanExport(context));
+
+    public Task ExecuteAsync(IToolbarActionContext context)
+    {
+        ImageStudioExport.ResolveLayout(context)?.RequestFrameExport("svg", context.CancellationToken);
+        return Task.CompletedTask;
+    }
+}

--- a/samples/showcase/image-studio/src/Verso.Showcase.ImageStudio/ImageStudioLayout.cs
+++ b/samples/showcase/image-studio/src/Verso.Showcase.ImageStudio/ImageStudioLayout.cs
@@ -30,9 +30,10 @@ public sealed class ImageStudioLayout
     : ILayoutEngine, ILayoutLifecycleHandler, ILayoutInteractionHandler
 {
     // Frame-channel message types. The host prefixes these with "ext/" on delivery, so the
-    // frame receives them as "ext/document" and "ext/vars".
+    // frame receives them as "ext/document", "ext/vars", and "ext/export-request".
     private const string DocumentMessage = "document";
     private const string VarsMessage = "vars";
+    private const string ExportRequestMessage = "export-request";
 
     // The live document for this notebook session. Never null; replaced on metadata load.
     private LayerDocument _doc = LayerDocument.Seed();
@@ -342,6 +343,23 @@ public sealed class ImageStudioLayout
         catch (NotSupportedException)
         {
             Console.Error.WriteLine("[image-studio] Host does not support file download; export skipped.");
+        }
+    }
+
+    // --- Host-driven export ---
+
+    /// <summary>
+    /// Asks every live frame to produce an export of the given format ("png" or "svg"). The
+    /// frame builds the bytes and sends them back as an "export" interaction, which
+    /// <see cref="HandleExport"/> turns into a host file download. Triggered by the Export
+    /// menu actions so the export lives in the host chrome rather than the frame.
+    /// </summary>
+    internal void RequestFrameExport(string format, CancellationToken ct)
+    {
+        foreach (var frame in _frames.Values)
+        {
+            if (frame.IsAlive)
+                _ = frame.PostMessageAsync(ExportRequestMessage, new { format }, ct);
         }
     }
 

--- a/samples/showcase/image-studio/src/Verso.Showcase.ImageStudio/README.md
+++ b/samples/showcase/image-studio/src/Verso.Showcase.ImageStudio/README.md
@@ -21,9 +21,13 @@ also declare it as a required extension so it installs automatically on open.
 ## Using it
 
 With the layout active you can add layers (solid, gradients, checkerboard, stripes, dots, rings,
-text, and procedural), set each layer's opacity and blend mode, reorder the stack, and export the
-composite as PNG or SVG. Add a procedural layer and bind it to a kernel variable to draw a layer from
-code in any language the notebook runs.
+text, and procedural), set each layer's opacity and blend mode, and reorder the stack. Add a
+procedural layer and bind it to a kernel variable to draw a layer from code in any language the
+notebook runs.
+
+To save your work, use the host **Export** menu: while Image Studio is the active layout it adds
+**PNG Image** (the rasterized canvas) and **SVG Image** (a resolution-independent re-emit of the
+vector layers) alongside the notebook's other export formats.
 
 ## License
 

--- a/samples/showcase/image-studio/src/Verso.Showcase.ImageStudio/assets/main.js
+++ b/samples/showcase/image-studio/src/Verso.Showcase.ImageStudio/assets/main.js
@@ -36,29 +36,10 @@ const STYLE = `
   }
   .app {
     display: grid;
-    grid-template-rows: auto 1fr;
     grid-template-columns: 56px 1fr 288px;
-    grid-template-areas: "top top top" "tools stage panel";
+    grid-template-areas: "tools stage panel";
     height: 100%;
   }
-  /* Top bar */
-  .top {
-    grid-area: top;
-    display: flex; align-items: center; gap: 12px;
-    padding: 0 14px; height: 46px;
-    background: var(--verso-bg-elevated, #1b1e26);
-    border-bottom: 1px solid var(--verso-border-default, #2a2e38);
-  }
-  .brand { display: flex; align-items: center; gap: 9px; font-weight: 700; letter-spacing: .2px; }
-  .brand .mark {
-    width: 22px; height: 22px; border-radius: 6px;
-    background: var(--verso-accent, #5b8def);
-    display: grid; place-items: center; color: #fff;
-    box-shadow: 0 2px 8px rgba(0,0,0,.35);
-  }
-  .brand .mark svg { width: 14px; height: 14px; }
-  .brand .sub { color: var(--verso-fg-muted, #9aa0ac); font-weight: 500; font-size: .85em; }
-  .top .spacer { flex: 1; }
   .btn {
     appearance: none; cursor: pointer; user-select: none;
     border: 1px solid var(--verso-border-default, #2a2e38);
@@ -232,7 +213,6 @@ const STYLE = `
 // --- Icons (inline SVG; CSP-safe) -------------------------------------------
 
 const ICON = {
-  logo: '<svg viewBox="0 0 16 16" fill="none"><rect x="2" y="3" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.4"/><circle cx="6" cy="6.4" r="1.2" fill="currentColor"/><path d="M3 11l3-3 2 2 3-3 2 2" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>',
   solid: '<svg viewBox="0 0 24 24" fill="none"><rect x="4" y="4" width="16" height="16" rx="2" fill="currentColor"/></svg>',
   gradient: '<svg viewBox="0 0 24 24" fill="none"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="currentColor" stop-opacity=".25"/><stop offset="1" stop-color="currentColor"/></linearGradient></defs><rect x="4" y="4" width="16" height="16" rx="2" fill="url(#g)"/></svg>',
   radial: '<svg viewBox="0 0 24 24" fill="none"><rect x="4" y="4" width="16" height="16" rx="2" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="4.5" fill="currentColor"/></svg>',
@@ -241,7 +221,6 @@ const ICON = {
   code: '<svg viewBox="0 0 24 24" fill="none"><path d="M9 8l-4 4 4 4M15 8l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>',
   sliders: '<svg viewBox="0 0 24 24" fill="none"><path d="M5 8h9M18 8h1M5 16h1M10 16h9" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/><circle cx="16" cy="8" r="2.2" fill="currentColor"/><circle cx="8" cy="16" r="2.2" fill="currentColor"/></svg>',
   add: '<svg viewBox="0 0 16 16" fill="none"><path d="M8 3v10M3 8h10" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>',
-  download: '<svg viewBox="0 0 16 16" fill="none"><path d="M8 2v8m0 0l-3-3m3 3l3-3M3 13h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>',
   eye: '<svg viewBox="0 0 24 24" fill="none"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="2.6" fill="currentColor"/></svg>',
   eyeOff: '<svg viewBox="0 0 24 24" fill="none"><path d="M4 4l16 16M9.5 9.6A2.6 2.6 0 0012 14.5M6.3 6.4C3.7 8 2 12 2 12s3.5 7 10 7c1.7 0 3.2-.4 4.5-1M11 5.1c.3 0 .7-.1 1-.1 6.5 0 10 7 10 7s-.8 1.6-2.3 3.2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>',
   trash: '<svg viewBox="0 0 16 16" fill="none"><path d="M3 5h10M6.5 5V3.5h3V5M5 5l.5 8h5L11 5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg>',
@@ -267,12 +246,6 @@ document.head.appendChild(styleEl);
 
 document.body.innerHTML = `
   <div class="app">
-    <div class="top">
-      <div class="brand"><span class="mark">${ICON.logo}</span> Image Studio <span class="sub">layered compositor</span></div>
-      <div class="spacer"></div>
-      <button class="btn" id="exportSvgBtn">${ICON.download} Export SVG</button>
-      <button class="btn" id="exportBtn">${ICON.download} Export PNG</button>
-    </div>
     <div class="tools" id="tools"></div>
     <div class="stage">
       <div class="viewport" id="viewport">
@@ -318,8 +291,6 @@ propsToggle.onclick = () => { showProps = !showProps; propsToggle.classList.togg
 toolsEl.appendChild(propsToggle);
 
 document.getElementById("addBtn").onclick = () => verso.interact("add-layer", { kind: "solid" });
-document.getElementById("exportBtn").onclick = exportPng;
-document.getElementById("exportSvgBtn").onclick = exportSvg;
 
 // Zoom controls: buttons, click-% to reset, Fit, Ctrl/Cmd+wheel, and +/-/0 keys.
 document.getElementById("zoomIn").onclick = () => zoomBy(1.25);
@@ -1128,6 +1099,13 @@ verso.onMessage((type, payload) => {
         renderCanvas();
         renderLayers();
       }
+      break;
+    case "ext/export-request":
+      // The host Export menu owns the export buttons now; it asks the frame to produce the
+      // bytes (only the frame can rasterize the canvas), and exportPng/exportSvg send the
+      // result back as an "export" interaction the host turns into a file download.
+      if (payload && payload.format === "svg") exportSvg();
+      else exportPng();
       break;
     case "verso/themeChanged":
       // Chrome restyles via CSS automatically; repaint the canvas (theme-derived text/stroke).

--- a/src/Verso.Abstractions/Extensions/IToolbarAction.cs
+++ b/src/Verso.Abstractions/Extensions/IToolbarAction.cs
@@ -37,6 +37,15 @@ public interface IToolbarAction : IExtension
     bool IsPrimary => false;
 
     /// <summary>
+    /// Optional prompt asking the user to confirm before the action runs. When non-null,
+    /// hosts show a confirmation dialog with this text and execute the action only if the
+    /// user accepts. Intended for destructive actions whose effect cannot be undone (e.g.
+    /// restarting a kernel, which discards session state). Defaults to <c>null</c> so the
+    /// action executes immediately on click.
+    /// </summary>
+    string? ConfirmationPrompt => null;
+
+    /// <summary>
     /// Specifies where the action should appear (e.g. main toolbar, cell toolbar, context menu).
     /// </summary>
     ToolbarPlacement Placement { get; }

--- a/src/Verso.Abstractions/Extensions/IToolbarAction.cs
+++ b/src/Verso.Abstractions/Extensions/IToolbarAction.cs
@@ -22,6 +22,21 @@ public interface IToolbarAction : IExtension
     string? Icon { get; }
 
     /// <summary>
+    /// When <c>true</c>, the toolbar renders only the icon and surfaces the
+    /// <see cref="DisplayName"/> as a hover tooltip instead of a visible label.
+    /// Hosts ignore this for actions without an <see cref="Icon"/>. Defaults to
+    /// <c>false</c> so the label is shown.
+    /// </summary>
+    bool IconOnly => false;
+
+    /// <summary>
+    /// When <c>true</c>, the toolbar gives this action a filled, accent-colored
+    /// "primary" appearance to mark it as the prominent call to action. Defaults
+    /// to <c>false</c> for the standard flat button style.
+    /// </summary>
+    bool IsPrimary => false;
+
+    /// <summary>
     /// Specifies where the action should appear (e.g. main toolbar, cell toolbar, context menu).
     /// </summary>
     ToolbarPlacement Placement { get; }

--- a/src/Verso.Abstractions/Models/LayoutInteractionContext.cs
+++ b/src/Verso.Abstractions/Models/LayoutInteractionContext.cs
@@ -27,8 +27,8 @@ public sealed class LayoutInteractionContext
     public string FrameInstanceId { get; init; } = "";
 
     /// <summary>
-    /// Application-defined interaction type (e.g. <c>"setEditMode"</c>,
-    /// <c>"updateCellPosition"</c>).
+    /// Application-defined interaction type (e.g. <c>"updateCellPosition"</c>,
+    /// <c>"run"</c>).
     /// </summary>
     public string InteractionType { get; init; } = "";
 

--- a/src/Verso.Blazor.Shared/Components/Notebook/Toolbar.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/Toolbar.razor
@@ -10,7 +10,7 @@
             </div>
         </div>
 
-        <div class="verso-kernel-status @KernelStatusClass" title="@KernelStatusText">
+        <div class="verso-kernel-status @KernelStatusClass" title="@KernelStatusTooltip">
             <span class="verso-kernel-status-dot"></span>
             <span class="verso-kernel-status-text">@KernelStatusText</span>
         </div>
@@ -52,9 +52,15 @@
             <div class="verso-toolbar-separator"></div>
         }
 
-        <button class="verso-toolbar-btn" @onclick="OnSave" title="Save">
+        <button class="verso-toolbar-btn"
+                @onclick="OnSave"
+                title="@(Service.IsDirty ? "Save (unsaved changes)" : "Save")">
             <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2h8l2 2v9a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z"/><path d="M5 2v3h4V2"/><path d="M5 10h6v4H5z"/></svg>
             Save
+            @if (Service.IsDirty)
+            {
+                <span class="verso-toolbar-dirty-dot" aria-hidden="true"></span>
+            }
         </button>
 
         <div class="verso-toolbar-separator"></div>
@@ -62,22 +68,39 @@
         @foreach (var action in _filteredToolbarActions)
         {
             var a = action;
-            var isEnabled = _enabledStates.GetValueOrDefault(a.ActionId, false);
-            var iconOnly = a.IconOnly && a.Icon is not null;
-            <button class="verso-toolbar-btn @(iconOnly ? "verso-toolbar-btn--icon" : "") @(a.IsPrimary ? "verso-toolbar-btn--primary" : "")"
-                    disabled="@(!isEnabled)"
-                    title="@a.DisplayName"
-                    aria-label="@a.DisplayName"
-                    @onclick="() => ExecuteActionAsync(a)">
-                @if (a.Icon is not null)
-                {
-                    @((MarkupString)a.Icon)
-                }
-                @if (!iconOnly)
-                {
-                    @a.DisplayName
-                }
-            </button>
+            @if (a.IsPrimary && IsExecutionInFlight)
+            {
+                @* While the kernel is running, the primary call to action flips from "run"
+                   to "stop": clicking it cancels the in-flight execution instead of starting
+                   another. The swap keys off IsPrimary rather than a specific action id so
+                   any host- or extension-supplied primary action gets the same treatment. *@
+                <button class="verso-toolbar-btn verso-toolbar-btn--stop"
+                        title="Stop Execution"
+                        aria-label="Stop Execution"
+                        @onclick="CancelExecutionAsync">
+                    <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><rect x="3.5" y="3.5" width="9" height="9" rx="1"/></svg>
+                    Stop
+                </button>
+            }
+            else
+            {
+                var isEnabled = _enabledStates.GetValueOrDefault(a.ActionId, false);
+                var iconOnly = a.IconOnly && a.Icon is not null;
+                <button class="verso-toolbar-btn @(iconOnly ? "verso-toolbar-btn--icon" : "") @(a.IsPrimary ? "verso-toolbar-btn--primary" : "")"
+                        disabled="@(!isEnabled)"
+                        title="@a.DisplayName"
+                        aria-label="@a.DisplayName"
+                        @onclick="() => OnActionClicked(a)">
+                    @if (a.Icon is not null)
+                    {
+                        @((MarkupString)a.Icon)
+                    }
+                    @if (!iconOnly)
+                    {
+                        @a.DisplayName
+                    }
+                </button>
+            }
         }
 
         <div class="verso-toolbar-separator"></div>
@@ -167,9 +190,42 @@
     }
 </div>
 
+@if (_pendingConfirmAction is { } pending)
+{
+    <div class="verso-modal-overlay" @onclick="CancelPendingAction">
+        <div class="verso-modal" role="dialog" aria-modal="true" aria-label="@pending.DisplayName"
+             @onclick:stopPropagation="true" @onkeydown="HandleConfirmKeyDown">
+            <div class="verso-modal-header">
+                <span class="verso-modal-title">@pending.DisplayName</span>
+                <button class="verso-modal-close" @onclick="CancelPendingAction" title="Cancel">
+                    <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/></svg>
+                </button>
+            </div>
+            <div class="verso-modal-body">
+                <p style="margin:0;">@pending.ConfirmationPrompt</p>
+            </div>
+            <div class="verso-modal-footer">
+                <button class="verso-modal-btn verso-modal-btn--secondary"
+                        @onclick="CancelPendingAction">Cancel</button>
+                <button class="verso-modal-btn verso-modal-btn--primary"
+                        @onclick="ConfirmPendingActionAsync">@pending.DisplayName</button>
+            </div>
+        </div>
+    </div>
+}
+
 @code {
     [Parameter] public INotebookService Service { get; set; } = default!;
     [Parameter] public Guid? SelectedCellId { get; set; }
+
+    /// <summary>
+    /// Set by the hosting page while it has an execution in flight (Run All or a cell run it
+    /// started). The per-cell execution events momentarily report zero running cells between
+    /// the cells of a batch, so without this flag the Stop button and the status pill would
+    /// toggle back to their idle forms at every cell boundary. While this is <c>true</c> the
+    /// toolbar holds the running presentation until the whole run finishes.
+    /// </summary>
+    [Parameter] public bool IsExecuting { get; set; }
     [Parameter] public EventCallback OnNewNotebook { get; set; }
     [Parameter] public EventCallback<string> OnOpenNotebook { get; set; }
     [Parameter] public EventCallback<(string FileName, string Content)> OnBrowseNotebook { get; set; }
@@ -279,37 +335,64 @@
     }
 
     // --- Kernel status ---
-    // Derived from the existing execution/restart events; no new plumbing. The
-    // set of in-flight cells tracks concurrent runs so the pill only returns to
-    // idle once every cell has finished.
+    // Derived from the execution/restart/health events. The set of in-flight
+    // cells tracks concurrent runs so the pill only returns to idle once every
+    // cell has finished.
 
-    private enum KernelActivity { Idle, Running, Restarting }
+    private enum KernelActivity { Idle, Running, Restarting, Error, Disconnected }
 
     private KernelActivity _kernelActivity = KernelActivity.Idle;
+    private string? _kernelStatusDetail;
     private readonly HashSet<Guid> _runningCells = new();
     private bool _kernelEventsWired;
 
-    private string KernelStatusText => _kernelActivity switch
+    // The page-level IsExecuting flag holds the running presentation across the idle gaps
+    // between cells of a batch; the per-cell events cover runs the page did not start
+    // (e.g. an extension action executing cells). Restart/error states always win.
+    private KernelActivity EffectiveActivity =>
+        _kernelActivity == KernelActivity.Idle && IsExecuting
+            ? KernelActivity.Running
+            : _kernelActivity;
+
+    // The primary action swaps to Stop whenever an execution is in flight, regardless of
+    // whether the run started from the toolbar or a cell's own Run button; cancelling
+    // targets the current execution either way.
+    private bool IsExecutionInFlight => EffectiveActivity == KernelActivity.Running;
+
+    private string KernelStatusText => EffectiveActivity switch
     {
         KernelActivity.Running => "Running…",
         KernelActivity.Restarting => "Restarting…",
+        KernelActivity.Error => "Kernel error",
+        KernelActivity.Disconnected => "Disconnected",
         _ => "Kernel idle"
     };
 
-    private string KernelStatusClass => _kernelActivity switch
+    // Error and disconnected states carry the underlying cause (exception message,
+    // process exit detail) as the hover tooltip.
+    private string KernelStatusTooltip =>
+        string.IsNullOrWhiteSpace(_kernelStatusDetail)
+            ? KernelStatusText
+            : $"{KernelStatusText}: {_kernelStatusDetail}";
+
+    private string KernelStatusClass => EffectiveActivity switch
     {
         KernelActivity.Running => "verso-kernel-status--running",
         KernelActivity.Restarting => "verso-kernel-status--restarting",
+        KernelActivity.Error => "verso-kernel-status--error",
+        KernelActivity.Disconnected => "verso-kernel-status--error",
         _ => "verso-kernel-status--idle"
     };
 
-    private void WireKernelEvents()
+    private void WireServiceEvents()
     {
         if (_kernelEventsWired || Service is null) return;
         Service.OnCellExecuting += HandleCellExecuting;
         Service.OnCellExecutionCompleted += HandleCellExecutionCompleted;
         Service.OnKernelRestarting += HandleKernelRestarting;
         Service.OnKernelRestarted += HandleKernelRestarted;
+        Service.OnKernelHealthChanged += HandleKernelHealthChanged;
+        Service.OnDirtyStateChanged += HandleDirtyStateChanged;
         _kernelEventsWired = true;
     }
 
@@ -317,13 +400,16 @@
     {
         _runningCells.Add(cellId);
         _kernelActivity = KernelActivity.Running;
+        _kernelStatusDetail = null;
         _ = InvokeAsync(StateHasChanged);
     }
 
     private void HandleCellExecutionCompleted(Guid cellId)
     {
         _runningCells.Remove(cellId);
-        if (_runningCells.Count == 0 && _kernelActivity != KernelActivity.Restarting)
+        // Only fall back to idle from Running; a restart, error, or disconnect
+        // reported mid-run must not be cleared by a straggling completion event.
+        if (_runningCells.Count == 0 && _kernelActivity == KernelActivity.Running)
             _kernelActivity = KernelActivity.Idle;
         _ = InvokeAsync(StateHasChanged);
     }
@@ -331,6 +417,7 @@
     private void HandleKernelRestarting(string? kernelId)
     {
         _kernelActivity = KernelActivity.Restarting;
+        _kernelStatusDetail = null;
         _ = InvokeAsync(StateHasChanged);
     }
 
@@ -338,7 +425,48 @@
     {
         _runningCells.Clear();
         _kernelActivity = KernelActivity.Idle;
+        _kernelStatusDetail = null;
         _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleKernelHealthChanged(KernelHealthChangedEventArgs args)
+    {
+        switch (args.Health)
+        {
+            case KernelHealth.Disconnected:
+                _runningCells.Clear();
+                _kernelActivity = KernelActivity.Disconnected;
+                _kernelStatusDetail = args.Detail;
+                break;
+            case KernelHealth.Faulted:
+                _runningCells.Clear();
+                _kernelActivity = KernelActivity.Error;
+                _kernelStatusDetail = args.Detail;
+                break;
+            default:
+                if (_kernelActivity is KernelActivity.Error or KernelActivity.Disconnected)
+                    _kernelActivity = _runningCells.Count > 0 ? KernelActivity.Running : KernelActivity.Idle;
+                _kernelStatusDetail = null;
+                break;
+        }
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleDirtyStateChanged()
+        => _ = InvokeAsync(StateHasChanged);
+
+    private async Task CancelExecutionAsync()
+    {
+        // Both hosts cancel whatever execution is currently in flight; the cell id is
+        // informational (see INotebookService.CancelCellAsync).
+        try
+        {
+            await Service.CancelCellAsync(_runningCells.FirstOrDefault());
+        }
+        catch (Exception ex)
+        {
+            await OnError.InvokeAsync($"Stop failed: {ex.Message}");
+        }
     }
 
     public void Dispose()
@@ -348,11 +476,13 @@
         Service.OnCellExecutionCompleted -= HandleCellExecutionCompleted;
         Service.OnKernelRestarting -= HandleKernelRestarting;
         Service.OnKernelRestarted -= HandleKernelRestarted;
+        Service.OnKernelHealthChanged -= HandleKernelHealthChanged;
+        Service.OnDirtyStateChanged -= HandleDirtyStateChanged;
     }
 
     protected override void OnInitialized()
     {
-        WireKernelEvents();
+        WireServiceEvents();
     }
 
     protected override async Task OnParametersSetAsync()
@@ -387,6 +517,38 @@
         _enabledExportActions = _exportActions
             .Where(a => _exportEnabledStates.GetValueOrDefault(a.ActionId, false))
             .ToList();
+    }
+
+    // --- Action confirmation ---
+
+    private ToolbarActionInfo? _pendingConfirmAction;
+
+    // Actions that declare a ConfirmationPrompt (e.g. Restart Kernel, whose effect cannot
+    // be undone) go through a confirm dialog; everything else executes immediately.
+    private Task OnActionClicked(ToolbarActionInfo action)
+    {
+        if (!string.IsNullOrWhiteSpace(action.ConfirmationPrompt))
+        {
+            _pendingConfirmAction = action;
+            return Task.CompletedTask;
+        }
+        return ExecuteActionAsync(action);
+    }
+
+    private async Task ConfirmPendingActionAsync()
+    {
+        var action = _pendingConfirmAction;
+        _pendingConfirmAction = null;
+        if (action is not null)
+            await ExecuteActionAsync(action);
+    }
+
+    private void CancelPendingAction() => _pendingConfirmAction = null;
+
+    private async Task HandleConfirmKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter") await ConfirmPendingActionAsync();
+        else if (e.Key == "Escape") CancelPendingAction();
     }
 
     private async Task ExecuteActionAsync(ToolbarActionInfo action)

--- a/src/Verso.Blazor.Shared/Components/Notebook/Toolbar.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/Toolbar.razor
@@ -398,58 +398,77 @@
 
     private void HandleCellExecuting(Guid cellId)
     {
-        _runningCells.Add(cellId);
-        _kernelActivity = KernelActivity.Running;
-        _kernelStatusDetail = null;
-        _ = InvokeAsync(StateHasChanged);
+        // These events fire on the kernel's execution/restart thread. Marshal the state
+        // mutation and the render onto Blazor's dispatcher together so the shared
+        // _runningCells set and status fields are never written off the dispatcher (a
+        // concurrent read from CancelExecutionAsync would otherwise race the HashSet).
+        _ = InvokeAsync(() =>
+        {
+            _runningCells.Add(cellId);
+            _kernelActivity = KernelActivity.Running;
+            _kernelStatusDetail = null;
+            StateHasChanged();
+        });
     }
 
     private void HandleCellExecutionCompleted(Guid cellId)
     {
-        _runningCells.Remove(cellId);
-        // Only fall back to idle from Running; a restart, error, or disconnect
-        // reported mid-run must not be cleared by a straggling completion event.
-        if (_runningCells.Count == 0 && _kernelActivity == KernelActivity.Running)
-            _kernelActivity = KernelActivity.Idle;
-        _ = InvokeAsync(StateHasChanged);
+        _ = InvokeAsync(() =>
+        {
+            _runningCells.Remove(cellId);
+            // Only fall back to idle from Running; a restart, error, or disconnect
+            // reported mid-run must not be cleared by a straggling completion event.
+            if (_runningCells.Count == 0 && _kernelActivity == KernelActivity.Running)
+                _kernelActivity = KernelActivity.Idle;
+            StateHasChanged();
+        });
     }
 
     private void HandleKernelRestarting(string? kernelId)
     {
-        _kernelActivity = KernelActivity.Restarting;
-        _kernelStatusDetail = null;
-        _ = InvokeAsync(StateHasChanged);
+        _ = InvokeAsync(() =>
+        {
+            _kernelActivity = KernelActivity.Restarting;
+            _kernelStatusDetail = null;
+            StateHasChanged();
+        });
     }
 
     private void HandleKernelRestarted(string? kernelId)
     {
-        _runningCells.Clear();
-        _kernelActivity = KernelActivity.Idle;
-        _kernelStatusDetail = null;
-        _ = InvokeAsync(StateHasChanged);
+        _ = InvokeAsync(() =>
+        {
+            _runningCells.Clear();
+            _kernelActivity = KernelActivity.Idle;
+            _kernelStatusDetail = null;
+            StateHasChanged();
+        });
     }
 
     private void HandleKernelHealthChanged(KernelHealthChangedEventArgs args)
     {
-        switch (args.Health)
+        _ = InvokeAsync(() =>
         {
-            case KernelHealth.Disconnected:
-                _runningCells.Clear();
-                _kernelActivity = KernelActivity.Disconnected;
-                _kernelStatusDetail = args.Detail;
-                break;
-            case KernelHealth.Faulted:
-                _runningCells.Clear();
-                _kernelActivity = KernelActivity.Error;
-                _kernelStatusDetail = args.Detail;
-                break;
-            default:
-                if (_kernelActivity is KernelActivity.Error or KernelActivity.Disconnected)
-                    _kernelActivity = _runningCells.Count > 0 ? KernelActivity.Running : KernelActivity.Idle;
-                _kernelStatusDetail = null;
-                break;
-        }
-        _ = InvokeAsync(StateHasChanged);
+            switch (args.Health)
+            {
+                case KernelHealth.Disconnected:
+                    _runningCells.Clear();
+                    _kernelActivity = KernelActivity.Disconnected;
+                    _kernelStatusDetail = args.Detail;
+                    break;
+                case KernelHealth.Faulted:
+                    _runningCells.Clear();
+                    _kernelActivity = KernelActivity.Error;
+                    _kernelStatusDetail = args.Detail;
+                    break;
+                default:
+                    if (_kernelActivity is KernelActivity.Error or KernelActivity.Disconnected)
+                        _kernelActivity = _runningCells.Count > 0 ? KernelActivity.Running : KernelActivity.Idle;
+                    _kernelStatusDetail = null;
+                    break;
+            }
+            StateHasChanged();
+        });
     }
 
     private void HandleDirtyStateChanged()

--- a/src/Verso.Blazor.Shared/Components/Notebook/Toolbar.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/Toolbar.razor
@@ -5,7 +5,7 @@
         <div class="verso-doc-info" title="@KernelTooltip">
             <svg class="verso-doc-info-icon" viewBox="0 0 16 16" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 1.5h5L13 5.5v8a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z"/><path d="M9 1.5V5.5h4"/></svg>
             <div class="verso-doc-info-text">
-                <span class="verso-doc-info-name">@DocName</span>
+                <span class="verso-doc-info-name" title="@DocNameFull">@DocName</span>
                 <span class="verso-doc-info-meta">@KernelLabel &middot; @CellCount @(CellCount == 1 ? "cell" : "cells")</span>
             </div>
         </div>
@@ -207,7 +207,12 @@
 
     // --- Document info cluster ---
 
-    private string DocName
+    // Hard cap on the displayed document name; longer names are cut with an ellipsis (the full
+    // name stays available via the name span's tooltip). Keeps the cluster a predictable width
+    // rather than letting it grow with the file name.
+    private const int DocNameMaxLength = 20;
+
+    private string DocNameFull
     {
         get
         {
@@ -215,6 +220,15 @@
                 ? System.IO.Path.GetFileName(Service.FilePath)
                 : Service.Title;
             return string.IsNullOrWhiteSpace(name) ? "Untitled" : name!;
+        }
+    }
+
+    private string DocName
+    {
+        get
+        {
+            var name = DocNameFull;
+            return name.Length > DocNameMaxLength ? name[..DocNameMaxLength] + "…" : name;
         }
     }
 

--- a/src/Verso.Blazor.Shared/Components/Notebook/Toolbar.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/Toolbar.razor
@@ -1,4 +1,23 @@
+@implements IDisposable
 <div class="verso-toolbar" @onclick="CloseAllDropdowns">
+    @if (Service.IsLoaded)
+    {
+        <div class="verso-doc-info" title="@KernelTooltip">
+            <svg class="verso-doc-info-icon" viewBox="0 0 16 16" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 1.5h5L13 5.5v8a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z"/><path d="M9 1.5V5.5h4"/></svg>
+            <div class="verso-doc-info-text">
+                <span class="verso-doc-info-name">@DocName</span>
+                <span class="verso-doc-info-meta">@KernelLabel &middot; @CellCount @(CellCount == 1 ? "cell" : "cells")</span>
+            </div>
+        </div>
+
+        <div class="verso-kernel-status @KernelStatusClass" title="@KernelStatusText">
+            <span class="verso-kernel-status-dot"></span>
+            <span class="verso-kernel-status-text">@KernelStatusText</span>
+        </div>
+
+        <div class="verso-toolbar-separator"></div>
+    }
+
     @if (!Service.IsEmbedded)
     {
         <div class="verso-toolbar-group">
@@ -44,85 +63,71 @@
         {
             var a = action;
             var isEnabled = _enabledStates.GetValueOrDefault(a.ActionId, false);
-            <button class="verso-toolbar-btn"
+            var iconOnly = a.IconOnly && a.Icon is not null;
+            <button class="verso-toolbar-btn @(iconOnly ? "verso-toolbar-btn--icon" : "") @(a.IsPrimary ? "verso-toolbar-btn--primary" : "")"
                     disabled="@(!isEnabled)"
                     title="@a.DisplayName"
+                    aria-label="@a.DisplayName"
                     @onclick="() => ExecuteActionAsync(a)">
                 @if (a.Icon is not null)
                 {
                     @((MarkupString)a.Icon)
                 }
-                @a.DisplayName
+                @if (!iconOnly)
+                {
+                    @a.DisplayName
+                }
             </button>
         }
 
         <div class="verso-toolbar-separator"></div>
 
-        <div class="verso-toolbar-group">
-            <button class="verso-toolbar-btn" disabled="@(!Service.LayoutCapabilities.HasFlag(LayoutCapabilities.CellInsert))" @onclick="OnAddCodeCell" title="Add Code Cell">+ Code</button>
-            <button class="verso-toolbar-btn" disabled="@(!Service.LayoutCapabilities.HasFlag(LayoutCapabilities.CellInsert))" @onclick="OnAddMarkdownCell" title="Add Markdown Cell">+ Markdown</button>
-        </div>
-
-        @if (Service.AvailableLayouts.Count > 1)
+        @if (Service.AvailableLayouts.Count > 1 || ShowThemeSection)
         {
-            <div class="verso-toolbar-separator"></div>
-
             <div class="verso-toolbar-dropdown">
                 <button class="verso-toolbar-btn"
-                        title="Switch Layout"
-                        @onclick="CycleLayout">
+                        title="View Options"
+                        @onclick="ToggleViewDropdown"
+                        @onclick:stopPropagation="true">
                     <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="1.5" y="1.5" width="13" height="13" rx="1"/><line x1="6" y1="1.5" x2="6" y2="14.5"/><line x1="6" y1="8" x2="14.5" y2="8"/></svg>
-                    @ActiveLayoutName
+                    View &#9662;
                 </button>
-                <button class="verso-toolbar-btn verso-toolbar-dropdown-chevron"
-                        @onclick="ToggleLayoutDropdown"
-                        @onclick:stopPropagation="true">
-                    &#9662;
-                </button>
-                @if (_showLayoutDropdown)
+                @if (_showViewDropdown)
                 {
                     <div class="verso-toolbar-dropdown-popup" @onclick:stopPropagation="true">
-                        @foreach (var layout in Service.AvailableLayouts)
+                        @if (Service.AvailableLayouts.Count > 1)
                         {
-                            var l = layout;
-                            var isActive = string.Equals(l.LayoutId, Service.ActiveLayoutId, StringComparison.OrdinalIgnoreCase);
-                            <button class="verso-toolbar-btn @(isActive ? "verso-toolbar-btn--active" : "")"
-                                    @onclick="() => SelectLayout(l.LayoutId)">
-                                @l.DisplayName
-                            </button>
+                            <div class="verso-toolbar-menu-header">Layout</div>
+                            @foreach (var layout in Service.AvailableLayouts)
+                            {
+                                var l = layout;
+                                var isActive = string.Equals(l.LayoutId, Service.ActiveLayoutId, StringComparison.OrdinalIgnoreCase);
+                                <button class="verso-toolbar-btn verso-toolbar-menu-item @(isActive ? "verso-toolbar-menu-item--active" : "")"
+                                        @onclick="() => SelectLayout(l.LayoutId)">
+                                    <span>@l.DisplayName</span>
+                                    @if (isActive)
+                                    {
+                                        <span class="verso-toolbar-menu-check">&#10003;</span>
+                                    }
+                                </button>
+                            }
                         }
-                    </div>
-                }
-            </div>
-        }
-
-        @if (Service.AvailableThemes.Count > 1 && !Service.IsEmbedded)
-        {
-            <div class="verso-toolbar-separator"></div>
-
-            <div class="verso-toolbar-dropdown">
-                <button class="verso-toolbar-btn"
-                        title="Switch Theme"
-                        @onclick="CycleTheme">
-                    <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.3"><circle cx="8" cy="8" r="6"/><circle cx="5.5" cy="6" r="1" fill="currentColor" stroke="none"/><circle cx="8" cy="4.5" r="1" fill="currentColor" stroke="none"/><circle cx="10.5" cy="6" r="1" fill="currentColor" stroke="none"/><circle cx="6" cy="10" r="1" fill="currentColor" stroke="none"/></svg>
-                    @ActiveThemeName
-                </button>
-                <button class="verso-toolbar-btn verso-toolbar-dropdown-chevron"
-                        @onclick="ToggleThemeDropdown"
-                        @onclick:stopPropagation="true">
-                    &#9662;
-                </button>
-                @if (_showThemeDropdown)
-                {
-                    <div class="verso-toolbar-dropdown-popup" @onclick:stopPropagation="true">
-                        @foreach (var theme in Service.AvailableThemes)
+                        @if (ShowThemeSection)
                         {
-                            var t = theme;
-                            var isActive = string.Equals(t.ThemeId, Service.ActiveThemeId, StringComparison.OrdinalIgnoreCase);
-                            <button class="verso-toolbar-btn @(isActive ? "verso-toolbar-btn--active" : "")"
-                                    @onclick="() => SelectTheme(t.ThemeId)">
-                                @t.DisplayName
-                            </button>
+                            <div class="verso-toolbar-menu-header">Theme</div>
+                            @foreach (var theme in Service.AvailableThemes)
+                            {
+                                var t = theme;
+                                var isActive = string.Equals(t.ThemeId, Service.ActiveThemeId, StringComparison.OrdinalIgnoreCase);
+                                <button class="verso-toolbar-btn verso-toolbar-menu-item @(isActive ? "verso-toolbar-menu-item--active" : "")"
+                                        @onclick="() => SelectTheme(t.ThemeId)">
+                                    <span>@t.DisplayName</span>
+                                    @if (isActive)
+                                    {
+                                        <span class="verso-toolbar-menu-check">&#10003;</span>
+                                    }
+                                </button>
+                            }
                         }
                     </div>
                 }
@@ -131,8 +136,6 @@
 
         @if (_exportActions.Count > 0)
         {
-            <div class="verso-toolbar-separator"></div>
-
             <div class="verso-toolbar-dropdown">
                 <button class="verso-toolbar-btn"
                         title="Export Notebook"
@@ -158,7 +161,6 @@
                 }
             </div>
         }
-
     }
 </div>
 
@@ -186,8 +188,7 @@
     private Dictionary<string, bool> _exportEnabledStates = new();
     private bool _showOpenInput;
     private string _openFilePath = "";
-    private bool _showLayoutDropdown;
-    private bool _showThemeDropdown;
+    private bool _showViewDropdown;
     private bool _showExportDropdown;
 
     private static readonly HashSet<string> _excludedActionIds = new(StringComparer.OrdinalIgnoreCase)
@@ -196,11 +197,145 @@
         "verso.switchTheme"
     };
 
-    private string ActiveLayoutName =>
-        Service.AvailableLayouts.FirstOrDefault(l => string.Equals(l.LayoutId, Service.ActiveLayoutId, StringComparison.OrdinalIgnoreCase))?.DisplayName ?? "Layout";
+    // Themes come from the host in the embedded (VS Code) shell, so the theme
+    // section is hidden there and only the layout section is offered.
+    private bool ShowThemeSection => Service.AvailableThemes.Count > 1 && !Service.IsEmbedded;
 
-    private string ActiveThemeName =>
-        Service.AvailableThemes.FirstOrDefault(t => string.Equals(t.ThemeId, Service.ActiveThemeId, StringComparison.OrdinalIgnoreCase))?.DisplayName ?? "Theme";
+    // --- Document info cluster ---
+
+    private string DocName
+    {
+        get
+        {
+            var name = !string.IsNullOrEmpty(Service.FilePath)
+                ? System.IO.Path.GetFileName(Service.FilePath)
+                : Service.Title;
+            return string.IsNullOrWhiteSpace(name) ? "Untitled" : name!;
+        }
+    }
+
+    private int CellCount => Service.Cells.Count;
+
+    private string PrimaryKernelName =>
+        ResolveLanguageName(Service.DefaultKernelId) ?? "No kernel";
+
+    // Distinct languages actually in use across code cells (a cell with no
+    // explicit language inherits the notebook default).
+    private List<string> DistinctLanguageIds => Service.Cells
+        .Where(c => string.Equals(c.Type, "code", StringComparison.OrdinalIgnoreCase))
+        .Select(c => c.Language ?? Service.DefaultKernelId)
+        .Where(id => !string.IsNullOrEmpty(id))
+        .Select(id => id!)
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    // The kernel label in the meta line. When more than one language is in use
+    // the primary kernel name is suffixed with the count of the others.
+    private string KernelLabel
+    {
+        get
+        {
+            var others = DistinctLanguageIds.Count - 1;
+            return others > 0 ? $"{PrimaryKernelName} +{others}" : PrimaryKernelName;
+        }
+    }
+
+    // Tooltip enumerating every kernel in use when the notebook is polyglot.
+    private string KernelTooltip
+    {
+        get
+        {
+            var names = DistinctLanguageIds
+                .Select(id => ResolveLanguageName(id) ?? id)
+                .ToList();
+            return names.Count > 1 ? "Kernels: " + string.Join(", ", names) : PrimaryKernelName;
+        }
+    }
+
+    private string? ResolveLanguageName(string? languageId)
+    {
+        if (string.IsNullOrEmpty(languageId)) return null;
+        return Service.RegisteredLanguages
+            .FirstOrDefault(l => string.Equals(l.Id, languageId, StringComparison.OrdinalIgnoreCase))?.DisplayName
+            ?? languageId;
+    }
+
+    // --- Kernel status ---
+    // Derived from the existing execution/restart events; no new plumbing. The
+    // set of in-flight cells tracks concurrent runs so the pill only returns to
+    // idle once every cell has finished.
+
+    private enum KernelActivity { Idle, Running, Restarting }
+
+    private KernelActivity _kernelActivity = KernelActivity.Idle;
+    private readonly HashSet<Guid> _runningCells = new();
+    private bool _kernelEventsWired;
+
+    private string KernelStatusText => _kernelActivity switch
+    {
+        KernelActivity.Running => "Running…",
+        KernelActivity.Restarting => "Restarting…",
+        _ => "Kernel idle"
+    };
+
+    private string KernelStatusClass => _kernelActivity switch
+    {
+        KernelActivity.Running => "verso-kernel-status--running",
+        KernelActivity.Restarting => "verso-kernel-status--restarting",
+        _ => "verso-kernel-status--idle"
+    };
+
+    private void WireKernelEvents()
+    {
+        if (_kernelEventsWired || Service is null) return;
+        Service.OnCellExecuting += HandleCellExecuting;
+        Service.OnCellExecutionCompleted += HandleCellExecutionCompleted;
+        Service.OnKernelRestarting += HandleKernelRestarting;
+        Service.OnKernelRestarted += HandleKernelRestarted;
+        _kernelEventsWired = true;
+    }
+
+    private void HandleCellExecuting(Guid cellId)
+    {
+        _runningCells.Add(cellId);
+        _kernelActivity = KernelActivity.Running;
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleCellExecutionCompleted(Guid cellId)
+    {
+        _runningCells.Remove(cellId);
+        if (_runningCells.Count == 0 && _kernelActivity != KernelActivity.Restarting)
+            _kernelActivity = KernelActivity.Idle;
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleKernelRestarting(string? kernelId)
+    {
+        _kernelActivity = KernelActivity.Restarting;
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleKernelRestarted(string? kernelId)
+    {
+        _runningCells.Clear();
+        _kernelActivity = KernelActivity.Idle;
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        if (!_kernelEventsWired || Service is null) return;
+        Service.OnCellExecuting -= HandleCellExecuting;
+        Service.OnCellExecutionCompleted -= HandleCellExecutionCompleted;
+        Service.OnKernelRestarting -= HandleKernelRestarting;
+        Service.OnKernelRestarted -= HandleKernelRestarted;
+    }
+
+    protected override void OnInitialized()
+    {
+        WireKernelEvents();
+    }
 
     protected override async Task OnParametersSetAsync()
     {
@@ -288,43 +423,16 @@
         await OnActionExecuted.InvokeAsync("verso.switchTheme");
     }
 
-    private async Task CycleLayout()
+    private void ToggleViewDropdown()
     {
-        var layouts = Service.AvailableLayouts;
-        if (layouts.Count < 2) return;
-        var currentIndex = layouts.ToList().FindIndex(l => string.Equals(l.LayoutId, Service.ActiveLayoutId, StringComparison.OrdinalIgnoreCase));
-        var nextIndex = (currentIndex + 1) % layouts.Count;
-        await SwitchLayout(layouts[nextIndex].LayoutId);
-    }
-
-    private async Task CycleTheme()
-    {
-        var themes = Service.AvailableThemes;
-        if (themes.Count < 2) return;
-        var currentIndex = themes.ToList().FindIndex(t => string.Equals(t.ThemeId, Service.ActiveThemeId, StringComparison.OrdinalIgnoreCase));
-        var nextIndex = (currentIndex + 1) % themes.Count;
-        await SwitchTheme(themes[nextIndex].ThemeId);
-    }
-
-    private void ToggleLayoutDropdown()
-    {
-        _showLayoutDropdown = !_showLayoutDropdown;
-        _showThemeDropdown = false;
-        _showExportDropdown = false;
-    }
-
-    private void ToggleThemeDropdown()
-    {
-        _showThemeDropdown = !_showThemeDropdown;
-        _showLayoutDropdown = false;
+        _showViewDropdown = !_showViewDropdown;
         _showExportDropdown = false;
     }
 
     private void ToggleExportDropdown()
     {
         _showExportDropdown = !_showExportDropdown;
-        _showLayoutDropdown = false;
-        _showThemeDropdown = false;
+        _showViewDropdown = false;
     }
 
     private async Task ExecuteExportAsync(ToolbarActionInfo action)
@@ -335,20 +443,19 @@
 
     private async Task SelectLayout(string layoutId)
     {
-        _showLayoutDropdown = false;
+        _showViewDropdown = false;
         await SwitchLayout(layoutId);
     }
 
     private async Task SelectTheme(string themeId)
     {
-        _showThemeDropdown = false;
+        _showViewDropdown = false;
         await SwitchTheme(themeId);
     }
 
     private void CloseAllDropdowns()
     {
-        _showLayoutDropdown = false;
-        _showThemeDropdown = false;
+        _showViewDropdown = false;
         _showExportDropdown = false;
     }
 
@@ -374,5 +481,4 @@
 
     private async Task OnSave() => await OnSaveNotebook.InvokeAsync();
     private async Task OnAddCodeCell() => await OnAddCell.InvokeAsync("code");
-    private async Task OnAddMarkdownCell() => await OnAddCell.InvokeAsync("markdown");
 }

--- a/src/Verso.Blazor.Shared/Components/Notebook/Toolbar.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/Toolbar.razor
@@ -134,7 +134,12 @@
             </div>
         }
 
-        @if (_exportActions.Count > 0)
+        @* Only surface export actions that are currently enabled. Actions gate themselves through
+           IsEnabledAsync (a layout-specific export enables only while its layout is active), so a
+           disabled action is hidden outright rather than shown greyed-out, and the Export button
+           disappears when nothing is exportable. The enabled set is recomputed in
+           RefreshEnabledStatesAsync. *@
+        @if (_enabledExportActions.Count > 0)
         {
             <div class="verso-toolbar-dropdown">
                 <button class="verso-toolbar-btn"
@@ -147,12 +152,10 @@
                 @if (_showExportDropdown)
                 {
                     <div class="verso-toolbar-dropdown-popup" @onclick:stopPropagation="true">
-                        @foreach (var action in _exportActions)
+                        @foreach (var action in _enabledExportActions)
                         {
                             var a = action;
-                            var isEnabled = _exportEnabledStates.GetValueOrDefault(a.ActionId, false);
                             <button class="verso-toolbar-btn"
-                                    disabled="@(!isEnabled)"
                                     @onclick="() => ExecuteExportAsync(a)">
                                 @a.DisplayName
                             </button>
@@ -186,6 +189,7 @@
     private IReadOnlyList<ToolbarActionInfo> _exportActions = Array.Empty<ToolbarActionInfo>();
     private Dictionary<string, bool> _enabledStates = new();
     private Dictionary<string, bool> _exportEnabledStates = new();
+    private IReadOnlyList<ToolbarActionInfo> _enabledExportActions = Array.Empty<ToolbarActionInfo>();
     private bool _showOpenInput;
     private string _openFilePath = "";
     private bool _showViewDropdown;
@@ -365,6 +369,10 @@
             _exportEnabledStates = await Service.GetActionEnabledStatesAsync(
                 ToolbarPlacement.ExportMenu, selectedIds);
         }
+
+        _enabledExportActions = _exportActions
+            .Where(a => _exportEnabledStates.GetValueOrDefault(a.ActionId, false))
+            .ToList();
     }
 
     private async Task ExecuteActionAsync(ToolbarActionInfo action)

--- a/src/Verso.Blazor.Shared/Models/ServiceDtos.cs
+++ b/src/Verso.Blazor.Shared/Models/ServiceDtos.cs
@@ -17,7 +17,27 @@ public sealed record ToolbarActionInfo(
     ToolbarPlacement Placement,
     int Order,
     bool IconOnly = false,
-    bool IsPrimary = false);
+    bool IsPrimary = false,
+    string? ConfirmationPrompt = null);
+
+/// <summary>
+/// Health of the kernel connection as observed by the host. <see cref="Faulted"/> means the
+/// kernel infrastructure failed (e.g. a restart threw); <see cref="Disconnected"/> means the
+/// host process or transport backing the kernel is gone. Both are recoverable by restarting.
+/// </summary>
+public enum KernelHealth
+{
+    Ok,
+    Faulted,
+    Disconnected,
+}
+
+/// <summary>
+/// Payload of <c>INotebookService.OnKernelHealthChanged</c>. <paramref name="Detail"/> carries
+/// an optional human-readable explanation (exception message, process exit description) that
+/// the UI can surface as a tooltip.
+/// </summary>
+public sealed record KernelHealthChangedEventArgs(KernelHealth Health, string? Detail = null);
 
 /// <summary>
 /// Payload of a <c>layout/updated</c> host-to-client notification. Carries the

--- a/src/Verso.Blazor.Shared/Models/ServiceDtos.cs
+++ b/src/Verso.Blazor.Shared/Models/ServiceDtos.cs
@@ -15,7 +15,9 @@ public sealed record ToolbarActionInfo(
     string DisplayName,
     string? Icon,
     ToolbarPlacement Placement,
-    int Order);
+    int Order,
+    bool IconOnly = false,
+    bool IsPrimary = false);
 
 /// <summary>
 /// Payload of a <c>layout/updated</c> host-to-client notification. Carries the

--- a/src/Verso.Blazor.Shared/Services/INotebookService.cs
+++ b/src/Verso.Blazor.Shared/Services/INotebookService.cs
@@ -21,6 +21,9 @@ public interface INotebookService
     /// <summary>The on-disk file path, or null if unsaved / embedded.</summary>
     string? FilePath { get; }
 
+    /// <summary>Whether the notebook has changes that have not been saved.</summary>
+    bool IsDirty { get; }
+
     // ── Notebook metadata ──────────────────────────────────────────────
 
     /// <summary>Notebook title.</summary>
@@ -152,6 +155,14 @@ public interface INotebookService
     /// loaded on open (offline, package missing, or consent declined). The notebook still opens;
     /// this lets the UI show a non-fatal notice that some layouts or cells may not work.</summary>
     event Action<IReadOnlyList<UnavailableExtensionInfo>>? OnRequiredExtensionsUnavailable;
+
+    /// <summary>Raised when <see cref="IsDirty"/> changes.</summary>
+    event Action? OnDirtyStateChanged;
+
+    /// <summary>Raised when the kernel's health changes: a restart failed (Faulted), the
+    /// process backing the kernel went away (Disconnected), or the kernel recovered (Ok).
+    /// Distinct from the restart events, which track a normal restart's progress.</summary>
+    event Action<KernelHealthChangedEventArgs>? OnKernelHealthChanged;
 
     // ── File operations ────────────────────────────────────────────────
 

--- a/src/Verso.Blazor.Shared/wwwroot/app.css
+++ b/src/Verso.Blazor.Shared/wwwroot/app.css
@@ -1259,16 +1259,6 @@ html, body {
     min-height: 0;
 }
 
-.verso-dashboard-toolbar {
-    display: flex;
-    justify-content: flex-end;
-    gap: 8px;
-    padding: 6px 16px;
-    border-bottom: 1px solid var(--verso-cell-border, #E0E0E0);
-    background: var(--verso-toolbar-background, transparent);
-    flex-shrink: 0;
-}
-
 .verso-dashboard-grid {
     display: grid;
     grid-template-columns: repeat(12, 1fr);
@@ -1368,25 +1358,6 @@ html, body {
     user-select: none;
 }
 
-.verso-dashboard-edit-toggle {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    height: 24px;
-    padding: 0 8px;
-    border: none;
-    border-radius: var(--verso-button-border-radius, 4px);
-    background: transparent;
-    color: var(--verso-editor-line-number, #858585);
-    cursor: pointer;
-    font-size: 11px;
-}
-
-.verso-dashboard-edit-toggle:hover {
-    background: var(--verso-toolbar-button-hover, #E0E0E0);
-    color: var(--verso-editor-foreground, #1E1E1E);
-}
-
 /* === Presentation Layout === */
 
 .verso-presentation-view {
@@ -1445,28 +1416,14 @@ html, body {
     display: none;
 }
 
+/* The dashboard is view-and-arrange only: the inner cell's editor and editing chrome stay
+   hidden at all times, so only rendered output shows inside each tile. */
 .verso-dashboard-cell .verso-cell-gutter,
 .verso-dashboard-cell .verso-cell-toolbar,
 .verso-dashboard-cell .verso-cell-editor,
 .verso-dashboard-cell .verso-cell-source-preview,
 .verso-dashboard-cell .verso-cell-status {
     display: none;
-}
-
-/* Show the inner cell's editor + gutter when the grid is in edit mode OR the
-   individual cell's Edit toggle is on. `display: revert` falls back to each
-   element's own CSS rule so we don't have to hardcode their display value here. */
-.verso-dashboard-grid[data-edit-mode="true"] .verso-dashboard-cell .verso-cell-gutter,
-.verso-dashboard-grid[data-edit-mode="true"] .verso-dashboard-cell .verso-cell-toolbar,
-.verso-dashboard-grid[data-edit-mode="true"] .verso-dashboard-cell .verso-cell-editor,
-.verso-dashboard-grid[data-edit-mode="true"] .verso-dashboard-cell .verso-cell-source-preview,
-.verso-dashboard-grid[data-edit-mode="true"] .verso-dashboard-cell .verso-cell-status,
-.verso-dashboard-cell[data-cell-edit="true"] .verso-cell-gutter,
-.verso-dashboard-cell[data-cell-edit="true"] .verso-cell-toolbar,
-.verso-dashboard-cell[data-cell-edit="true"] .verso-cell-editor,
-.verso-dashboard-cell[data-cell-edit="true"] .verso-cell-source-preview,
-.verso-dashboard-cell[data-cell-edit="true"] .verso-cell-status {
-    display: revert;
 }
 
 /* The drag/resize handles are layout chrome, not Blazor's chrome; the Cell
@@ -1477,18 +1434,6 @@ html, body {
     border: none;
     background: transparent;
     box-shadow: none;
-}
-
-/* When a cell is in edit mode, its native gutter (with its own Run button)
-   appears, making the host toolbar's Run redundant. Hide it so we don't ship
-   two Run buttons stacked on top of each other. */
-.verso-dashboard-cell[data-cell-edit="true"] .verso-dashboard-cell-toolbar .verso-cell-btn--run {
-    display: none;
-}
-
-/* Same when the grid is globally in edit mode. */
-.verso-dashboard-grid[data-edit-mode="true"] .verso-dashboard-cell-toolbar .verso-cell-btn--run {
-    display: none;
 }
 
 /* Document info cluster: icon + filename over a kernel/cell-count meta line */

--- a/src/Verso.Blazor.Shared/wwwroot/app.css
+++ b/src/Verso.Blazor.Shared/wwwroot/app.css
@@ -112,6 +112,31 @@ html, body {
     opacity: 0.45;
 }
 
+/* Stop button shown in place of the primary action while execution is in flight.
+   Hosts can supply a dedicated fill pair (the VS Code webview maps the status bar
+   error item colors); otherwise the theme's status-error color is used. The pair
+   exists because --verso-status-error doubles as a text color elsewhere (error
+   banner, kernel pill) and a good text red is not always a good button fill. */
+.verso-toolbar-btn--stop {
+    background: var(--verso-toolbar-stop-background, var(--verso-status-error, #DC3545));
+    color: var(--verso-toolbar-stop-foreground, #FFFFFF);
+    font-weight: 600;
+}
+
+.verso-toolbar-btn--stop:hover:not(:disabled) {
+    background: var(--verso-toolbar-stop-background, var(--verso-status-error, #DC3545));
+    filter: brightness(0.88);
+}
+
+/* Unsaved-changes indicator on the Save button. */
+.verso-toolbar-dirty-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--verso-accent-primary, #0078D4);
+    flex: none;
+}
+
 .verso-toolbar-input {
     height: 26px;
     padding: 0 8px;
@@ -1477,15 +1502,21 @@ html, body {
     text-overflow: ellipsis;
 }
 
-/* Kernel status pill: idle / running / restarting. Right-aligned in the bar. */
+/* Kernel status pill: idle / running / restarting / error / disconnected.
+
+   The pill is a passive indicator, not a control: it deliberately has no border so it
+   does not read as a clickable chip next to the real buttons. The min-width is sized to
+   the longest status string ("Restarting…" / "Disconnected") so the buttons to its right
+   do not shift horizontally when the status text changes mid-run. */
 
 .verso-kernel-status {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 6px;
     padding: 3px 10px;
+    min-width: 112px;
     border-radius: 11px;
-    border: 1px solid transparent;
     font-size: 12px;
     white-space: nowrap;
     flex: none;
@@ -1505,20 +1536,23 @@ html, body {
 
 .verso-kernel-status--idle {
     color: var(--verso-success, #3FB950);
-    border-color: rgba(63, 185, 80, 0.4);
-    background: rgba(63, 185, 80, 0.08);
+    background: rgba(63, 185, 80, 0.1);
 }
 
 .verso-kernel-status--running {
     color: var(--verso-accent-primary, #0078D4);
-    border-color: rgba(0, 120, 212, 0.4);
-    background: rgba(0, 120, 212, 0.08);
+    background: rgba(0, 120, 212, 0.1);
 }
 
 .verso-kernel-status--restarting {
     color: var(--verso-warning, #D29922);
-    border-color: rgba(210, 153, 34, 0.4);
-    background: rgba(210, 153, 34, 0.08);
+    background: rgba(210, 153, 34, 0.1);
+}
+
+/* Kernel infrastructure failure or lost host process; the tooltip carries the cause. */
+.verso-kernel-status--error {
+    color: var(--verso-status-error, #DC3545);
+    background: rgba(220, 53, 69, 0.1);
 }
 
 .verso-kernel-status--running .verso-kernel-status-dot {

--- a/src/Verso.Blazor.Shared/wwwroot/app.css
+++ b/src/Verso.Blazor.Shared/wwwroot/app.css
@@ -88,6 +88,30 @@ html, body {
     cursor: default;
 }
 
+/* Icon-only toolbar action: hide the label, keep a square hit target; the
+   button's title attribute supplies the hover tooltip. */
+.verso-toolbar-btn--icon {
+    padding: 0 7px;
+}
+
+/* Primary toolbar action: filled accent button marking the prominent call to
+   action (e.g. Run All). */
+.verso-toolbar-btn--primary {
+    background: var(--verso-accent-primary, #0078D4);
+    color: #FFFFFF;
+    font-weight: 600;
+}
+
+.verso-toolbar-btn--primary:hover:not(:disabled) {
+    background: var(--verso-accent-secondary, #005A9E);
+}
+
+.verso-toolbar-btn--primary:disabled {
+    background: var(--verso-accent-primary, #0078D4);
+    color: #FFFFFF;
+    opacity: 0.45;
+}
+
 .verso-toolbar-input {
     height: 26px;
     padding: 0 8px;
@@ -1467,15 +1491,98 @@ html, body {
     display: none;
 }
 
-/* Layout switcher active button */
+/* Document info cluster: icon + filename over a kernel/cell-count meta line */
 
-.verso-toolbar-btn--active {
-    background: var(--verso-accent-primary, #0078D4);
-    color: #FFFFFF;
+.verso-doc-info {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 8px;
+    min-width: 0;
+    max-width: 320px;
 }
 
-.verso-toolbar-btn--active:hover:not(:disabled) {
-    background: var(--verso-accent-secondary, #005A9E);
+.verso-doc-info-icon {
+    flex: none;
+    color: var(--verso-accent-primary, #0078D4);
+}
+
+.verso-doc-info-text {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    line-height: 1.25;
+    min-width: 0;
+}
+
+.verso-doc-info-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--verso-toolbar-foreground, #1E1E1E);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.verso-doc-info-meta {
+    font-size: 11px;
+    color: var(--verso-text-muted, #888);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Kernel status pill: idle / running / restarting. Right-aligned in the bar. */
+
+.verso-kernel-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 10px;
+    border-radius: 11px;
+    border: 1px solid transparent;
+    font-size: 12px;
+    white-space: nowrap;
+    flex: none;
+}
+
+.verso-kernel-status-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+    flex: none;
+}
+
+.verso-kernel-status-text {
+    color: inherit;
+}
+
+.verso-kernel-status--idle {
+    color: var(--verso-success, #3FB950);
+    border-color: rgba(63, 185, 80, 0.4);
+    background: rgba(63, 185, 80, 0.08);
+}
+
+.verso-kernel-status--running {
+    color: var(--verso-accent-primary, #0078D4);
+    border-color: rgba(0, 120, 212, 0.4);
+    background: rgba(0, 120, 212, 0.08);
+}
+
+.verso-kernel-status--restarting {
+    color: var(--verso-warning, #D29922);
+    border-color: rgba(210, 153, 34, 0.4);
+    background: rgba(210, 153, 34, 0.08);
+}
+
+.verso-kernel-status--running .verso-kernel-status-dot {
+    animation: verso-kernel-pulse 1s ease-in-out infinite;
+}
+
+@keyframes verso-kernel-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
 }
 
 /* Toolbar dropdown toggle */
@@ -1512,6 +1619,38 @@ html, body {
     justify-content: flex-start;
     width: 100%;
     border-radius: 2px;
+}
+
+/* Sectioned "View" menu: header label above each group */
+
+.verso-toolbar-menu-header {
+    padding: 6px 8px 2px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--verso-text-muted, #888);
+    pointer-events: none;
+}
+
+.verso-toolbar-menu-header:not(:first-child) {
+    margin-top: 4px;
+}
+
+/* Menu rows push the active checkmark to the trailing edge */
+
+.verso-toolbar-dropdown-popup .verso-toolbar-menu-item {
+    justify-content: space-between;
+    gap: 24px;
+}
+
+.verso-toolbar-menu-item--active {
+    color: var(--verso-accent-primary, #0078D4);
+    font-weight: 600;
+}
+
+.verso-toolbar-menu-check {
+    color: var(--verso-accent-primary, #0078D4);
 }
 
 /* === Notebook Body Layout === */

--- a/src/Verso.Blazor.Shared/wwwroot/js/cell-interact-interop.js
+++ b/src/Verso.Blazor.Shared/wwwroot/js/cell-interact-interop.js
@@ -54,3 +54,77 @@ window.versoCellInteract = (() => {
         }
     };
 })();
+
+/**
+ * Click-through guard for rendered cell previews.
+ *
+ * A rendered (collapsed-input) cell shows its output as a preview, and a single click on that
+ * preview selects the cell, which swaps in the editor. That is the right gesture for plain
+ * content, but it also fires when the output contains interactive controls (a button, an input,
+ * a link, a web component), so clicking a widget would yank the cell into edit mode instead of
+ * letting the widget respond.
+ *
+ * This installs one listener that, when a click lands on an interactive element inside a
+ * clickable preview, stops the event before it reaches the notebook's delegated click handler.
+ * The control still receives the click in the target phase, so it works normally; the cell just
+ * stays rendered. Clicking any non-interactive part of the preview still enters edit mode.
+ *
+ * The walk uses event.composedPath() rather than event.target so it sees through Shadow DOM:
+ * clicks inside a web component's shadow root are retargeted to the host element by the time they
+ * reach document, so target.closest(...) would miss the real control. The composed path still
+ * lists the inner nodes (for composed events like click), and a custom element or shadow host is
+ * itself treated as interactive so closed shadow roots are covered too.
+ *
+ * The listener sits on document.body, strictly below the document where the framework registers
+ * its delegated click handler, so it always runs first regardless of load order. Authors can mark
+ * a custom interactive region with data-verso-interactive to opt it into the same pass-through.
+ */
+(function installCellPreviewClickGuard() {
+    var PREVIEW_CLASS = 'verso-cell-outputs--clickable';
+    var INTERACTIVE_SELECTOR =
+        'a, button, input, select, textarea, label, summary, option, ' +
+        '[contenteditable=""], [contenteditable="true"], ' +
+        '[role="button"], [role="link"], [role="checkbox"], [role="tab"], ' +
+        '[data-verso-interactive]';
+
+    function isInteractive(el) {
+        // A standard control, an ARIA control, or an author opt-in.
+        if (el.matches && el.matches(INTERACTIVE_SELECTOR)) return true;
+        // A custom element (its tag name carries a hyphen) — the whole web component owns its
+        // own interactions, so a click anywhere inside it should not drop into editing.
+        if (el.localName && el.localName.indexOf('-') !== -1) return true;
+        // A shadow host, even when the shadow root is closed and its internals are hidden.
+        if (el.shadowRoot) return true;
+        return false;
+    }
+
+    function onClick(e) {
+        var path = (e.composedPath && e.composedPath()) || null;
+        if (!path || !path.length) return;
+
+        var sawInteractive = false;
+        for (var i = 0; i < path.length; i++) {
+            var node = path[i];
+            if (!node || node.nodeType !== 1) continue;        // elements only
+            if (node.classList && node.classList.contains(PREVIEW_CLASS)) {
+                // Reached the edit-trigger surface. If anything below it was interactive, let the
+                // control keep the click and leave the cell rendered.
+                if (sawInteractive) e.stopPropagation();
+                return;
+            }
+            if (isInteractive(node)) sawInteractive = true;
+        }
+    }
+
+    function install() {
+        if (!document.body || document.body.dataset.versoCellPreviewGuard === '1') return;
+        document.body.dataset.versoCellPreviewGuard = '1';
+        document.body.addEventListener('click', onClick);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', install);
+    } else {
+        install();
+    }
+})();

--- a/src/Verso.Blazor.Shared/wwwroot/js/monaco-interop.js
+++ b/src/Verso.Blazor.Shared/wwwroot/js/monaco-interop.js
@@ -437,10 +437,27 @@ window.versoMonaco = (function () {
         },
 
         scrollToSelected: function () {
-            const el = document.querySelector('.verso-cell--selected');
-            if (el) {
-                el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-            }
+            // Poll across animation frames until the selected cell is actually
+            // scrollable, then scroll to it. In the custom portaling layouts every cell
+            // is first rendered inside a hidden pool (display:none, so offsetHeight is 0)
+            // and only moved into a visible slot once the layout HTML regenerates. For a
+            // newly added cell that regeneration is a full round trip on the server host
+            // (over the circuit), so a fixed delay or a bare offsetHeight check can fire
+            // while the cell is still pooled, where scrollIntoView does nothing. We wait
+            // for the cell to leave the pool and become measurable. Non-portaling layouts
+            // have no pool, so the closest() check is null and the cell is ready as soon
+            // as it has height. The cap keeps this bounded if the cell never slots in.
+            let tries = 0;
+            (function retry() {
+                const el = document.querySelector('.verso-cell--selected');
+                const ready = el && !el.closest('.verso-cell-pool') && el.offsetHeight > 0;
+                if (ready) {
+                    el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+                    return;
+                }
+                if (tries++ > 180) return; // ~3s at 60fps; give up rather than scroll a hidden node
+                requestAnimationFrame(retry);
+            })();
         },
 
         updateEditorSettings: function (settings) {

--- a/src/Verso.Blazor.Wasm/Pages/NotebookPage.razor
+++ b/src/Verso.Blazor.Wasm/Pages/NotebookPage.razor
@@ -558,6 +558,7 @@
     {
         var cell = await Service.AddCellAsync(type);
         _selectedCellId = cell.Id;
+        await ScrollToSelectedCell();
     }
 
     private async Task HandleRunCell(Guid cellId)

--- a/src/Verso.Blazor.Wasm/Pages/NotebookPage.razor
+++ b/src/Verso.Blazor.Wasm/Pages/NotebookPage.razor
@@ -563,6 +563,8 @@
 
     private async Task HandleRunCell(Guid cellId)
     {
+        LeaveEditModeForRenderOnlyCell(cellId);
+
         // _executingCellId and cell metadata are managed by HandleCellExecutingEvent /
         // HandleCellExecutedEvent (driven by the host's cell/executionState notifications
         // and Scaffold.OnCellExecuting/OnCellExecuted on the engine side).
@@ -663,6 +665,22 @@
             && Service.ShouldCollapseInput(cell.Type)
             && !string.IsNullOrWhiteSpace(cell.Source))
             await HandleRunCell(cellId);
+    }
+
+    // A render-only cell (markdown, html, ...) shows its editor only while selected and its
+    // rendered output only while not. Running one means "render it", so if it is the cell being
+    // edited, drop it out of edit and selection here; otherwise the new output would stay hidden
+    // behind the editor and the run would look like it did nothing. The preview appears once
+    // execution produces output.
+    private void LeaveEditModeForRenderOnlyCell(Guid cellId)
+    {
+        var cell = Service.Cells.FirstOrDefault(c => c.Id == cellId);
+        if (cell is null || !Service.ShouldCollapseInput(cell.Type))
+            return;
+        if (_editingCellId == cellId)
+            _editingCellId = null;
+        if (_selectedCellId == cellId)
+            _selectedCellId = null;
     }
 
     private async Task HandleKeyDown(KeyboardEventArgs e)

--- a/src/Verso.Blazor.Wasm/Pages/NotebookPage.razor
+++ b/src/Verso.Blazor.Wasm/Pages/NotebookPage.razor
@@ -12,6 +12,7 @@
      tabindex="0" @onkeydown="HandleKeyDown">
     <Toolbar Service="Service"
              SelectedCellId="_selectedCellId"
+             IsExecuting="_activeExecutions > 0"
              OnSaveNotebook="HandleSave"
              OnAddCell="HandleAddCell"
              OnActionExecuted="HandleActionExecuted"
@@ -561,6 +562,12 @@
         await ScrollToSelectedCell();
     }
 
+    // Count of page-initiated runs currently in flight. Drives the toolbar's IsExecuting
+    // parameter so the Stop button and status pill hold their running presentation across
+    // the per-cell gaps of a batch instead of toggling at every cell boundary. A counter
+    // rather than a bool because cell runs can overlap.
+    private int _activeExecutions;
+
     private async Task HandleRunCell(Guid cellId)
     {
         LeaveEditModeForRenderOnlyCell(cellId);
@@ -568,6 +575,7 @@
         // _executingCellId and cell metadata are managed by HandleCellExecutingEvent /
         // HandleCellExecutedEvent (driven by the host's cell/executionState notifications
         // and Scaffold.OnCellExecuting/OnCellExecuted on the engine side).
+        _activeExecutions++;
         try
         {
             await Service.ExecuteCellAsync(cellId);
@@ -579,6 +587,10 @@
         catch (Exception ex)
         {
             _error = $"Execution error: {ex.Message}";
+        }
+        finally
+        {
+            _activeExecutions--;
         }
     }
 
@@ -776,6 +788,7 @@
         // driven by the host's cell/executionState notifications that the RemoteNotebookService
         // decodes. A trailing RefreshCellListAsync inside ExecuteAllAsync re-hydrates cell
         // metadata (ExecutionCount / LastElapsed / LastStatus) from the host.
+        _activeExecutions++;
         try
         {
             await Service.ExecuteAllAsync();
@@ -787,6 +800,10 @@
         catch (Exception ex)
         {
             _error = $"Execution error: {ex.Message}";
+        }
+        finally
+        {
+            _activeExecutions--;
         }
     }
 

--- a/src/Verso.Blazor.Wasm/Services/RemoteNotebookService.cs
+++ b/src/Verso.Blazor.Wasm/Services/RemoteNotebookService.cs
@@ -1566,7 +1566,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
         _toolbarActions = actionsResult.Actions?.Select(a => new ToolbarActionInfo(
             a.ActionId, a.DisplayName, a.Icon,
             Enum.TryParse<ToolbarPlacement>(a.Placement, true, out var p) ? p : ToolbarPlacement.MainToolbar,
-            a.Order)).ToList() ?? new();
+            a.Order, a.IconOnly, a.IsPrimary)).ToList() ?? new();
 
         // Cell types
         var cellTypesResult = await _bridge.RequestAsync<CellTypesResponse>("notebook/getCellTypes", null);
@@ -1976,6 +1976,8 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
         public string? Icon { get; set; }
         public string Placement { get; set; } = "";
         public int Order { get; set; }
+        public bool IconOnly { get; set; }
+        public bool IsPrimary { get; set; }
     }
 
     private sealed class EnabledStatesResponse

--- a/src/Verso.Blazor.Wasm/Services/RemoteNotebookService.cs
+++ b/src/Verso.Blazor.Wasm/Services/RemoteNotebookService.cs
@@ -100,6 +100,14 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
     /// The notebook still opens; the UI should show a non-fatal notice.</summary>
     public event Action<IReadOnlyList<UnavailableExtensionInfo>>? OnRequiredExtensionsUnavailable;
 
+    /// <summary>Raised when <see cref="IsDirty"/> changes.</summary>
+    public event Action? OnDirtyStateChanged;
+
+    /// <summary>Raised when the host process dies (Disconnected, from the extension's
+    /// <c>host/exited</c> message) or an in-process kernel restart fails (Faulted, from the
+    /// host's <c>kernel/faulted</c> notification).</summary>
+    public event Action<KernelHealthChangedEventArgs>? OnKernelHealthChanged;
+
     // ── Extension consent state ────────────────────────────────────────
     private string? _pendingConsentRequestId;
     private IReadOnlyList<ExtensionConsentInfo>? _pendingConsentExtensions;
@@ -132,6 +140,19 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
     public bool IsEmbedded => true;
     public string? FilePath => _filePath;
 
+    // Local view of unsaved changes: set by this service's own mutations (the same set the
+    // bridge uses to mark the VS Code document dirty) and cleared when the extension reports
+    // the document was saved, so a Cmd/Ctrl+S outside the webview clears it too.
+    private bool _isDirty;
+    public bool IsDirty => _isDirty;
+
+    private void SetDirty(bool value)
+    {
+        if (_isDirty == value) return;
+        _isDirty = value;
+        OnDirtyStateChanged?.Invoke();
+    }
+
     // ── Notebook metadata ───────────────────────────────────────────────
 
     public string? Title
@@ -148,7 +169,10 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
             if (string.Equals(_defaultKernelId, value, StringComparison.OrdinalIgnoreCase)) return;
             _defaultKernelId = value;
             if (_isLoaded && value is not null)
+            {
                 _ = _bridge.RequestVoidAsync("notebook/setDefaultKernel", new { kernelId = value });
+                SetDirty(true);
+            }
         }
     }
 
@@ -228,6 +252,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
         _defaultKernelId = result.DefaultKernel;
         _cells = result.Cells?.Select(MapCellFromDto).ToList() ?? new();
         _isLoaded = true;
+        SetDirty(false);
 
         // Fetch supplementary data
         await RefreshExtensionDataAsync();
@@ -251,6 +276,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
         if (result.Content is not null)
         {
             await _bridge.RequestVoidAsync("extension/writeFile", new { content = result.Content, filePath });
+            SetDirty(false);
         }
     }
 
@@ -264,6 +290,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
 
         var cell = MapCellFromDto(dto);
         _cells.Add(cell);
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
         return cell;
     }
@@ -276,6 +303,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
 
         var cell = MapCellFromDto(dto);
         _cells.Insert(Math.Clamp(index, 0, _cells.Count), cell);
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
         return cell;
     }
@@ -284,7 +312,11 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
     {
         await _bridge.RequestVoidAsync("cell/remove", new { cellId = cellId.ToString() });
         var removed = _cells.RemoveAll(c => c.Id == cellId) > 0;
-        if (removed) OnNotebookChanged?.Invoke();
+        if (removed)
+        {
+            SetDirty(true);
+            OnNotebookChanged?.Invoke();
+        }
         return removed;
     }
 
@@ -299,6 +331,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
             _cells.Insert(Math.Clamp(toIndex, 0, _cells.Count), cell);
         }
 
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
     }
 
@@ -308,6 +341,8 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
         var cell = _cells.FirstOrDefault(c => c.Id == cellId);
         if (cell is not null)
             cell.Source = source;
+
+        SetDirty(true);
 
         // Debounce the remote call to avoid flooding the bridge on every keystroke
         if (_debounceCts.TryGetValue(cellId, out var existingCts))
@@ -363,6 +398,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
         await _bridge.RequestVoidAsync("cell/changeType", new { cellId = cellId.ToString(), type = newType });
         // Re-fetch cell list after type change since the host may rebuild the cell
         await RefreshCellListAsync();
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
     }
 
@@ -370,6 +406,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
     {
         await _bridge.RequestVoidAsync("cell/changeLanguage", new { cellId = cellId.ToString(), language = newLanguage });
         await RefreshCellListAsync();
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
     }
 
@@ -380,6 +417,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
         foreach (var cell in _cells)
             cell.Outputs.Clear();
 
+        SetDirty(true);
         OnCellExecuted?.Invoke();
     }
 
@@ -411,6 +449,9 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
             cell.LastStatus = result.Status;
         }
 
+        // Execution mutates outputs and execution counts, which are part of the saved file.
+        SetDirty(true);
+
         // Refresh variables directly after execution instead of relying
         // solely on the fire-and-forget notification handler.
         await RefreshVariablesSafeAsync();
@@ -434,6 +475,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
         var response = await _bridge.RequestAsync<ExecutionRunAllResponse>(
             "execution/runAll", null);
 
+        SetDirty(true);
         await RefreshCellListAsync();
         await RefreshVariablesSafeAsync();
 
@@ -514,6 +556,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
             });
 
         // Refresh state since actions can mutate cells, outputs, etc.
+        SetDirty(true);
         await RefreshCellListAsync();
         await RefreshVariablesSafeAsync();
         OnCellExecuted?.Invoke();
@@ -1096,6 +1139,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
 
         // Refresh local cell cache so metadata-dependent rendering (e.g. visibility) reflects the change
         await RefreshCellListAsync();
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
     }
 
@@ -1189,7 +1233,33 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
             case "theme/vscodeKindChanged":
                 HandleVsCodeThemeKindChanged(paramsJson);
                 break;
+            case "document/saved":
+                // The extension saved the document (webview Save button or Cmd/Ctrl+S in
+                // VS Code), so the local unsaved-changes flag is stale either way.
+                SetDirty(false);
+                break;
+            case "host/exited":
+                HandleHostExited(paramsJson);
+                break;
+            case "kernel/faulted":
+                HandleKernelFaulted(paramsJson);
+                break;
         }
+    }
+
+    private void HandleHostExited(string? paramsJson)
+    {
+        var detail = TryReadStringProperty(paramsJson, "detail");
+        OnKernelHealthChanged?.Invoke(new KernelHealthChangedEventArgs(
+            KernelHealth.Disconnected,
+            detail ?? "The kernel host process exited."));
+    }
+
+    private void HandleKernelFaulted(string? paramsJson)
+    {
+        var message = TryReadStringProperty(paramsJson, "message");
+        OnKernelHealthChanged?.Invoke(new KernelHealthChangedEventArgs(
+            KernelHealth.Faulted, message));
     }
 
     /// <summary>
@@ -1566,7 +1636,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
         _toolbarActions = actionsResult.Actions?.Select(a => new ToolbarActionInfo(
             a.ActionId, a.DisplayName, a.Icon,
             Enum.TryParse<ToolbarPlacement>(a.Placement, true, out var p) ? p : ToolbarPlacement.MainToolbar,
-            a.Order, a.IconOnly, a.IsPrimary)).ToList() ?? new();
+            a.Order, a.IconOnly, a.IsPrimary, a.ConfirmationPrompt)).ToList() ?? new();
 
         // Cell types
         var cellTypesResult = await _bridge.RequestAsync<CellTypesResponse>("notebook/getCellTypes", null);
@@ -1978,6 +2048,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
         public int Order { get; set; }
         public bool IconOnly { get; set; }
         public bool IsPrimary { get; set; }
+        public string? ConfirmationPrompt { get; set; }
     }
 
     private sealed class EnabledStatesResponse

--- a/src/Verso.Blazor/Components/Pages/NotebookPage.razor
+++ b/src/Verso.Blazor/Components/Pages/NotebookPage.razor
@@ -905,7 +905,26 @@
     }
 
     private Task HandleRunCell(Guid cellId)
-        => StartExecutionAsync(async () => await Service.ExecuteCellAsync(cellId));
+    {
+        LeaveEditModeForRenderOnlyCell(cellId);
+        return StartExecutionAsync(async () => await Service.ExecuteCellAsync(cellId));
+    }
+
+    // A render-only cell (markdown, html, ...) shows its editor only while selected and its
+    // rendered output only while not. Running one means "render it", so if it is the cell being
+    // edited, drop it out of edit and selection here; otherwise the new output would stay hidden
+    // behind the editor and the run would look like it did nothing. The preview appears once
+    // execution produces output.
+    private void LeaveEditModeForRenderOnlyCell(Guid cellId)
+    {
+        var cell = Service.Cells.FirstOrDefault(c => c.Id == cellId);
+        if (cell is null || !Service.ShouldCollapseInput(cell.Type))
+            return;
+        if (_editingCellId == cellId)
+            _editingCellId = null;
+        if (_selectedCellId == cellId)
+            _selectedCellId = null;
+    }
 
     private async Task HandleCancelCell(Guid cellId)
     {

--- a/src/Verso.Blazor/Components/Pages/NotebookPage.razor
+++ b/src/Verso.Blazor/Components/Pages/NotebookPage.razor
@@ -13,6 +13,7 @@
      tabindex="0" @onkeydown="HandleKeyDown">
     <Toolbar Service="Service"
              SelectedCellId="_selectedCellId"
+             IsExecuting="_executionInProgress"
              OnNewNotebook="HandleNew"
              OnOpenNotebook="HandleOpen"
              OnBrowseNotebook="HandleBrowse"
@@ -776,6 +777,8 @@
             {
                 case "saved":
                     _hasNativeHandle = true;
+                    if (Service is ServerNotebookService svc)
+                        svc.MarkSaved();
                     await ShowStatusAsync($"Saved to {result.FileName}");
                     return;
                 case "cancelled":
@@ -830,9 +833,17 @@
                 "versoSaveDialog.save", content);
 
             if (result.Status == "saved")
+            {
+                // The browser file handle wrote the bytes, so SaveAsync never ran;
+                // clear the unsaved-changes flag here instead.
+                if (Service is ServerNotebookService serverService)
+                    serverService.MarkSaved();
                 await ShowStatusAsync($"Saved to {result.FileName}");
+            }
             else
+            {
                 _error = $"Failed to save: {result.Message ?? "unknown error"}";
+            }
         }
         catch (Exception ex)
         {

--- a/src/Verso.Blazor/Components/Pages/NotebookPage.razor
+++ b/src/Verso.Blazor/Components/Pages/NotebookPage.razor
@@ -901,6 +901,7 @@
     {
         var cell = await Service.AddCellAsync(type);
         _selectedCellId = cell.Id;
+        await ScrollToSelectedCell();
     }
 
     private Task HandleRunCell(Guid cellId)

--- a/src/Verso.Blazor/Services/ServerNotebookService.cs
+++ b/src/Verso.Blazor/Services/ServerNotebookService.cs
@@ -115,18 +115,44 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
     public bool IsEmbedded => false;
     public string? FilePath => _filePath;
 
+    public bool IsDirty { get; private set; }
+
+    /// <summary>
+    /// Marks the notebook as saved (clears the dirty flag). Exposed for save paths that
+    /// write the serialized content themselves instead of going through
+    /// <see cref="SaveAsync"/>, such as the browser native-file-handle save.
+    /// </summary>
+    public void MarkSaved() => SetDirty(false);
+
+    private void SetDirty(bool value)
+    {
+        if (IsDirty == value) return;
+        IsDirty = value;
+        OnDirtyStateChanged?.Invoke();
+    }
+
     // ── Notebook metadata ──────────────────────────────────────────────
 
     public string? Title
     {
         get => _scaffold?.Title;
-        set { if (_scaffold is not null) _scaffold.Title = value; }
+        set
+        {
+            if (_scaffold is null || _scaffold.Title == value) return;
+            _scaffold.Title = value;
+            SetDirty(true);
+        }
     }
 
     public string? DefaultKernelId
     {
         get => _scaffold?.DefaultKernelId;
-        set { if (_scaffold is not null) _scaffold.DefaultKernelId = value; }
+        set
+        {
+            if (_scaffold is null || _scaffold.DefaultKernelId == value) return;
+            _scaffold.DefaultKernelId = value;
+            SetDirty(true);
+        }
     }
 
     public IReadOnlyList<KernelLanguageInfo> RegisteredLanguages
@@ -312,6 +338,8 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
     public event Action<string?>? OnKernelRestarting;
     public event Action<string?>? OnKernelRestarted;
     public event Action<IReadOnlyList<UnavailableExtensionInfo>>? OnRequiredExtensionsUnavailable;
+    public event Action? OnDirtyStateChanged;
+    public event Action<KernelHealthChangedEventArgs>? OnKernelHealthChanged;
 
     // Required extensions that failed to load on the current notebook, keyed by package id, so the
     // extension panel can flag the matching installed row. Reset per open in WireConsentHandler.
@@ -343,6 +371,8 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
         SubscribeToEngineEvents();
         WarmUpKernelsInBackground();
 
+        // A new notebook exists nowhere on disk yet, so it starts with unsaved changes.
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
     }
 
@@ -376,6 +406,7 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
         SubscribeToEngineEvents();
         WarmUpKernelsInBackground();
 
+        SetDirty(false);
         OnNotebookChanged?.Invoke();
 
         await ScanAndRequestConsentAsync(notebook);
@@ -414,6 +445,9 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
         SubscribeToEngineEvents();
         WarmUpKernelsInBackground();
 
+        // Opened from content without a resolvable path: there is no file to write back
+        // to yet, so treat it like a new notebook with unsaved changes.
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
 
         await ScanAndRequestConsentAsync(notebook);
@@ -426,6 +460,7 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
         var json = await PrepareSerializedContentAsync();
         await File.WriteAllTextAsync(filePath, json);
         _filePath = filePath;
+        SetDirty(false);
     }
 
     public async Task<string?> GetSerializedContentAsync()
@@ -467,6 +502,7 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
 
         var effectiveLanguage = ResolveLanguage(type, language);
         var cell = _scaffold.AddCell(type, effectiveLanguage);
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
         return Task.FromResult(cell);
     }
@@ -478,6 +514,7 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
 
         var effectiveLanguage = ResolveLanguage(type, language);
         var cell = _scaffold.InsertCell(index, type, effectiveLanguage);
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
         return Task.FromResult(cell);
     }
@@ -486,7 +523,11 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
     {
         if (_scaffold is null) return Task.FromResult(false);
         var result = _scaffold.RemoveCell(cellId);
-        if (result) OnNotebookChanged?.Invoke();
+        if (result)
+        {
+            SetDirty(true);
+            OnNotebookChanged?.Invoke();
+        }
         return Task.FromResult(result);
     }
 
@@ -494,13 +535,16 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
     {
         if (_scaffold is null) return Task.CompletedTask;
         _scaffold.MoveCell(fromIndex, toIndex);
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
         return Task.CompletedTask;
     }
 
     public Task UpdateCellSourceAsync(Guid cellId, string source)
     {
-        _scaffold?.UpdateCellSource(cellId, source);
+        if (_scaffold is null) return Task.CompletedTask;
+        _scaffold.UpdateCellSource(cellId, source);
+        SetDirty(true);
         return Task.CompletedTask;
     }
 
@@ -519,6 +563,7 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
         cell.Language = effectiveLanguage;
         cell.Outputs.Clear();
 
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
         return Task.CompletedTask;
     }
@@ -544,13 +589,16 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
             catch { /* warm-up failure is non-fatal */ }
         });
 
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
         return Task.CompletedTask;
     }
 
     public Task ClearAllOutputsAsync()
     {
-        _scaffold?.ClearAllOutputs();
+        if (_scaffold is null) return Task.CompletedTask;
+        _scaffold.ClearAllOutputs();
+        SetDirty(true);
         OnCellExecuted?.Invoke();
         return Task.CompletedTask;
     }
@@ -603,10 +651,11 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
 
     public async Task RestartKernelAsync()
     {
+        // Restart progress and failure events flow from the Scaffold's own restart events
+        // (forwarded in SubscribeToEngineEvents), so the toolbar-action path that calls the
+        // engine directly reports status the same way this method does.
         if (_scaffold is null) return;
-        OnKernelRestarting?.Invoke(null);
         await _scaffold.RestartKernelAsync();
-        OnKernelRestarted?.Invoke(null);
     }
 
     private CancellationToken ResetExecutionToken()
@@ -625,7 +674,7 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
         return _extensionHost.GetToolbarActions()
             .Where(a => a.Placement == placement)
             .OrderBy(a => a.Order)
-            .Select(a => new ToolbarActionInfo(a.ActionId, a.DisplayName, a.Icon, a.Placement, a.Order, a.IconOnly, a.IsPrimary))
+            .Select(a => new ToolbarActionInfo(a.ActionId, a.DisplayName, a.Icon, a.Placement, a.Order, a.IconOnly, a.IsPrimary, a.ConfirmationPrompt))
             .ToList();
     }
 
@@ -828,6 +877,7 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
             _scaffold.Notebook.ActiveLayout = new LayoutReference(ext.ExtensionId, active.LayoutId);
             _scaffold.Notebook.RequiresLegacyLayoutResolution = false;
         }
+        SetDirty(true);
         OnLayoutChanged?.Invoke();
         return Task.CompletedTask;
     }
@@ -837,6 +887,7 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
         if (_scaffold?.ThemeEngine is null) return Task.CompletedTask;
         _scaffold.ThemeEngine.SetActiveTheme(themeId);
         _scaffold.Notebook.PreferredThemeId = themeId;
+        SetDirty(true);
         OnThemeChanged?.Invoke();
         return Task.CompletedTask;
     }
@@ -1122,6 +1173,7 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
 
         var context = new BlazorCellRenderContext(_scaffold, cell);
         await provider.OnPropertyChangedAsync(cell, propertyName, value, context);
+        SetDirty(true);
         OnNotebookChanged?.Invoke();
 
         // Property changes (e.g. per-layout visibility) can affect what an
@@ -1266,6 +1318,9 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
             _scaffold.OnCellExecuting += HandleScaffoldCellExecuting;
             _scaffold.OnCellExecuted += HandleScaffoldCellExecuted;
             _scaffold.OnCellOutputUpdated += HandleScaffoldCellOutputUpdated;
+            _scaffold.OnKernelRestarting += HandleScaffoldKernelRestarting;
+            _scaffold.OnKernelRestarted += HandleScaffoldKernelRestarted;
+            _scaffold.OnKernelRestartFailed += HandleScaffoldKernelRestartFailed;
             _scaffold.InputRequester = RequestInputFromUIAsync;
         }
 
@@ -1286,6 +1341,9 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
             _scaffold.OnCellExecuting -= HandleScaffoldCellExecuting;
             _scaffold.OnCellExecuted -= HandleScaffoldCellExecuted;
             _scaffold.OnCellOutputUpdated -= HandleScaffoldCellOutputUpdated;
+            _scaffold.OnKernelRestarting -= HandleScaffoldKernelRestarting;
+            _scaffold.OnKernelRestarted -= HandleScaffoldKernelRestarted;
+            _scaffold.OnKernelRestartFailed -= HandleScaffoldKernelRestartFailed;
             _scaffold.InputRequester = null;
         }
 
@@ -1310,9 +1368,24 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
 
     private void HandleScaffoldCellExecuted(Guid cellId)
     {
+        // Execution mutates outputs and execution counts, which are part of the saved file.
+        SetDirty(true);
         OnCellExecutionCompleted?.Invoke(cellId);
         OnCellExecuted?.Invoke();
     }
+
+    private void HandleScaffoldKernelRestarting(string? kernelId)
+        => OnKernelRestarting?.Invoke(kernelId);
+
+    private void HandleScaffoldKernelRestarted(string? kernelId)
+    {
+        OnKernelRestarted?.Invoke(kernelId);
+        OnKernelHealthChanged?.Invoke(new KernelHealthChangedEventArgs(KernelHealth.Ok));
+    }
+
+    private void HandleScaffoldKernelRestartFailed(string? kernelId, Exception ex)
+        => OnKernelHealthChanged?.Invoke(
+            new KernelHealthChangedEventArgs(KernelHealth.Faulted, ex.Message));
 
     private void HandleScaffoldCellOutputUpdated(Guid cellId)
     {

--- a/src/Verso.Blazor/Services/ServerNotebookService.cs
+++ b/src/Verso.Blazor/Services/ServerNotebookService.cs
@@ -625,7 +625,7 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
         return _extensionHost.GetToolbarActions()
             .Where(a => a.Placement == placement)
             .OrderBy(a => a.Order)
-            .Select(a => new ToolbarActionInfo(a.ActionId, a.DisplayName, a.Icon, a.Placement, a.Order))
+            .Select(a => new ToolbarActionInfo(a.ActionId, a.DisplayName, a.Icon, a.Placement, a.Order, a.IconOnly, a.IsPrimary))
             .ToList();
     }
 

--- a/src/Verso.Host/Dto/NotebookDto.cs
+++ b/src/Verso.Host/Dto/NotebookDto.cs
@@ -78,6 +78,8 @@ public sealed class ToolbarActionDto
     public string? Icon { get; set; }
     public string Placement { get; set; } = "";
     public int Order { get; set; }
+    public bool IconOnly { get; set; }
+    public bool IsPrimary { get; set; }
 }
 
 // --- Cell ---

--- a/src/Verso.Host/Dto/NotebookDto.cs
+++ b/src/Verso.Host/Dto/NotebookDto.cs
@@ -80,6 +80,7 @@ public sealed class ToolbarActionDto
     public int Order { get; set; }
     public bool IconOnly { get; set; }
     public bool IsPrimary { get; set; }
+    public string? ConfirmationPrompt { get; set; }
 }
 
 // --- Cell ---

--- a/src/Verso.Host/Dto/NotebookDto.cs
+++ b/src/Verso.Host/Dto/NotebookDto.cs
@@ -330,11 +330,6 @@ public sealed class LayoutUpdateCellParams
     public int Height { get; set; }
 }
 
-public sealed class LayoutSetEditModeParams
-{
-    public bool EditMode { get; set; }
-}
-
 public sealed class LayoutGetRendererPackageParams
 {
     public string NotebookId { get; set; } = "";

--- a/src/Verso.Host/Handlers/LayoutHandler.cs
+++ b/src/Verso.Host/Handlers/LayoutHandler.cs
@@ -155,21 +155,6 @@ public static class LayoutHandler
             .ConfigureAwait(false);
     }
 
-    public static async Task<object?> HandleSetEditMode(NotebookSession ns, JsonElement? @params)
-    {
-        var p = @params?.Deserialize<LayoutSetEditModeParams>(JsonRpcMessage.SerializerOptions)
-            ?? throw new JsonException("Missing params for layout/setEditMode");
-
-        Console.Error.WriteLine(
-            "[deprecation] layout/setEditMode is forwarded to layout/interact and will be removed in v2.0. " +
-            "Migrate clients to layout/interact with interactionType 'setEditMode'.");
-
-        var payload = p.EditMode ? "true" : "false";
-
-        return await HandleInteractAsync(ns, BuildDashboardInteractParams("setEditMode", payload))
-            .ConfigureAwait(false);
-    }
-
     private static JsonElement BuildDashboardInteractParams(string interactionType, string payload)
     {
         var interactParams = new LayoutInteractParams

--- a/src/Verso.Host/Handlers/NotebookHandler.cs
+++ b/src/Verso.Host/Handlers/NotebookHandler.cs
@@ -372,7 +372,9 @@ public static class NotebookHandler
                 DisplayName = a.DisplayName,
                 Icon = a.Icon,
                 Placement = a.Placement.ToString(),
-                Order = a.Order
+                Order = a.Order,
+                IconOnly = a.IconOnly,
+                IsPrimary = a.IsPrimary
             }).ToList()
         };
     }

--- a/src/Verso.Host/Handlers/NotebookHandler.cs
+++ b/src/Verso.Host/Handlers/NotebookHandler.cs
@@ -374,7 +374,8 @@ public static class NotebookHandler
                 Placement = a.Placement.ToString(),
                 Order = a.Order,
                 IconOnly = a.IconOnly,
-                IsPrimary = a.IsPrimary
+                IsPrimary = a.IsPrimary,
+                ConfirmationPrompt = a.ConfirmationPrompt
             }).ToList()
         };
     }

--- a/src/Verso.Host/HostSession.cs
+++ b/src/Verso.Host/HostSession.cs
@@ -329,7 +329,6 @@ public sealed class HostSession : IAsyncDisposable
             MethodNames.LayoutRender => await LayoutHandler.HandleRenderAsync(ns, @params),
             MethodNames.LayoutGetCellContainer => await LayoutHandler.HandleGetCellContainerAsync(ns, @params),
             MethodNames.LayoutUpdateCell => await LayoutHandler.HandleUpdateCell(ns, @params),
-            MethodNames.LayoutSetEditMode => await LayoutHandler.HandleSetEditMode(ns, @params),
             MethodNames.LayoutInteract => await LayoutHandler.HandleInteractAsync(ns, @params),
             MethodNames.LayoutGetRendererPackage => await LayoutHandler.HandleGetRendererPackageAsync(ns, @params),
             MethodNames.LayoutGetStaticAssets => await LayoutHandler.HandleGetStaticAssetsAsync(ns, @params),

--- a/src/Verso.Host/HostSession.cs
+++ b/src/Verso.Host/HostSession.cs
@@ -44,7 +44,17 @@ public sealed class NotebookSession : IAsyncDisposable
         ExtensionHost.OnExtensionLoaded += HandleExtensionLoaded;
         ExtensionHost.OnExtensionStatusChanged += HandleExtensionStatusChanged;
         Scaffold.OnCellOutputUpdated += HandleCellOutputUpdated;
+        Scaffold.OnKernelRestartFailed += HandleKernelRestartFailed;
         Scaffold.InputRequester = RequestInputAsync;
+    }
+
+    private void HandleKernelRestartFailed(string? kernelId, Exception ex)
+    {
+        SendNotification(Protocol.MethodNames.KernelFaulted, new
+        {
+            kernelId,
+            message = ex.Message
+        });
     }
 
     private void HandleExtensionLoaded(Abstractions.IExtension extension)
@@ -77,7 +87,13 @@ public sealed class NotebookSession : IAsyncDisposable
 
     public void CancelExecution()
     {
-        _executionCts?.Cancel();
+        // The CTS is disposed and replaced at the start of the next run; a cancel that
+        // races that swap should be a no-op rather than an RPC error.
+        try
+        {
+            _executionCts?.Cancel();
+        }
+        catch (ObjectDisposedException) { }
     }
 
     public void SendNotification(string method, object? @params = null)
@@ -186,6 +202,7 @@ public sealed class NotebookSession : IAsyncDisposable
         ExtensionHost.OnExtensionLoaded -= HandleExtensionLoaded;
         ExtensionHost.OnExtensionStatusChanged -= HandleExtensionStatusChanged;
         Scaffold.OnCellOutputUpdated -= HandleCellOutputUpdated;
+        Scaffold.OnKernelRestartFailed -= HandleKernelRestartFailed;
         Scaffold.InputRequester = null;
 
         // Cancel any pending consent requests

--- a/src/Verso.Host/Protocol/MethodNames.cs
+++ b/src/Verso.Host/Protocol/MethodNames.cs
@@ -62,7 +62,6 @@ public static class MethodNames
     public const string LayoutRender = "layout/render";
     public const string LayoutGetCellContainer = "layout/getCellContainer";
     public const string LayoutUpdateCell = "layout/updateCell";
-    public const string LayoutSetEditMode = "layout/setEditMode";
     public const string LayoutInteract = "layout/interact";
     public const string LayoutGetRendererPackage = "layout/getRendererPackage";
     public const string LayoutGetStaticAssets = "layout/getStaticAssets";

--- a/src/Verso.Host/Protocol/MethodNames.cs
+++ b/src/Verso.Host/Protocol/MethodNames.cs
@@ -41,6 +41,7 @@ public static class MethodNames
     // Kernel
     public const string KernelRestart = "kernel/restart";
     public const string KernelRestartRequested = "kernel/restartRequested";
+    public const string KernelFaulted = "kernel/faulted";
     public const string KernelGetCompletions = "kernel/getCompletions";
     public const string KernelGetDiagnostics = "kernel/getDiagnostics";
     public const string KernelGetHoverInfo = "kernel/getHoverInfo";

--- a/src/Verso/Execution/ExecutionPipeline.cs
+++ b/src/Verso/Execution/ExecutionPipeline.cs
@@ -319,6 +319,11 @@ internal sealed class ExecutionPipeline
 
         var result = await renderer.RenderInputAsync(cell.Source, renderContext).ConfigureAwait(false);
         cell.Outputs.Add(new CellOutput(result.MimeType, result.Content));
+        // Surface the rendered output the same way kernel execution does, so out-of-process
+        // hosts receive it incrementally as the cell finishes rather than only at the end of a
+        // Run All. Without this, render-only cells (e.g. Markdown) emit no output notification
+        // and their content appears only after the whole batch completes.
+        _notifyOutputUpdated?.Invoke(cell.Id);
 
         stopwatch.Stop();
 

--- a/src/Verso/Extensions/Layouts/DashboardLayout.cs
+++ b/src/Verso/Extensions/Layouts/DashboardLayout.cs
@@ -7,7 +7,7 @@ namespace Verso.Extensions.Layouts;
 
 /// <summary>
 /// Grid-based dashboard layout that arranges cells in a 12-column CSS Grid.
-/// Shows output-only cells with optional edit toggles and resize handles.
+/// Shows output-only cells that can be moved, resized, and run, but never code-edited.
 /// </summary>
 [VersoExtension]
 public sealed class DashboardLayout : ILayoutEngine, ILayoutInteractionHandler
@@ -17,8 +17,6 @@ public sealed class DashboardLayout : ILayoutEngine, ILayoutInteractionHandler
     private const int DefaultCellHeight = 4;
 
     private readonly Dictionary<Guid, GridPosition> _gridPositions = new();
-    private readonly HashSet<Guid> _cellsInEdit = new();
-    private bool _isEditMode;
 
     // --- IExtension ---
 
@@ -43,28 +41,13 @@ public sealed class DashboardLayout : ILayoutEngine, ILayoutInteractionHandler
             CellVisibilityState.OutputOnly,
         };
 
-    public bool SupportsPropertiesPanel => _isEditMode;
+    public bool SupportsPropertiesPanel => false;
 
-    public LayoutCapabilities Capabilities
-    {
-        get
-        {
-            var caps = LayoutCapabilities.CellResize | LayoutCapabilities.CellExecute | LayoutCapabilities.CellEdit;
-            if (_isEditMode)
-                caps |= LayoutCapabilities.CellInsert | LayoutCapabilities.CellDelete | LayoutCapabilities.CellReorder;
-            return caps;
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets whether the dashboard is in edit mode.
-    /// Edit mode enables cell insert, delete, and reorder capabilities.
-    /// </summary>
-    public bool IsEditMode
-    {
-        get => _isEditMode;
-        set => _isEditMode = value;
-    }
+    // The dashboard is a view-and-arrange surface: tiles can be moved, resized, and run, but
+    // their code is never edited here. So it advertises resize and execute, and deliberately not
+    // CellEdit, CellInsert, CellDelete, or CellReorder.
+    public LayoutCapabilities Capabilities =>
+        LayoutCapabilities.CellResize | LayoutCapabilities.CellExecute;
 
     private static readonly ICellRenderer _fallbackRenderer = new ContentFallbackRenderer();
 
@@ -76,25 +59,8 @@ public sealed class DashboardLayout : ILayoutEngine, ILayoutInteractionHandler
         var renderers = context.ExtensionHost.GetRenderers();
         var sb = new StringBuilder();
 
-        var editMode = _isEditMode ? "true" : "false";
-
-        // Outer wrapper: toolbar sits above the grid so it isn't subject to grid
-        // auto-placement (which would otherwise drop it below the last cell).
-        sb.Append("<div class=\"verso-dashboard-root\" data-edit-mode=\"")
-          .Append(editMode)
-          .Append("\">");
-
-        sb.Append("<div class=\"verso-dashboard-toolbar\">")
-          .Append("<button class=\"verso-dashboard-edit-toggle\" data-action=\"setEditMode\" data-payload=\"")
-          .Append(_isEditMode ? "false" : "true")
-          .Append("\">")
-          .Append(_isEditMode ? "Done" : "Edit")
-          .Append("</button>")
-          .Append("</div>");
-
-        sb.Append("<div class=\"verso-dashboard-grid\" data-edit-mode=\"")
-          .Append(editMode)
-          .Append("\">");
+        sb.Append("<div class=\"verso-dashboard-root\">");
+        sb.Append("<div class=\"verso-dashboard-grid\">");
 
         foreach (var cell in cells)
         {
@@ -112,9 +78,6 @@ public sealed class DashboardLayout : ILayoutEngine, ILayoutInteractionHandler
 
             if (!pos.Visible) continue;
 
-            var cellEdit = _cellsInEdit.Contains(cell.Id) ? "true" : "false";
-            var editLabel = _cellsInEdit.Contains(cell.Id) ? "Hide Code" : "Edit";
-
             // Slot wrapper: the WASM portal injects the live <Cell> Blazor component here.
             // The toolbar and resize handle are siblings of the slot content so portal nodes
             // stay intact across layout updates.
@@ -126,26 +89,19 @@ public sealed class DashboardLayout : ILayoutEngine, ILayoutInteractionHandler
               .Append(cell.Id)
               .Append("\" data-target-id=\"")
               .Append(cell.Id)
-              .Append("\" data-cell-edit=\"")
-              .Append(cellEdit)
               .Append("\" style=\"grid-column:")
               .Append(pos.Column + 1).Append("/span ").Append(pos.Width)
               .Append(";grid-row:")
               .Append(pos.Row + 1).Append("/span ").Append(pos.Height)
               .Append("\">");
 
-            // Toolbar IS the drag handle: clicking empty space drags, clicking buttons fires
-            // their data-action via layout-interact. dashboard-interop.js skips drag when the
+            // Toolbar IS the drag handle: clicking empty space drags, clicking the Run button
+            // fires its data-action via layout-interact. dashboard-interop.js skips drag when the
             // mousedown target is inside a <button>.
             sb.Append("<div class=\"verso-dashboard-cell-toolbar verso-dashboard-drag-handle\" title=\"Drag to move\">")
               .Append("<button class=\"verso-cell-btn verso-cell-btn--run\" data-action=\"run\" data-target-id=\"")
               .Append(cell.Id)
               .Append("\" title=\"Run\"><span>&#x25B6;</span></button>")
-              .Append("<button class=\"verso-dashboard-edit-toggle\" data-action=\"toggleCellEdit\" data-target-id=\"")
-              .Append(cell.Id)
-              .Append("\" title=\"Toggle Code\">")
-              .Append(editLabel)
-              .Append("</button>")
               .Append("<span class=\"verso-dashboard-drag-icon\" title=\"Drag to move\">&#x2630;</span>")
               .Append("</div>");
 
@@ -185,7 +141,6 @@ public sealed class DashboardLayout : ILayoutEngine, ILayoutInteractionHandler
     public Task OnCellRemovedAsync(Guid cellId, IVersoContext context)
     {
         _gridPositions.Remove(cellId);
-        _cellsInEdit.Remove(cellId);
         return Task.CompletedTask;
     }
 
@@ -290,30 +245,18 @@ public sealed class DashboardLayout : ILayoutEngine, ILayoutInteractionHandler
                 context.RequestRender();
                 return;
 
-            case "setEditMode":
-                _isEditMode = ParseSetEditModePayload(context.Payload);
-                context.RequestRender();
-                return;
-
             case "run":
                 if (TryParseTargetCellId(context, out var runCellId))
                     await context.Verso.Notebook.ExecuteCellAsync(runCellId);
-                return;
-
-            case "toggleCellEdit":
-                if (TryParseTargetCellId(context, out var editCellId))
-                {
-                    if (!_cellsInEdit.Add(editCellId))
-                        _cellsInEdit.Remove(editCellId);
-                    context.RequestRender();
-                }
                 return;
 
             default:
                 // Unknown interaction types are ignored rather than faulting the host. Throwing
                 // here surfaces as a transport-level error and is forward-incompatible: a newer
                 // client emitting an interaction this build doesn't know would break an otherwise
-                // healthy dashboard. Matches the built-in notebook layout's no-op handling.
+                // healthy dashboard. This also absorbs the retired "setEditMode"/"toggleCellEdit"
+                // interactions (the dashboard no longer edits code) as graceful no-ops. Matches
+                // the built-in notebook layout's no-op handling.
                 System.Diagnostics.Debug.WriteLine(
                     $"[DashboardLayout] Ignoring unsupported interactionType '{context.InteractionType}'.");
                 return;
@@ -362,22 +305,6 @@ public sealed class DashboardLayout : ILayoutEngine, ILayoutInteractionHandler
         int height = root.TryGetProperty("height", out var heightProp) ? heightProp.GetInt32() : DefaultCellHeight;
 
         UpdateCellPosition(cellId, row, col, width, height);
-    }
-
-    private static bool ParseSetEditModePayload(string payload)
-    {
-        if (string.IsNullOrWhiteSpace(payload))
-            throw new InvalidOperationException(
-                "DASHBOARD_INTERACTION_INVALID_PAYLOAD: setEditMode requires a 'true' or 'false' payload.");
-
-        // Accept the bare string ("true"/"false") and a JSON-boolean form (wrapped or
-        // unwrapped) for robustness across client serializers.
-        var trimmed = payload.Trim();
-        if (bool.TryParse(trimmed, out var value))
-            return value;
-
-        throw new InvalidOperationException(
-            $"DASHBOARD_INTERACTION_INVALID_PAYLOAD: setEditMode payload '{payload}' is not 'true' or 'false'.");
     }
 
     // --- Private helpers ---

--- a/src/Verso/Extensions/ToolbarActions/ClearOutputsAction.cs
+++ b/src/Verso/Extensions/ToolbarActions/ClearOutputsAction.cs
@@ -24,6 +24,7 @@ public sealed class ClearOutputsAction : IToolbarAction
     public string ActionId => "verso.action.clear-outputs";
     public string DisplayName => "Clear Outputs";
     public string? Icon => "<svg viewBox=\"0 0 16 16\" width=\"16\" height=\"16\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.3\" stroke-linecap=\"round\"><line x1=\"1\" y1=\"3.5\" x2=\"8.5\" y2=\"3.5\"/><line x1=\"1\" y1=\"8\" x2=\"8.5\" y2=\"8\"/><line x1=\"1\" y1=\"12.5\" x2=\"6.5\" y2=\"12.5\"/><path d=\"M11 5.5l4 4m0-4l-4 4\"/></svg>";
+    public bool IconOnly => true;
     public ToolbarPlacement Placement => ToolbarPlacement.MainToolbar;
     public int Order => 30;
 

--- a/src/Verso/Extensions/ToolbarActions/RestartKernelAction.cs
+++ b/src/Verso/Extensions/ToolbarActions/RestartKernelAction.cs
@@ -25,6 +25,8 @@ public sealed class RestartKernelAction : IToolbarAction
     public string DisplayName => "Restart Kernel";
     public string? Icon => "<svg viewBox=\"0 0 16 16\" width=\"16\" height=\"16\" fill=\"currentColor\"><path d=\"M12.75 8a4.5 4.5 0 0 1-8.61 1.83l-1.39.57A6 6 0 0 0 14.25 8 6 6 0 0 0 3.5 4.33V2.5H2v4l.75.75h3.5v-1.5H4.35A4.5 4.5 0 0 1 12.75 8z\"/></svg>";
     public bool IconOnly => true;
+    public string? ConfirmationPrompt =>
+        "Restarting the kernel discards all variables and execution state. Restart now?";
     public ToolbarPlacement Placement => ToolbarPlacement.MainToolbar;
     public int Order => 40;
 

--- a/src/Verso/Extensions/ToolbarActions/RestartKernelAction.cs
+++ b/src/Verso/Extensions/ToolbarActions/RestartKernelAction.cs
@@ -24,6 +24,7 @@ public sealed class RestartKernelAction : IToolbarAction
     public string ActionId => "verso.action.restart-kernel";
     public string DisplayName => "Restart Kernel";
     public string? Icon => "<svg viewBox=\"0 0 16 16\" width=\"16\" height=\"16\" fill=\"currentColor\"><path d=\"M12.75 8a4.5 4.5 0 0 1-8.61 1.83l-1.39.57A6 6 0 0 0 14.25 8 6 6 0 0 0 3.5 4.33V2.5H2v4l.75.75h3.5v-1.5H4.35A4.5 4.5 0 0 1 12.75 8z\"/></svg>";
+    public bool IconOnly => true;
     public ToolbarPlacement Placement => ToolbarPlacement.MainToolbar;
     public int Order => 40;
 

--- a/src/Verso/Extensions/ToolbarActions/RunAllAction.cs
+++ b/src/Verso/Extensions/ToolbarActions/RunAllAction.cs
@@ -24,6 +24,7 @@ public sealed class RunAllAction : IToolbarAction
     public string ActionId => "verso.action.run-all";
     public string DisplayName => "Run All";
     public string? Icon => "<svg viewBox=\"0 0 16 16\" width=\"16\" height=\"16\" fill=\"currentColor\"><path d=\"M2 3v10l5-5z\"/><path d=\"M8 3v10l5-5z\"/></svg>";
+    public bool IsPrimary => true;
     public ToolbarPlacement Placement => ToolbarPlacement.MainToolbar;
     public int Order => 10;
 

--- a/src/Verso/Scaffold.cs
+++ b/src/Verso/Scaffold.cs
@@ -336,6 +336,23 @@ public sealed class Scaffold : IAsyncDisposable
     }
 
     /// <summary>
+    /// Raised when an in-process kernel restart begins, before the old kernel is disposed.
+    /// Not raised when <see cref="HostRestartHandler"/> is set: the external supervisor owns
+    /// the restart lifecycle and its own progress signaling in that case.
+    /// </summary>
+    public event Action<string?>? OnKernelRestarting;
+
+    /// <summary>Raised after an in-process kernel restart completes and the fresh kernel is warm.</summary>
+    public event Action<string?>? OnKernelRestarted;
+
+    /// <summary>
+    /// Raised when an in-process kernel restart fails (dispose or warm-up threw). The old
+    /// kernel is gone at this point, so observers should treat the kernel as unavailable
+    /// until a later restart succeeds.
+    /// </summary>
+    public event Action<string?, Exception>? OnKernelRestartFailed;
+
+    /// <summary>
     /// Restarts a kernel. When <see cref="HostRestartHandler"/> is set the call is
     /// delegated externally (the supervisor will respawn the process); otherwise the
     /// kernel is disposed in-process, the variable store is cleared, and the kernel
@@ -355,11 +372,21 @@ public sealed class Scaffold : IAsyncDisposable
         var kernel = ResolveKernel(id)
             ?? throw new InvalidOperationException($"No kernel registered for language '{id}'.");
 
-        await kernel.DisposeAsync().ConfigureAwait(false);
-        _initializationTasks.TryRemove(id, out _);
-        _variables.Clear();
+        OnKernelRestarting?.Invoke(id);
+        try
+        {
+            await kernel.DisposeAsync().ConfigureAwait(false);
+            _initializationTasks.TryRemove(id, out _);
+            _variables.Clear();
 
-        await WarmUpKernelAsync(id).ConfigureAwait(false);
+            await WarmUpKernelAsync(id).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            OnKernelRestartFailed?.Invoke(id, ex);
+            throw;
+        }
+        OnKernelRestarted?.Invoke(id);
     }
 
     /// <summary>

--- a/tests/Verso.Blazor.Shared.Tests/Fakes/FakeNotebookService.cs
+++ b/tests/Verso.Blazor.Shared.Tests/Fakes/FakeNotebookService.cs
@@ -15,6 +15,7 @@ public sealed class FakeNotebookService : INotebookService
     public bool IsLoaded { get; set; } = true;
     public bool IsEmbedded { get; set; }
     public string? FilePath { get; set; } = "/fake/notebook.verso";
+    public bool IsDirty { get; set; }
 
     // ── Notebook metadata ──────────────────────────────────────────────
 
@@ -87,6 +88,8 @@ public sealed class FakeNotebookService : INotebookService
     public event Action<string?>? OnKernelRestarting;
     public event Action<string?>? OnKernelRestarted;
     public event Action<IReadOnlyList<UnavailableExtensionInfo>>? OnRequiredExtensionsUnavailable;
+    public event Action? OnDirtyStateChanged;
+    public event Action<KernelHealthChangedEventArgs>? OnKernelHealthChanged;
 
     // ── Call tracking ──────────────────────────────────────────────────
 
@@ -212,7 +215,13 @@ public sealed class FakeNotebookService : INotebookService
         ToolbarPlacement placement, IReadOnlyList<Guid> selectedCellIds)
         => Task.FromResult(ActionEnabledStates);
 
-    public Task ExecuteActionAsync(string actionId, IReadOnlyList<Guid> selectedCellIds) => Task.CompletedTask;
+    public List<string> ExecutedActionIds { get; } = new();
+
+    public Task ExecuteActionAsync(string actionId, IReadOnlyList<Guid> selectedCellIds)
+    {
+        ExecutedActionIds.Add(actionId);
+        return Task.CompletedTask;
+    }
 
     // ── Cell interaction ────────────────────────────────────────────────
 
@@ -403,4 +412,8 @@ public sealed class FakeNotebookService : INotebookService
     public void RaiseOutputUpdated() => OnOutputUpdated?.Invoke();
     public void RaiseKernelRestarting(string? kernelId = null) => OnKernelRestarting?.Invoke(kernelId);
     public void RaiseKernelRestarted(string? kernelId = null) => OnKernelRestarted?.Invoke(kernelId);
+    public void RaiseCellExecuting(Guid cellId) => OnCellExecuting?.Invoke(cellId);
+    public void RaiseCellExecutionCompleted(Guid cellId) => OnCellExecutionCompleted?.Invoke(cellId);
+    public void RaiseDirtyStateChanged() => OnDirtyStateChanged?.Invoke();
+    public void RaiseKernelHealthChanged(KernelHealthChangedEventArgs args) => OnKernelHealthChanged?.Invoke(args);
 }

--- a/tests/Verso.Blazor.Shared.Tests/ToolbarTests.cs
+++ b/tests/Verso.Blazor.Shared.Tests/ToolbarTests.cs
@@ -55,6 +55,32 @@ public sealed class ToolbarTests : BunitTestContext
         Assert.IsFalse(cut.Markup.Contains("Save"));
     }
 
+    // ── Document name ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void DocName_ShownInFull_WhenWithinLimit()
+    {
+        _service.FilePath = "/notebooks/report.verso";   // "report.verso" — 12 chars
+
+        var cut = RenderToolbar();
+
+        Assert.IsTrue(cut.Markup.Contains("report.verso"));
+        Assert.IsFalse(cut.Markup.Contains("…"));
+    }
+
+    [TestMethod]
+    public void DocName_TruncatedWithEllipsis_WhenTooLong()
+    {
+        _service.FilePath = "/notebooks/this-file-has-a-very-long-name.verso";
+
+        var cut = RenderToolbar();
+
+        // Displayed name is cut to 20 characters with a trailing ellipsis...
+        Assert.IsTrue(cut.Markup.Contains("this-file-has-a-very…"));
+        // ...while the untruncated name stays available as the element's tooltip.
+        Assert.IsTrue(cut.Markup.Contains("this-file-has-a-very-long-name.verso"));
+    }
+
     // ── View dropdown (Layout + Theme) ─────────────────────────────────
     //
     // Layout and theme switching share a single "View" dropdown. The button appears only when

--- a/tests/Verso.Blazor.Shared.Tests/ToolbarTests.cs
+++ b/tests/Verso.Blazor.Shared.Tests/ToolbarTests.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Components.Forms;
-
 namespace Verso.Blazor.Shared.Tests;
 
 [TestClass]
@@ -57,60 +55,26 @@ public sealed class ToolbarTests : BunitTestContext
         Assert.IsFalse(cut.Markup.Contains("Save"));
     }
 
-    // ── Add Cell buttons ───────────────────────────────────────────────
+    // ── View dropdown (Layout + Theme) ─────────────────────────────────
+    //
+    // Layout and theme switching share a single "View" dropdown. The button appears only when
+    // there is something to switch (more than one layout, or more than one theme on a host that
+    // owns its own theming), and each section renders only when its own choices warrant it. The
+    // choices live inside the popup, so the dropdown is opened before asserting on them.
 
     [TestMethod]
-    public void AddCodeAndMarkdown_ShownWhenLoaded()
+    public void ViewDropdown_HiddenWhenSingleLayoutAndSingleTheme()
     {
-        _service.IsLoaded = true;
+        _service.AvailableLayouts = new List<LayoutInfo> { new("notebook", "Notebook", false) };
+        _service.AvailableThemes = new List<ThemeInfo> { new("light", "Light", ThemeKind.Light) };
 
         var cut = RenderToolbar();
 
-        Assert.IsTrue(cut.Markup.Contains("+ Code"));
-        Assert.IsTrue(cut.Markup.Contains("+ Markdown"));
+        Assert.IsFalse(HasViewButton(cut));
     }
 
     [TestMethod]
-    public void AddCodeButton_FiresOnAddCell_WithCode()
-    {
-        string? addedType = null;
-        var cut = RenderToolbar(onAddCell: type => addedType = type);
-
-        var btn = cut.FindAll("button").First(b => b.TextContent.Contains("+ Code"));
-        btn.Click();
-
-        Assert.AreEqual("code", addedType);
-    }
-
-    [TestMethod]
-    public void AddMarkdownButton_FiresOnAddCell_WithMarkdown()
-    {
-        string? addedType = null;
-        var cut = RenderToolbar(onAddCell: type => addedType = type);
-
-        var btn = cut.FindAll("button").First(b => b.TextContent.Contains("+ Markdown"));
-        btn.Click();
-
-        Assert.AreEqual("markdown", addedType);
-    }
-
-    // ── Layout dropdown ────────────────────────────────────────────────
-
-    [TestMethod]
-    public void LayoutDropdown_HiddenWhenSingleLayout()
-    {
-        _service.AvailableLayouts = new List<LayoutInfo>
-        {
-            new("notebook", "Notebook", false)
-        };
-
-        var cut = RenderToolbar();
-
-        Assert.IsFalse(cut.Markup.Contains("Switch Layout"));
-    }
-
-    [TestMethod]
-    public void LayoutDropdown_ShownWhenMultipleLayouts()
+    public void ViewDropdown_ShowsLayouts_WhenMultipleLayouts()
     {
         _service.AvailableLayouts = new List<LayoutInfo>
         {
@@ -120,27 +84,33 @@ public sealed class ToolbarTests : BunitTestContext
         _service.ActiveLayoutId = "notebook";
 
         var cut = RenderToolbar();
+        OpenViewDropdown(cut);
 
-        Assert.IsTrue(cut.Markup.Contains("Notebook"));
+        Assert.IsTrue(cut.Markup.Contains("Layout"));      // section header
+        Assert.IsTrue(cut.Markup.Contains("Dashboard"));   // the switchable layout
     }
 
-    // ── Theme dropdown ─────────────────────────────────────────────────
-
     [TestMethod]
-    public void ThemeDropdown_HiddenWhenSingleTheme()
+    public void ViewDropdown_OmitsLayoutSection_WhenSingleLayout()
     {
+        // One layout, but multiple themes force the dropdown open: it offers themes and no
+        // Layout section, since there is nothing to switch to.
+        _service.AvailableLayouts = new List<LayoutInfo> { new("notebook", "Notebook", false) };
         _service.AvailableThemes = new List<ThemeInfo>
         {
-            new("light", "Light", ThemeKind.Light)
+            new("light", "Light", ThemeKind.Light),
+            new("dark", "Dark", ThemeKind.Dark)
         };
 
         var cut = RenderToolbar();
+        OpenViewDropdown(cut);
 
-        Assert.IsFalse(cut.Markup.Contains("Switch Theme"));
+        Assert.IsFalse(cut.Markup.Contains("Layout"));
+        Assert.IsTrue(cut.Markup.Contains("Theme"));
     }
 
     [TestMethod]
-    public void ThemeDropdown_ShownWhenMultipleThemes_NotEmbedded()
+    public void ViewDropdown_ShowsThemes_WhenMultipleThemes_NotEmbedded()
     {
         _service.AvailableThemes = new List<ThemeInfo>
         {
@@ -151,13 +121,39 @@ public sealed class ToolbarTests : BunitTestContext
         _service.IsEmbedded = false;
 
         var cut = RenderToolbar();
+        OpenViewDropdown(cut);
 
-        Assert.IsTrue(cut.Markup.Contains("Light"));
+        Assert.IsTrue(cut.Markup.Contains("Theme"));   // section header
+        Assert.IsTrue(cut.Markup.Contains("Dark"));    // the switchable theme
     }
 
     [TestMethod]
-    public void ThemeDropdown_HiddenWhenEmbedded()
+    public void ViewDropdown_OmitsThemeSection_WhenSingleTheme()
     {
+        // Multiple layouts force the dropdown open; one theme means no Theme section.
+        _service.AvailableLayouts = new List<LayoutInfo>
+        {
+            new("notebook", "Notebook", false),
+            new("dashboard", "Dashboard", true)
+        };
+        _service.AvailableThemes = new List<ThemeInfo> { new("light", "Light", ThemeKind.Light) };
+
+        var cut = RenderToolbar();
+        OpenViewDropdown(cut);
+
+        Assert.IsFalse(cut.Markup.Contains("Theme"));
+        Assert.IsTrue(cut.Markup.Contains("Layout"));
+    }
+
+    [TestMethod]
+    public void ViewDropdown_OmitsThemeSection_WhenEmbedded()
+    {
+        // Embedded hosts own theming, so the Theme section never appears even with many themes.
+        _service.AvailableLayouts = new List<LayoutInfo>
+        {
+            new("notebook", "Notebook", false),
+            new("dashboard", "Dashboard", true)
+        };
         _service.AvailableThemes = new List<ThemeInfo>
         {
             new("light", "Light", ThemeKind.Light),
@@ -166,34 +162,33 @@ public sealed class ToolbarTests : BunitTestContext
         _service.IsEmbedded = true;
 
         var cut = RenderToolbar();
+        OpenViewDropdown(cut);
 
-        // Theme dropdown hidden in embedded mode
-        Assert.IsFalse(cut.Markup.Contains("Switch Theme"));
+        Assert.IsFalse(cut.Markup.Contains("Theme"));
     }
 
     // ── Not loaded state ───────────────────────────────────────────────
 
     [TestMethod]
-    public void WhenNotLoaded_CellAndSaveButtonsHidden()
+    public void WhenNotLoaded_SaveButtonHidden()
     {
         _service.IsLoaded = false;
 
         var cut = RenderToolbar();
 
         Assert.IsFalse(cut.Markup.Contains("Save"));
-        Assert.IsFalse(cut.Markup.Contains("+ Code"));
-        Assert.IsFalse(cut.Markup.Contains("+ Markdown"));
     }
 
-    // ── Helper ─────────────────────────────────────────────────────────
+    // ── Helpers ────────────────────────────────────────────────────────
 
-    private IRenderedComponent<Toolbar> RenderToolbar(
-        Action<string>? onAddCell = null)
-    {
-        return RenderComponent<Toolbar>(p => p
-            .Add(t => t.Service, _service)
-            .Add(t => t.OnAddCell, onAddCell ?? (_ => { })));
-    }
+    private IRenderedComponent<Toolbar> RenderToolbar()
+        => RenderComponent<Toolbar>(p => p.Add(t => t.Service, _service));
+
+    private static bool HasViewButton(IRenderedComponent<Toolbar> cut)
+        => cut.FindAll("button").Any(b => b.TextContent.Contains("View"));
+
+    private static void OpenViewDropdown(IRenderedComponent<Toolbar> cut)
+        => cut.FindAll("button").First(b => b.TextContent.Contains("View")).Click();
 }
 
 /// <summary>

--- a/tests/Verso.Blazor.Shared.Tests/ToolbarTests.cs
+++ b/tests/Verso.Blazor.Shared.Tests/ToolbarTests.cs
@@ -205,10 +205,226 @@ public sealed class ToolbarTests : BunitTestContext
         Assert.IsFalse(cut.Markup.Contains("Save"));
     }
 
+    // ── Action confirmation ────────────────────────────────────────────
+    //
+    // Actions that declare a ConfirmationPrompt (destructive ones like Restart Kernel)
+    // open a confirm dialog on click and only execute once the user accepts.
+
+    [TestMethod]
+    public void ActionWithConfirmationPrompt_ClickShowsDialog_WithoutExecuting()
+    {
+        AddRestartAction();
+
+        var cut = RenderToolbar();
+        cut.Find("button[title='Restart Kernel']").Click();
+
+        Assert.IsTrue(cut.Markup.Contains("verso-modal"));
+        Assert.IsTrue(cut.Markup.Contains("Restart now?"));
+        Assert.AreEqual(0, _service.ExecutedActionIds.Count);
+    }
+
+    [TestMethod]
+    public void ConfirmationDialog_Confirm_ExecutesAction()
+    {
+        AddRestartAction();
+
+        var cut = RenderToolbar();
+        cut.Find("button[title='Restart Kernel']").Click();
+        cut.Find(".verso-modal-footer .verso-modal-btn--primary").Click();
+
+        CollectionAssert.Contains(_service.ExecutedActionIds, "verso.action.restart-kernel");
+        Assert.IsFalse(cut.Markup.Contains("verso-modal"));
+    }
+
+    [TestMethod]
+    public void ConfirmationDialog_Cancel_DoesNotExecute()
+    {
+        AddRestartAction();
+
+        var cut = RenderToolbar();
+        cut.Find("button[title='Restart Kernel']").Click();
+        cut.Find(".verso-modal-footer .verso-modal-btn--secondary").Click();
+
+        Assert.AreEqual(0, _service.ExecutedActionIds.Count);
+        Assert.IsFalse(cut.Markup.Contains("verso-modal"));
+    }
+
+    [TestMethod]
+    public void ActionWithoutConfirmationPrompt_ExecutesImmediately()
+    {
+        AddRunAllAction();
+
+        var cut = RenderToolbar();
+        cut.Find("button[title='Run All']").Click();
+
+        CollectionAssert.Contains(_service.ExecutedActionIds, "verso.action.run-all");
+        Assert.IsFalse(cut.Markup.Contains("verso-modal"));
+    }
+
+    // ── Run All / Stop swap ────────────────────────────────────────────
+
+    [TestMethod]
+    public void PrimaryAction_SwapsToStop_WhileExecuting()
+    {
+        AddRunAllAction();
+        var cellId = Guid.NewGuid();
+
+        var cut = RenderToolbar();
+        cut.InvokeAsync(() => _service.RaiseCellExecuting(cellId));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.IsNotNull(cut.Find("button[title='Stop Execution']"));
+            Assert.IsFalse(cut.Markup.Contains("Run All"));
+        });
+    }
+
+    [TestMethod]
+    public void StopButton_CancelsExecution()
+    {
+        AddRunAllAction();
+        var cellId = Guid.NewGuid();
+
+        var cut = RenderToolbar();
+        cut.InvokeAsync(() => _service.RaiseCellExecuting(cellId));
+
+        cut.WaitForElement("button[title='Stop Execution']").Click();
+
+        CollectionAssert.Contains(_service.CancelledCellIds, cellId);
+    }
+
+    [TestMethod]
+    public void StopButton_PersistsAcrossCellBoundaries_WhilePageExecutionInProgress()
+    {
+        // During a Run All batch the running-cell set momentarily drains between cells.
+        // The page-level IsExecuting flag must hold the Stop button (and the Running pill)
+        // through those gaps so the toolbar does not toggle at every cell boundary.
+        AddRunAllAction();
+        var cellId = Guid.NewGuid();
+
+        var cut = RenderComponent<Toolbar>(p => p
+            .Add(t => t.Service, _service)
+            .Add(t => t.IsExecuting, true));
+
+        cut.InvokeAsync(() => _service.RaiseCellExecuting(cellId));
+        cut.InvokeAsync(() => _service.RaiseCellExecutionCompleted(cellId));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.IsNotNull(cut.Find("button[title='Stop Execution']"));
+            Assert.IsFalse(cut.Markup.Contains("Run All"));
+            Assert.IsTrue(cut.Markup.Contains("Running…"));
+        });
+
+        // The page reports the whole run finished: the primary action and idle pill return.
+        cut.SetParametersAndRender(p => p.Add(t => t.IsExecuting, false));
+        cut.WaitForAssertion(() =>
+        {
+            Assert.IsTrue(cut.Markup.Contains("Run All"));
+            Assert.IsTrue(cut.Markup.Contains("Kernel idle"));
+        });
+    }
+
+    [TestMethod]
+    public void PrimaryAction_RestoredAfterExecutionCompletes()
+    {
+        AddRunAllAction();
+        var cellId = Guid.NewGuid();
+
+        var cut = RenderToolbar();
+        cut.InvokeAsync(() => _service.RaiseCellExecuting(cellId));
+        cut.WaitForElement("button[title='Stop Execution']");
+        cut.InvokeAsync(() => _service.RaiseCellExecutionCompleted(cellId));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.IsTrue(cut.Markup.Contains("Run All"));
+            Assert.IsFalse(cut.Markup.Contains("Stop Execution"));
+        });
+    }
+
+    // ── Save dirty state ───────────────────────────────────────────────
+
+    [TestMethod]
+    public void SaveButton_ShowsDirtyDot_WhenDirty()
+    {
+        _service.IsDirty = true;
+
+        var cut = RenderToolbar();
+
+        Assert.IsTrue(cut.Markup.Contains("verso-toolbar-dirty-dot"));
+        Assert.IsNotNull(cut.Find("button[title='Save (unsaved changes)']"));
+    }
+
+    [TestMethod]
+    public void SaveButton_NoDirtyDot_WhenClean()
+    {
+        _service.IsDirty = false;
+
+        var cut = RenderToolbar();
+
+        Assert.IsFalse(cut.Markup.Contains("verso-toolbar-dirty-dot"));
+    }
+
+    // ── Kernel status pill health states ───────────────────────────────
+
+    [TestMethod]
+    public void KernelPill_ShowsDisconnected_OnHostLoss()
+    {
+        var cut = RenderToolbar();
+        cut.InvokeAsync(() => _service.RaiseKernelHealthChanged(
+            new KernelHealthChangedEventArgs(KernelHealth.Disconnected, "host process exited")));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.IsTrue(cut.Markup.Contains("Disconnected"));
+            Assert.IsTrue(cut.Markup.Contains("verso-kernel-status--error"));
+            // The cause is surfaced as the pill tooltip.
+            Assert.IsTrue(cut.Markup.Contains("host process exited"));
+        });
+    }
+
+    [TestMethod]
+    public void KernelPill_ShowsError_OnFault_AndRecoversOnRestart()
+    {
+        var cut = RenderToolbar();
+        cut.InvokeAsync(() => _service.RaiseKernelHealthChanged(
+            new KernelHealthChangedEventArgs(KernelHealth.Faulted, "warm-up failed")));
+
+        cut.WaitForAssertion(() => Assert.IsTrue(cut.Markup.Contains("Kernel error")));
+
+        cut.InvokeAsync(() => _service.RaiseKernelRestarting());
+        cut.WaitForAssertion(() => Assert.IsTrue(cut.Markup.Contains("Restarting…")));
+
+        cut.InvokeAsync(() => _service.RaiseKernelRestarted());
+        cut.WaitForAssertion(() => Assert.IsTrue(cut.Markup.Contains("Kernel idle")));
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     private IRenderedComponent<Toolbar> RenderToolbar()
         => RenderComponent<Toolbar>(p => p.Add(t => t.Service, _service));
+
+    private void AddRestartAction()
+    {
+        _service.ToolbarActions.Add(new ToolbarActionInfo(
+            "verso.action.restart-kernel", "Restart Kernel",
+            "<svg viewBox=\"0 0 16 16\"></svg>",
+            ToolbarPlacement.MainToolbar, 40,
+            IconOnly: true,
+            ConfirmationPrompt: "Restarting the kernel discards all variables and execution state. Restart now?"));
+        _service.ActionEnabledStates["verso.action.restart-kernel"] = true;
+    }
+
+    private void AddRunAllAction()
+    {
+        _service.ToolbarActions.Add(new ToolbarActionInfo(
+            "verso.action.run-all", "Run All",
+            "<svg viewBox=\"0 0 16 16\"></svg>",
+            ToolbarPlacement.MainToolbar, 10,
+            IsPrimary: true));
+        _service.ActionEnabledStates["verso.action.run-all"] = true;
+    }
 
     private static bool HasViewButton(IRenderedComponent<Toolbar> cut)
         => cut.FindAll("button").Any(b => b.TextContent.Contains("View"));

--- a/tests/Verso.Host.Tests/Handlers/LayoutHandlerTests.cs
+++ b/tests/Verso.Host.Tests/Handlers/LayoutHandlerTests.cs
@@ -48,9 +48,9 @@ public class LayoutHandlerTests
             ExtensionId = handler.ExtensionId,
             LayoutId = handler.LayoutId,
             FrameInstanceId = "nb-1/dashboard/0",
-            InteractionType = "setEditMode",
-            Payload = "true",
-            TargetId = "edit-toggle"
+            InteractionType = "customAction",
+            Payload = "payload-data",
+            TargetId = "target-1"
         }));
 
         Assert.IsNull(result, "layout/interact returns null on success.");
@@ -60,9 +60,9 @@ public class LayoutHandlerTests
         Assert.AreEqual(handler.ExtensionId, ctx.ExtensionId);
         Assert.AreEqual(handler.LayoutId, ctx.LayoutId);
         Assert.AreEqual("nb-1/dashboard/0", ctx.FrameInstanceId);
-        Assert.AreEqual("setEditMode", ctx.InteractionType);
-        Assert.AreEqual("true", ctx.Payload);
-        Assert.AreEqual("edit-toggle", ctx.TargetId);
+        Assert.AreEqual("customAction", ctx.InteractionType);
+        Assert.AreEqual("payload-data", ctx.Payload);
+        Assert.AreEqual("target-1", ctx.TargetId);
         Assert.IsNotNull(ctx.Verso);
     }
 
@@ -339,25 +339,6 @@ public class LayoutHandlerTests
         Assert.AreEqual(4.0, legacyContainer.Y);
         Assert.AreEqual(8.0, legacyContainer.Width);
         Assert.AreEqual(5.0, legacyContainer.Height);
-    }
-
-    [TestMethod]
-    public async Task HandleSetEditMode_ForwardsToHandleInteract_TogglesIsEditMode()
-    {
-        var (session, notebookId, _) = await CreateOpenSession();
-        var ns = session.GetSession(notebookId);
-        var dashboard = GetLoadedDashboard(ns);
-        dashboard.IsEditMode = false;
-
-        Assert.IsFalse(dashboard.IsEditMode);
-
-        await LayoutHandler.HandleSetEditMode(ns, JsonSerializer.SerializeToElement(
-            new LayoutSetEditModeParams { EditMode = true }, JsonRpcMessage.SerializerOptions));
-        Assert.IsTrue(dashboard.IsEditMode);
-
-        await LayoutHandler.HandleSetEditMode(ns, JsonSerializer.SerializeToElement(
-            new LayoutSetEditModeParams { EditMode = false }, JsonRpcMessage.SerializerOptions));
-        Assert.IsFalse(dashboard.IsEditMode);
     }
 
     // ─── layout/getRendererPackage ────────────────────────────────────────────

--- a/tests/Verso.Tests/Execution/ExecutionPipelineTests.cs
+++ b/tests/Verso.Tests/Execution/ExecutionPipelineTests.cs
@@ -116,12 +116,41 @@ public sealed class ExecutionPipelineTests
         Assert.AreEqual(ExecutionResult.ExecutionStatus.Failed, result.Status);
     }
 
+    [TestMethod]
+    public async Task RenderOnlyCell_FiresOutputNotification()
+    {
+        // Regression: render-only cells (e.g. Markdown) must raise the output-updated
+        // notification just like kernel execution does, so out-of-process hosts receive
+        // their content incrementally as the cell finishes instead of only at the end of a
+        // Run All. Previously the render path added the output without notifying, so these
+        // cells appeared blank until the whole batch completed.
+        var renderer = new FakeCellRenderer(cellTypeId: "markdown");
+        var cell = new CellModel { Type = "markdown", Source = "# Title" };
+
+        var notified = new List<Guid>();
+        var pipeline = BuildPipeline(
+            kernel: null, cell,
+            renderers: new ICellRenderer[] { renderer },
+            notifyOutputUpdated: notified.Add);
+
+        var result = await pipeline.ExecuteAsync(cell, CancellationToken.None);
+
+        Assert.AreEqual(ExecutionResult.ExecutionStatus.Success, result.Status);
+        Assert.AreEqual(1, cell.Outputs.Count);
+        Assert.AreEqual("input:# Title", cell.Outputs[0].Content);
+        CollectionAssert.Contains(notified, cell.Id, "Render-only cell must notify that its output updated.");
+    }
+
     private static ExecutionPipeline BuildPipeline(
-        FakeLanguageKernel? kernel, CellModel cell, string? defaultKernelId = null)
+        FakeLanguageKernel? kernel, CellModel cell, string? defaultKernelId = null,
+        IReadOnlyList<ICellRenderer>? renderers = null,
+        Action<Guid>? notifyOutputUpdated = null)
     {
         var variables = new VariableStore();
         var theme = new StubThemeContext();
-        var extensionHost = new StubExtensionHostContext(() => Array.Empty<ILanguageKernel>());
+        var extensionHost = new StubExtensionHostContext(
+            () => Array.Empty<ILanguageKernel>(),
+            renderers is null ? null : () => renderers);
         var metadata = new NotebookMetadataContext(new NotebookModel { DefaultKernelId = defaultKernelId });
 
         return new ExecutionPipeline(
@@ -130,6 +159,7 @@ public sealed class ExecutionPipelineTests
             resolveKernel: langId => kernel?.LanguageId.Equals(langId, StringComparison.OrdinalIgnoreCase) == true ? kernel : null,
             ensureInitialized: k => k.InitializeAsync(),
             resolveLanguageId: _ => cell.Language ?? defaultKernelId,
-            getExecutionCount: _ => 1);
+            getExecutionCount: _ => 1,
+            notifyOutputUpdated: notifyOutputUpdated);
     }
 }

--- a/tests/Verso.Tests/Extensions/DashboardLayoutTests.cs
+++ b/tests/Verso.Tests/Extensions/DashboardLayoutTests.cs
@@ -24,32 +24,21 @@ public sealed class DashboardLayoutTests
         => Assert.IsTrue(_layout.RequiresCustomRenderer);
 
     [TestMethod]
-    public void Capabilities_ViewMode_HasResizeAndExecute()
+    public void Capabilities_HasResizeAndExecute()
     {
         Assert.IsTrue(_layout.Capabilities.HasFlag(LayoutCapabilities.CellResize));
         Assert.IsTrue(_layout.Capabilities.HasFlag(LayoutCapabilities.CellExecute));
-        Assert.IsTrue(_layout.Capabilities.HasFlag(LayoutCapabilities.CellEdit));
     }
 
     [TestMethod]
-    public void Capabilities_ViewMode_NoCellInsert()
+    public void Capabilities_DoesNotAllowCodeEditingOrStructuralChanges()
     {
+        // The dashboard is view-and-arrange only: move, resize, and run, but never edit code or
+        // add/remove/reorder cells.
+        Assert.IsFalse(_layout.Capabilities.HasFlag(LayoutCapabilities.CellEdit));
         Assert.IsFalse(_layout.Capabilities.HasFlag(LayoutCapabilities.CellInsert));
         Assert.IsFalse(_layout.Capabilities.HasFlag(LayoutCapabilities.CellDelete));
         Assert.IsFalse(_layout.Capabilities.HasFlag(LayoutCapabilities.CellReorder));
-    }
-
-    [TestMethod]
-    public void Capabilities_EditMode_HasInsertDeleteReorder()
-    {
-        _layout.IsEditMode = true;
-
-        Assert.IsTrue(_layout.Capabilities.HasFlag(LayoutCapabilities.CellInsert));
-        Assert.IsTrue(_layout.Capabilities.HasFlag(LayoutCapabilities.CellDelete));
-        Assert.IsTrue(_layout.Capabilities.HasFlag(LayoutCapabilities.CellReorder));
-        Assert.IsTrue(_layout.Capabilities.HasFlag(LayoutCapabilities.CellResize));
-        Assert.IsTrue(_layout.Capabilities.HasFlag(LayoutCapabilities.CellExecute));
-        Assert.IsTrue(_layout.Capabilities.HasFlag(LayoutCapabilities.CellEdit));
     }
 
     [TestMethod]
@@ -101,14 +90,17 @@ public sealed class DashboardLayoutTests
     }
 
     [TestMethod]
-    public async Task RenderLayoutAsync_EmitsEditModeToggleButton()
+    public async Task RenderLayoutAsync_EmitsNoCodeEditingAffordances()
     {
         var cells = new List<CellModel> { new() { Id = Guid.NewGuid() } };
 
         var result = await _layout.RenderLayoutAsync(cells, _context);
 
-        Assert.IsTrue(result.Content.Contains("data-action=\"setEditMode\""),
-            "Edit-mode toggle is a layout-scoped button routed via layout/interact.");
+        // The dashboard never edits code, so it emits neither the global edit toggle nor the
+        // per-cell code toggle; only Run, drag, and resize chrome remain.
+        Assert.IsFalse(result.Content.Contains("data-action=\"setEditMode\""));
+        Assert.IsFalse(result.Content.Contains("data-action=\"toggleCellEdit\""));
+        Assert.IsTrue(result.Content.Contains("data-action=\"run\""));
     }
 
     [TestMethod]
@@ -280,39 +272,32 @@ public sealed class DashboardLayoutTests
     }
 
     [TestMethod]
-    public async Task OnLayoutInteractionAsync_SetEditModeTrue_EnablesEditMode()
+    public async Task OnLayoutInteractionAsync_SetEditMode_IsIgnored()
     {
-        Assert.IsFalse(_layout.IsEditMode);
-
+        // setEditMode is retired (the dashboard no longer edits code). A stray "setEditMode"
+        // interaction from an older client must be absorbed as a graceful no-op that neither
+        // throws nor re-enables structural editing capabilities.
         await _layout.OnLayoutInteractionAsync(BuildContext("setEditMode", "true"));
 
-        Assert.IsTrue(_layout.IsEditMode);
-        Assert.IsTrue(_layout.Capabilities.HasFlag(LayoutCapabilities.CellInsert));
-        Assert.IsTrue(_layout.Capabilities.HasFlag(LayoutCapabilities.CellDelete));
-        Assert.IsTrue(_layout.Capabilities.HasFlag(LayoutCapabilities.CellReorder));
-    }
-
-    [TestMethod]
-    public async Task OnLayoutInteractionAsync_SetEditModeFalse_DisablesEditMode()
-    {
-        _layout.IsEditMode = true;
-
-        await _layout.OnLayoutInteractionAsync(BuildContext("setEditMode", "false"));
-
-        Assert.IsFalse(_layout.IsEditMode);
         Assert.IsFalse(_layout.Capabilities.HasFlag(LayoutCapabilities.CellInsert));
+        Assert.IsFalse(_layout.Capabilities.HasFlag(LayoutCapabilities.CellDelete));
+        Assert.IsFalse(_layout.Capabilities.HasFlag(LayoutCapabilities.CellReorder));
     }
 
     [TestMethod]
     public async Task OnLayoutInteractionAsync_UnknownType_IsNoOp()
     {
-        _layout.IsEditMode = true;
+        var cellId = Guid.NewGuid();
+        _layout.UpdateCellPosition(cellId, 1, 2, 4, 3);
 
         // An unrecognized interaction type must be ignored rather than thrown, so a newer
         // client emitting an interaction this build doesn't know cannot fault a healthy
         // dashboard. Mirrors the built-in notebook layout's silent handling.
         await _layout.OnLayoutInteractionAsync(BuildContext("nope", "{}"));
 
-        Assert.IsTrue(_layout.IsEditMode, "Unknown interaction must not mutate layout state.");
+        // State is untouched: the position set above is still intact.
+        var container = await _layout.GetCellContainerAsync(cellId, _context);
+        Assert.AreEqual(2.0, container.X);
+        Assert.AreEqual(1.0, container.Y);
     }
 }

--- a/tests/Verso.Tests/Extensions/VisibilityDefaultsTests.cs
+++ b/tests/Verso.Tests/Extensions/VisibilityDefaultsTests.cs
@@ -89,16 +89,10 @@ public sealed class VisibilityDefaultsTests
     }
 
     [TestMethod]
-    public void DashboardLayout_SupportsPropertiesPanel_EditMode_IsTrue()
+    public void DashboardLayout_SupportsPropertiesPanel_IsFalse()
     {
-        var layout = new DashboardLayout { IsEditMode = true };
-        Assert.IsTrue(layout.SupportsPropertiesPanel);
-    }
-
-    [TestMethod]
-    public void DashboardLayout_SupportsPropertiesPanel_ViewMode_IsFalse()
-    {
-        var layout = new DashboardLayout { IsEditMode = false };
+        // The dashboard is view-and-arrange only, so it never offers a properties panel.
+        ILayoutEngine layout = new DashboardLayout();
         Assert.IsFalse(layout.SupportsPropertiesPanel);
     }
 }

--- a/vscode/src/blazor/blazorBridge.ts
+++ b/vscode/src/blazor/blazorBridge.ts
@@ -30,6 +30,7 @@ export class BlazorBridge implements vscode.Disposable {
     "extension/unavailable",
     "kernel/restarting",
     "kernel/restarted",
+    "kernel/faulted",
     "layout/missing",
     "layout/updated",
     "layout/frameMessage",

--- a/vscode/src/blazor/blazorBridge.ts
+++ b/vscode/src/blazor/blazorBridge.ts
@@ -209,6 +209,20 @@ export class BlazorBridge implements vscode.Disposable {
   }
 
   /**
+   * Posts a notification to the webview signaling that a kernel restart failed
+   * and the kernel is now unavailable. The WASM app resolves its status pill to
+   * an error state carrying {@link message} so it never hangs on "Restarting…".
+   * The property name is `message` to match the webview's kernel/faulted handler.
+   */
+  notifyFaulted(message: string): void {
+    this.webview.postMessage({
+      type: "jsonrpc-notification",
+      method: "kernel/faulted",
+      params: { message },
+    });
+  }
+
+  /**
    * Swaps the underlying host process after a restart and re-binds notification
    * handlers against the new process. The provider calls this once the new
    * {@link HostProcess} is started and the notebook has been reopened.

--- a/vscode/src/blazor/blazorEditorProvider.ts
+++ b/vscode/src/blazor/blazorEditorProvider.ts
@@ -391,6 +391,11 @@ export class BlazorEditorProvider
         }`
       );
       bridge.endRestart();
+      bridge.notifyFaulted(
+        `Restart aborted: the notebook snapshot could not be captured (${
+          err instanceof Error ? err.message : String(err)
+        }).`
+      );
       vscode.window.showErrorMessage(
         "Verso: kernel restart aborted because the notebook snapshot could not be captured. Save and reopen the file."
       );
@@ -410,6 +415,11 @@ export class BlazorEditorProvider
         `New host failed to start: ${err instanceof Error ? err.message : String(err)}`
       );
       bridge.endRestart();
+      bridge.notifyFaulted(
+        `Kernel restart failed: the host process did not start (${
+          err instanceof Error ? err.message : String(err)
+        }).`
+      );
       vscode.window.showErrorMessage(
         `Verso: kernel restart failed (host did not start): ${
           err instanceof Error ? err.message : String(err)
@@ -433,6 +443,11 @@ export class BlazorEditorProvider
         }`
       );
       bridge.endRestart();
+      bridge.notifyFaulted(
+        `Kernel restart failed: the notebook did not reopen (${
+          err instanceof Error ? err.message : String(err)
+        }).`
+      );
       vscode.window.showErrorMessage(
         `Verso: kernel restart failed (notebook did not reopen): ${
           err instanceof Error ? err.message : String(err)

--- a/vscode/src/blazor/blazorEditorProvider.ts
+++ b/vscode/src/blazor/blazorEditorProvider.ts
@@ -205,6 +205,13 @@ export class BlazorEditorProvider
     const bridge = new BlazorBridge(webview, host, this.context.globalState);
     bridge.setDocumentUri(document.uri);
 
+    // Tell the webview when the host dies unexpectedly so its kernel status can
+    // show "Disconnected" instead of a stale "Kernel idle". Provider-driven
+    // restarts dispose the old host first, so they do not fire this.
+    host.onUnexpectedExit = (detail) => {
+      bridge.notify("host/exited", { detail });
+    };
+
     // Mark the document dirty whenever the WASM app mutates the notebook.
     bridge.onDidEdit = () => {
       this._onDidChangeCustomDocument.fire({ document });
@@ -436,6 +443,9 @@ export class BlazorEditorProvider
 
     bridge.setHost(newHost);
     bridge.setNotebookId(result.notebookId);
+    newHost.onUnexpectedExit = (detail) => {
+      bridge.notify("host/exited", { detail });
+    };
     notebookRegistry.register(document.uri, result.notebookId);
     hostRegistry.register(document.uri, { host: newHost, bridge });
 
@@ -508,6 +518,10 @@ export class BlazorEditorProvider
     );
     const data = new TextEncoder().encode(result.content);
     await vscode.workspace.fs.writeFile(document.uri, data);
+
+    // Let the webview clear its unsaved-changes indicator; this fires for both the
+    // webview Save button (which routes through workbench save) and Cmd/Ctrl+S.
+    session.bridge.notify("document/saved");
   }
 
   async saveCustomDocumentAs(
@@ -544,6 +558,8 @@ export class BlazorEditorProvider
     );
     const data = new TextEncoder().encode(result.content);
     await vscode.workspace.fs.writeFile(targetUri, data);
+
+    session.bridge.notify("document/saved");
 
     // Save As on a scratch keeps it at the chosen location: rebind the editor to
     // the real file (once this save completes) so later saves write in place.
@@ -824,6 +840,10 @@ export class BlazorEditorProvider
             --verso-toolbar-button-hover: var(--vscode-toolbar-hoverBackground);
             --verso-toolbar-separator: var(--vscode-panel-border, #E0E0E0);
             --verso-toolbar-disabled-foreground: var(--vscode-disabledForeground);
+            /* Filled Stop button. statusBarItem error colors are a designed bg/fg pair,
+               unlike errorForeground (a text color that can wash out as a button fill). */
+            --verso-toolbar-stop-background: var(--vscode-statusBarItem-errorBackground, #B52E31);
+            --verso-toolbar-stop-foreground: var(--vscode-statusBarItem-errorForeground, #FFFFFF);
             --verso-sidebar-background: var(--vscode-sideBar-background);
             --verso-sidebar-foreground: var(--vscode-sideBar-foreground, var(--vscode-foreground));
             --verso-sidebar-item-hover: var(--vscode-list-hoverBackground);

--- a/vscode/src/host/hostProcess.ts
+++ b/vscode/src/host/hostProcess.ts
@@ -25,6 +25,13 @@ export class HostProcess implements vscode.Disposable {
   private readyPromise: Promise<void> | undefined;
   private disposed = false;
 
+  /**
+   * Fired when the process exits without dispose() having been called (a crash or
+   * external kill, not a normal shutdown or provider-driven restart). Receives a
+   * short human-readable exit description.
+   */
+  onUnexpectedExit: ((detail: string) => void) | undefined;
+
   constructor(private readonly hostDllPath: string) {}
 
   async start(): Promise<void> {
@@ -63,6 +70,7 @@ export class HostProcess implements vscode.Disposable {
           vscode.window.showWarningMessage(
             `Verso host process exited (${detail.toast})`
           );
+          this.onUnexpectedExit?.(detail.toast);
         } else {
           log.info(`Verso.Host exited (${detail.log})`);
         }

--- a/vscode/src/host/protocol.ts
+++ b/vscode/src/host/protocol.ts
@@ -267,10 +267,6 @@ export interface LayoutUpdateCellParams {
   height: number;
 }
 
-export interface LayoutSetEditModeParams {
-  editMode: boolean;
-}
-
 // --- Theme DTOs ---
 
 export interface ThemeResult {


### PR DESCRIPTION
This pull request enhances the Form Studio and Grid Studio features to support both `DataBlock` and `DataTable` types as chart and grid data sources, improving flexibility for users who work with different data structures. It also updates the UI and documentation to reflect this broader support, and refines the layout and terminology for clarity and usability.

**Support for multiple chart/grid data sources:**

* The `DataBlockReader` and `DataBlockInterop` classes now recognize and can read both `DataBlock` and `System.Data.DataTable` objects, providing a unified interface (`ReadSource`/`ReadDataTable`) to project these sources into serializable forms for charting and grid display. [[1]](diffhunk://#diff-609fe450737541ab038a3471578949b93c33ba824f5b114ea64f0e725bb51d60L25-R30) [[2]](diffhunk://#diff-609fe450737541ab038a3471578949b93c33ba824f5b114ea64f0e725bb51d60R40-R56) [[3]](diffhunk://#diff-609fe450737541ab038a3471578949b93c33ba824f5b114ea64f0e725bb51d60R109-R135) [[4]](diffhunk://#diff-152a04520c56de01b23d615d41dbf2055bcac3cccf1cdaa19f1dec785bfc940eR42-R44) [[5]](diffhunk://#diff-152a04520c56de01b23d615d41dbf2055bcac3cccf1cdaa19f1dec785bfc940eR97-R126)
* The Form Studio layout logic and UI now treat both `DataBlock` and `DataTable` as valid chart sources, updating variable lists and selection logic accordingly. [[1]](diffhunk://#diff-a1b248604181b68e466a22d288b8368a087439ac06b7bb2c9f3ff64f2d0b95a7L12-R13) [[2]](diffhunk://#diff-a1b248604181b68e466a22d288b8368a087439ac06b7bb2c9f3ff64f2d0b95a7L333-R334) [[3]](diffhunk://#diff-a1b248604181b68e466a22d288b8368a087439ac06b7bb2c9f3ff64f2d0b95a7L361-R382)

**UI and terminology improvements:**

* The UI and help text now use the more general term "data source" instead of "DataBlock" where appropriate, clarifying that charts and grids can use either type. [[1]](diffhunk://#diff-a4a916fd3902c650b914b39109ca3731ed34f1cb87de5b7636489c6f7e887baeL423-R420) [[2]](diffhunk://#diff-a4a916fd3902c650b914b39109ca3731ed34f1cb87de5b7636489c6f7e887baeL502-R501) [[3]](diffhunk://#diff-a4a916fd3902c650b914b39109ca3731ed34f1cb87de5b7636489c6f7e887baeL540-R537) [[4]](diffhunk://#diff-a4a916fd3902c650b914b39109ca3731ed34f1cb87de5b7636489c6f7e887baeL765-R763)
* The Form Studio app layout has been refined for better usability, with the left palette now spanning the full height and improved handling of preview mode. [[1]](diffhunk://#diff-a4a916fd3902c650b914b39109ca3731ed34f1cb87de5b7636489c6f7e887baeL81-L96) [[2]](diffhunk://#diff-a4a916fd3902c650b914b39109ca3731ed34f1cb87de5b7636489c6f7e887baeL112-R112) [[3]](diffhunk://#diff-a4a916fd3902c650b914b39109ca3731ed34f1cb87de5b7636489c6f7e887baeL187-L192) [[4]](diffhunk://#diff-a4a916fd3902c650b914b39109ca3731ed34f1cb87de5b7636489c6f7e887baeL205) [[5]](diffhunk://#diff-a4a916fd3902c650b914b39109ca3731ed34f1cb87de5b7636489c6f7e887baeR210) [[6]](diffhunk://#diff-a4a916fd3902c650b914b39109ca3731ed34f1cb87de5b7636489c6f7e887baeR651)

**Documentation updates:**

* The documentation and code comments have been updated to clarify the new support for `DataTable` as a chart/grid source and to improve descriptions of data handling. [[1]](diffhunk://#diff-a666e14d0c1f8205a28c809d6c4cca60ea91967d6160d8272b40db1da696295eL658-R658) [[2]](diffhunk://#diff-609fe450737541ab038a3471578949b93c33ba824f5b114ea64f0e725bb51d60L25-R30)

These changes make Form Studio and Grid Studio more versatile and user-friendly by supporting a wider range of data sources and improving the clarity of the user interface.