### PR TITLE
Coalesce output notifications and improve cell rendering

### DIFF
--- a/src/Verso.Blazor.Shared/Components/Editor/MonacoEditor.razor
+++ b/src/Verso.Blazor.Shared/Components/Editor/MonacoEditor.razor
@@ -17,6 +17,7 @@
     private DotNetObjectReference<MonacoEditor>? _dotnetRef;
     private bool _initialized;
     private string? _lastSetValue;
+    private string? _lastSetLanguage;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -31,6 +32,7 @@
             }, _dotnetRef);
             _initialized = true;
             _lastSetValue = Value;
+            _lastSetLanguage = Language;
         }
     }
 
@@ -44,7 +46,15 @@
             await JS.InvokeVoidAsync("versoMonaco.setValue", _elementId, Value);
         }
 
-        await JS.InvokeVoidAsync("versoMonaco.setLanguage", _elementId, Language);
+        // Guarded like setValue above: this method runs on every parent render (during Run All,
+        // once per coalesced output flush for every code cell), and an unconditional interop call
+        // here keeps the webview main thread busy for no reason. The language virtually never
+        // changes after creation.
+        if (Language != _lastSetLanguage)
+        {
+            _lastSetLanguage = Language;
+            await JS.InvokeVoidAsync("versoMonaco.setLanguage", _elementId, Language);
+        }
     }
 
     [JSInvokable]

--- a/src/Verso.Blazor.Shared/Components/Notebook/Cell.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/Cell.razor
@@ -143,7 +143,12 @@
                      style="@OutputPreviewStyle"
                      data-cell-id="@CellData.Id"
                      @onclick="() => OnSelect.InvokeAsync(CellData.Id)">
-                    <OutputView Outputs="CellData.Outputs" ExtendedMimeTypes="false" />
+                    <ErrorBoundary @ref="_outputErrorBoundary" @key="@OutputBoundaryKey">
+                        <ChildContent>
+                            <OutputView Outputs="CellData.Outputs" ExtendedMimeTypes="false" />
+                        </ChildContent>
+                        <ErrorContent>@RenderOutputError(context)</ErrorContent>
+                    </ErrorBoundary>
                 </div>
             }
             else
@@ -201,7 +206,12 @@
                      style="@OutputPreviewStyle"
                      data-cell-id="@CellData.Id"
                      @onclick="HandleOutputClick">
-                    <OutputView Outputs="CellData.Outputs" />
+                    <ErrorBoundary @ref="_outputErrorBoundary" @key="@OutputBoundaryKey">
+                        <ChildContent>
+                            <OutputView Outputs="CellData.Outputs" />
+                        </ChildContent>
+                        <ErrorContent>@RenderOutputError(context)</ErrorContent>
+                    </ErrorBoundary>
                 </div>
             }
         }
@@ -232,8 +242,23 @@
     [Parameter] public EventCallback<Guid> OnToggleSection { get; set; }
 
     private List<ToolbarActionInfo> _enabledCellActions = new();
+    private string? _enabledActionsSignature;
     private bool _showTypeDropdown;
     private bool _showLanguageDropdown;
+
+    // Output rendering is wrapped in an ErrorBoundary so a single output that throws during render
+    // degrades to an inline error card instead of tearing down the whole notebook renderer. The
+    // boundary is keyed by execution count, so re-running the cell starts a fresh (recovered) boundary;
+    // clearing the cell's outputs removes it entirely, and Retry recovers it in place.
+    private ErrorBoundary? _outputErrorBoundary;
+    private string OutputBoundaryKey => $"output-boundary-{CellData.ExecutionCount?.ToString() ?? "0"}";
+    private void RecoverOutputRender() => _outputErrorBoundary?.Recover();
+    private RenderFragment<Exception> RenderOutputError => renderError =>
+        @<div class="verso-output verso-output--error">
+            <div class="verso-output-error-name">This output could not be rendered</div>
+            <pre class="verso-output-error-content">@renderError.Message</pre>
+            <button class="verso-cell-btn verso-cell-btn--action" @onclick="RecoverOutputRender" title="Retry rendering this output">Retry</button>
+        </div>;
 
     // The type/language menus render in the browser top layer (popover) so they paint above the
     // composited Monaco editors of neighbouring cells. These refs let OnAfterRenderAsync show the
@@ -257,6 +282,11 @@
     };
 
     private bool _pendingAutoExecute;
+    // Latches the one-time auto-render request for non-editable cells (e.g. the parameters form) so a
+    // re-render that happens before the first render's output arrives does not re-request execution.
+    // A render-only cell never reports an executing state, so IsExecuting alone cannot guard against
+    // re-entrancy; without this latch the cell would repeatedly re-run and spin the UI.
+    private bool _autoExecuteRequested;
 
     private bool SupportsInputCollapse => IsEditable && string.Equals(CellData.Type, "code", StringComparison.OrdinalIgnoreCase);
 
@@ -335,21 +365,51 @@
         if (cellActions.Count == 0)
         {
             _enabledCellActions = new();
-            return;
+            _enabledActionsSignature = null;
+        }
+        else
+        {
+            // Query the host for enabled states only when an input that can affect them has changed.
+            // Blazor re-runs this method on every parent render, and during Run All the notebook re-renders
+            // once per streamed output; without this guard each of those re-renders issued a
+            // toolbar/getEnabledStates round-trip per cell, flooding the host's request channel.
+            var signature = string.Join(
+                "|",
+                cellActions.Count,
+                string.Join(",", cellActions.Select(a => a.ActionId)),
+                CellData.Id,
+                CellData.Outputs.Count,
+                IsSelected,
+                EffectiveStatus,
+                IsExecuting);
+
+            if (signature != _enabledActionsSignature)
+            {
+                var enabledStates = await Service.GetActionEnabledStatesAsync(
+                    ToolbarPlacement.CellToolbar,
+                    new List<Guid> { CellData.Id });
+
+                _enabledCellActions = cellActions
+                    .Where(a => enabledStates.GetValueOrDefault(a.ActionId, false)
+                                && !_hardcodedActionIds.Contains(a.ActionId))
+                    .ToList();
+                _enabledActionsSignature = signature;
+            }
         }
 
-        var enabledStates = await Service.GetActionEnabledStatesAsync(
-            ToolbarPlacement.CellToolbar,
-            new List<Guid> { CellData.Id });
-
-        _enabledCellActions = cellActions
-            .Where(a => enabledStates.GetValueOrDefault(a.ActionId, false)
-                        && !_hardcodedActionIds.Contains(a.ActionId))
-            .ToList();
-
-        // Schedule auto-execute for non-editable cells that have no outputs yet
-        if (!IsEditable && CellData.Outputs.Count == 0 && !IsExecuting)
+        // Auto-render non-editable cells (e.g. the parameters form) once on open when they have no
+        // outputs yet. The latch resets as soon as outputs exist, so clearing a cell's outputs re-renders
+        // the form, but it prevents the many re-renders that occur before the first output arrives from
+        // each re-triggering execution.
+        if (CellData.Outputs.Count > 0)
+        {
+            _autoExecuteRequested = false;
+        }
+        else if (!IsEditable && !IsExecuting && !_autoExecuteRequested)
+        {
             _pendingAutoExecute = true;
+            _autoExecuteRequested = true;
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Verso.Blazor.Shared/Components/Notebook/Cell.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/Cell.razor
@@ -2,6 +2,7 @@
 @using System.Text
 @using System.Text.Json
 @using Verso.Blazor.Shared.Models
+@implements IDisposable
 @inject INotebookService Service
 @inject IJSRuntime JS
 
@@ -246,10 +247,11 @@
     private bool _showTypeDropdown;
     private bool _showLanguageDropdown;
 
-    // Output rendering is wrapped in an ErrorBoundary so a single output that throws during render
-    // degrades to an inline error card instead of tearing down the whole notebook renderer. The
-    // boundary is keyed by execution count, so re-running the cell starts a fresh (recovered) boundary;
-    // clearing the cell's outputs removes it entirely, and Retry recovers it in place.
+    // OutputView isolates each output in its own per-output ErrorBoundary (the first line of
+    // defense); this cell-level boundary is the outer net for failures outside any per-output
+    // scope, so neither tears down the whole notebook renderer. It is keyed by execution count,
+    // so re-running the cell starts a fresh (recovered) boundary; clearing the cell's outputs
+    // removes it entirely, and Retry recovers it in place.
     private ErrorBoundary? _outputErrorBoundary;
     private string OutputBoundaryKey => $"output-boundary-{CellData.ExecutionCount?.ToString() ?? "0"}";
     private void RecoverOutputRender() => _outputErrorBoundary?.Recover();
@@ -350,7 +352,37 @@
             : $"{ts.TotalMinutes:F1}m";
     }
 
+    protected override void OnInitialized()
+    {
+        // Enabled states are computed host-side from more than this cell's render inputs: an
+        // extension's IsEnabled predicate can read variables, other cells, and kernel state, none
+        // of which the signature below can see. These events invalidate the cached signature and
+        // re-query so the toolbar does not go stale when that state changes on its own.
+        Service.OnVariablesChanged += HandleEnablementStateChanged;
+        Service.OnExtensionStatusChanged += HandleEnablementStateChanged;
+        Service.OnKernelRestarted += HandleEnablementStateChangedForKernel;
+    }
+
     protected override async Task OnParametersSetAsync()
+    {
+        await RefreshEnabledCellActionsAsync();
+
+        // Auto-render non-editable cells (e.g. the parameters form) once on open when they have no
+        // outputs yet. The latch resets as soon as outputs exist, so clearing a cell's outputs re-renders
+        // the form, but it prevents the many re-renders that occur before the first output arrives from
+        // each re-triggering execution.
+        if (CellData.Outputs.Count > 0)
+        {
+            _autoExecuteRequested = false;
+        }
+        else if (!IsEditable && !IsExecuting && !_autoExecuteRequested)
+        {
+            _pendingAutoExecute = true;
+            _autoExecuteRequested = true;
+        }
+    }
+
+    private async Task RefreshEnabledCellActionsAsync()
     {
         if (!Service.IsLoaded)
         {
@@ -366,50 +398,68 @@
         {
             _enabledCellActions = new();
             _enabledActionsSignature = null;
-        }
-        else
-        {
-            // Query the host for enabled states only when an input that can affect them has changed.
-            // Blazor re-runs this method on every parent render, and during Run All the notebook re-renders
-            // once per streamed output; without this guard each of those re-renders issued a
-            // toolbar/getEnabledStates round-trip per cell, flooding the host's request channel.
-            var signature = string.Join(
-                "|",
-                cellActions.Count,
-                string.Join(",", cellActions.Select(a => a.ActionId)),
-                CellData.Id,
-                CellData.Outputs.Count,
-                IsSelected,
-                EffectiveStatus,
-                IsExecuting);
-
-            if (signature != _enabledActionsSignature)
-            {
-                var enabledStates = await Service.GetActionEnabledStatesAsync(
-                    ToolbarPlacement.CellToolbar,
-                    new List<Guid> { CellData.Id });
-
-                _enabledCellActions = cellActions
-                    .Where(a => enabledStates.GetValueOrDefault(a.ActionId, false)
-                                && !_hardcodedActionIds.Contains(a.ActionId))
-                    .ToList();
-                _enabledActionsSignature = signature;
-            }
+            return;
         }
 
-        // Auto-render non-editable cells (e.g. the parameters form) once on open when they have no
-        // outputs yet. The latch resets as soon as outputs exist, so clearing a cell's outputs re-renders
-        // the form, but it prevents the many re-renders that occur before the first output arrives from
-        // each re-triggering execution.
-        if (CellData.Outputs.Count > 0)
+        // Query the host for enabled states only when an input that can affect them has changed.
+        // Blazor re-runs OnParametersSetAsync on every parent render, and during Run All the
+        // notebook re-renders once per streamed output; without this guard each of those
+        // re-renders issued a toolbar/getEnabledStates round-trip per cell, flooding the host's
+        // request channel. Host-side state the signature cannot see (variables, extensions,
+        // kernel) invalidates it through the events wired in OnInitialized.
+        var signature = string.Join(
+            "|",
+            cellActions.Count,
+            string.Join(",", cellActions.Select(a => a.ActionId)),
+            CellData.Id,
+            CellData.Type,
+            CellData.Language,
+            CellData.Outputs.Count,
+            IsSelected,
+            EffectiveStatus,
+            IsExecuting);
+
+        if (signature == _enabledActionsSignature) return;
+
+        var enabledStates = await Service.GetActionEnabledStatesAsync(
+            ToolbarPlacement.CellToolbar,
+            new List<Guid> { CellData.Id });
+
+        _enabledCellActions = cellActions
+            .Where(a => enabledStates.GetValueOrDefault(a.ActionId, false)
+                        && !_hardcodedActionIds.Contains(a.ActionId))
+            .ToList();
+        _enabledActionsSignature = signature;
+    }
+
+    // True while an invalidation-triggered refresh is queued, so a burst of host-side state
+    // changes coalesces into one re-query.
+    private bool _enablementRefreshScheduled;
+
+    private void HandleEnablementStateChanged()
+    {
+        _enabledActionsSignature = null;
+
+        if (_enablementRefreshScheduled) return;
+        _enablementRefreshScheduled = true;
+
+        // The event can arrive off the dispatcher, and a parent render (which would re-run
+        // OnParametersSetAsync) is not guaranteed to follow, so marshal and re-query directly.
+        _ = InvokeAsync(async () =>
         {
-            _autoExecuteRequested = false;
-        }
-        else if (!IsEditable && !IsExecuting && !_autoExecuteRequested)
-        {
-            _pendingAutoExecute = true;
-            _autoExecuteRequested = true;
-        }
+            _enablementRefreshScheduled = false;
+            await RefreshEnabledCellActionsAsync();
+            StateHasChanged();
+        });
+    }
+
+    private void HandleEnablementStateChangedForKernel(string? kernelId) => HandleEnablementStateChanged();
+
+    public void Dispose()
+    {
+        Service.OnVariablesChanged -= HandleEnablementStateChanged;
+        Service.OnExtensionStatusChanged -= HandleEnablementStateChanged;
+        Service.OnKernelRestarted -= HandleEnablementStateChangedForKernel;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Verso.Blazor.Shared/Components/Notebook/CellPropertiesPanel.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/CellPropertiesPanel.razor
@@ -53,10 +53,12 @@
             if (_subscribedService is not null)
             {
                 _subscribedService.OnCellExecuted -= HandleCellChanged;
+                _subscribedService.OnCellExecutionCompleted -= HandleCellCompleted;
                 _subscribedService.OnNotebookChanged -= HandleNotebookChanged;
             }
             _subscribedService = Service;
             Service.OnCellExecuted += HandleCellChanged;
+            Service.OnCellExecutionCompleted += HandleCellCompleted;
             Service.OnNotebookChanged += HandleNotebookChanged;
         }
 
@@ -111,6 +113,11 @@
         });
     }
 
+    // A cell finishing execution now raises only the per-cell completion event, not the parameterless
+    // OnCellExecuted, so listen here too to keep the panel refreshed after a run. The completed cell id
+    // is ignored: the panel always reloads whichever cell is currently selected, matching prior behavior.
+    private void HandleCellCompleted(Guid cellId) => HandleCellChanged();
+
     private async void HandleNotebookChanged()
     {
         await InvokeAsync(async () =>
@@ -125,6 +132,7 @@
         if (_subscribedService is not null)
         {
             _subscribedService.OnCellExecuted -= HandleCellChanged;
+            _subscribedService.OnCellExecutionCompleted -= HandleCellCompleted;
             _subscribedService.OnNotebookChanged -= HandleNotebookChanged;
         }
     }

--- a/src/Verso.Blazor.Shared/Components/Notebook/OutputView.razor
+++ b/src/Verso.Blazor.Shared/Components/Notebook/OutputView.razor
@@ -5,59 +5,77 @@
 
 @for (var outputIndex = 0; outputIndex < Outputs.Count; outputIndex++)
 {
-    var output = Outputs[outputIndex];
-    @if (output.IsError)
-    {
-        <div class="verso-output verso-output--error">
-            <div class="verso-output-error-name">@(output.ErrorName ?? "Error")</div>
-            <pre class="verso-output-error-content">@output.Content</pre>
-            @if (ExtendedMimeTypes && output.ErrorStackTrace is not null)
+    var index = outputIndex;
+    var output = Outputs[index];
+    @* Each output renders inside its own ErrorBoundary so one payload that throws during render
+       degrades to a single inline error card while sibling outputs keep rendering. The output
+       object is part of the boundary key (CellOutput is a record with value equality, so the
+       position disambiguates duplicates); replacing an output via re-run or an interaction update
+       therefore recreates the boundary and recovers without user action. Retry bumps
+       _retryVersion, which rotates every key and re-attempts all outputs. *@
+    <ErrorBoundary @key="(index, output, _retryVersion)">
+        <ChildContent>
+            @if (output.IsError)
             {
-                <pre class="verso-output-error-stack">@output.ErrorStackTrace</pre>
+                <div class="verso-output verso-output--error">
+                    <div class="verso-output-error-name">@(output.ErrorName ?? "Error")</div>
+                    <pre class="verso-output-error-content">@output.Content</pre>
+                    @if (ExtendedMimeTypes && output.ErrorStackTrace is not null)
+                    {
+                        <pre class="verso-output-error-stack">@output.ErrorStackTrace</pre>
+                    }
+                </div>
             }
-        </div>
-    }
-    else if (ExtendedMimeTypes && output.MimeType == "text/x-verso-mermaid")
-    {
-        <div class="verso-output verso-output--html verso-mermaid-container">
-            <pre class="mermaid">@output.Content</pre>
-        </div>
-    }
-    else if (output.MimeType == "text/html" || output.MimeType == "image/svg+xml")
-    {
-        @* @key forces Blazor to tear down and recreate the element when the output object
-           changes, rather than diffing MarkupString child nodes in place which can cause
-           removeChild errors when interactive elements (inputs, checkboxes) hold
-           browser-managed DOM state. CellOutput is a record (value equality), so the
-           position is part of the key: two identical outputs in one cell must not collide. *@
-        <div @key="(outputIndex, output)" class="verso-output verso-output--html">
-            @((MarkupString)output.Content)
-        </div>
-    }
-    else if (ExtendedMimeTypes && output.MimeType.StartsWith("image/"))
-    {
-        <div class="verso-output verso-output--html">
-            <img src="@($"data:{output.MimeType};base64,{output.Content}")" style="max-width:100%" />
-        </div>
-    }
-    else if (ExtendedMimeTypes && output.MimeType == "application/json")
-    {
-        <div class="verso-output verso-output--html">
-            @((MarkupString)RenderJsonTree(output.Content))
-        </div>
-    }
-    else if (ExtendedMimeTypes && output.MimeType == "text/csv")
-    {
-        <div class="verso-output verso-output--html">
-            @((MarkupString)RenderCsvTable(output.Content))
-        </div>
-    }
-    else
-    {
-        <div class="verso-output verso-output--text">
-            <pre>@output.Content</pre>
-        </div>
-    }
+            else if (ExtendedMimeTypes && output.MimeType == "text/x-verso-mermaid")
+            {
+                <div class="verso-output verso-output--html verso-mermaid-container">
+                    <pre class="mermaid">@output.Content</pre>
+                </div>
+            }
+            else if (output.MimeType == "text/html" || output.MimeType == "image/svg+xml")
+            {
+                @* @key forces Blazor to tear down and recreate the element when the output object
+                   changes, rather than diffing MarkupString child nodes in place which can cause
+                   removeChild errors when interactive elements (inputs, checkboxes) hold
+                   browser-managed DOM state. CellOutput is a record (value equality), so the
+                   position is part of the key: two identical outputs in one cell must not collide. *@
+                <div @key="(index, output)" class="verso-output verso-output--html">
+                    @((MarkupString)output.Content)
+                </div>
+            }
+            else if (ExtendedMimeTypes && output.MimeType.StartsWith("image/"))
+            {
+                <div class="verso-output verso-output--html">
+                    <img src="@($"data:{output.MimeType};base64,{output.Content}")" style="max-width:100%" />
+                </div>
+            }
+            else if (ExtendedMimeTypes && output.MimeType == "application/json")
+            {
+                <div class="verso-output verso-output--html">
+                    @((MarkupString)RenderJsonTree(output.Content))
+                </div>
+            }
+            else if (ExtendedMimeTypes && output.MimeType == "text/csv")
+            {
+                <div class="verso-output verso-output--html">
+                    @((MarkupString)RenderCsvTable(output.Content))
+                </div>
+            }
+            else
+            {
+                <div class="verso-output verso-output--text">
+                    <pre>@output.Content</pre>
+                </div>
+            }
+        </ChildContent>
+        <ErrorContent Context="renderError">
+            <div class="verso-output verso-output--error">
+                <div class="verso-output-error-name">This output could not be rendered</div>
+                <pre class="verso-output-error-content">@renderError.Message</pre>
+                <button class="verso-cell-btn verso-cell-btn--action" @onclick="RetryOutputRender" title="Retry rendering this output">Retry</button>
+            </div>
+        </ErrorContent>
+    </ErrorBoundary>
 }
 
 @code {
@@ -70,6 +88,12 @@
     /// used by non-editable cells: errors without stack traces, HTML and SVG, and plain text.
     /// </summary>
     [Parameter] public bool ExtendedMimeTypes { get; set; } = true;
+
+    // Part of every per-output ErrorBoundary key; incrementing it recreates the boundaries so
+    // Retry re-attempts rendering after an output has faulted.
+    private int _retryVersion;
+
+    private void RetryOutputRender() => _retryVersion++;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/Verso.Blazor.Wasm/Services/RemoteNotebookService.cs
+++ b/src/Verso.Blazor.Wasm/Services/RemoteNotebookService.cs
@@ -57,6 +57,14 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
     private readonly Dictionary<Guid, CancellationTokenSource> _debounceCts = new();
     private const int DebounceDelayMs = 250;
 
+    // ── Coalesced whole-page output notifications ───────────────────────
+    // A burst of Display() calls during Run All would otherwise raise OnOutputUpdated (and a whole-page
+    // StateHasChanged) once per output. Cell outputs are updated synchronously as each notification
+    // arrives; only the render notification is throttled to roughly one per frame, with a trailing raise
+    // guaranteeing the final state renders.
+    private bool _outputNotifyScheduled;
+    private const int OutputNotifyCoalesceMs = 32;
+
     // ── Events ──────────────────────────────────────────────────────────
     public event Action? OnCellExecuted;
     public event Action<Guid>? OnCellExecuting;
@@ -1574,7 +1582,7 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
                         foreach (var output in notif.Outputs ?? Enumerable.Empty<CellOutputDto>())
                             cell.Outputs.Add(MapOutputFromDto(output));
 
-                        OnOutputUpdated?.Invoke();
+                        NotifyOutputUpdatedCoalesced();
                         RaiseCellOutputUpdated(paramsJson!, cellId);
                         return;
                     }
@@ -1603,6 +1611,22 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
         catch (JsonException) { }
     }
 
+    // Throttle the whole-page output-update notification: schedule at most one raise per coalescing
+    // window during a burst. The trailing raise ensures the final output state is rendered.
+    private void NotifyOutputUpdatedCoalesced()
+    {
+        if (_outputNotifyScheduled) return;
+        _outputNotifyScheduled = true;
+        _ = FlushOutputNotifyAsync();
+    }
+
+    private async Task FlushOutputNotifyAsync()
+    {
+        await Task.Delay(OutputNotifyCoalesceMs);
+        _outputNotifyScheduled = false;
+        OnOutputUpdated?.Invoke();
+    }
+
     private void HandleCellExecutionState(string? paramsJson)
     {
         if (paramsJson is null) return;
@@ -1617,10 +1641,11 @@ public sealed class RemoteNotebookService : IIsolatedLayoutHost, IAsyncDisposabl
         }
         else
         {
+            // Only the per-cell completion event fires here. The parameterless OnCellExecuted is
+            // reserved for non-execution mutations (clear-outputs, toolbar actions); firing both on
+            // completion made every subscriber render twice per finished cell, which during Run All
+            // multiplied into a whole-page render storm.
             OnCellExecutionCompleted?.Invoke(id);
-            // Preserve the parameterless event so existing subscribers (e.g. StateHasChanged)
-            // continue to trigger a UI refresh per cell.
-            OnCellExecuted?.Invoke();
         }
     }
 

--- a/src/Verso.Blazor/Services/NotebookService.cs
+++ b/src/Verso.Blazor/Services/NotebookService.cs
@@ -492,8 +492,9 @@ public sealed class NotebookService : IAsyncDisposable
 
     private void HandleScaffoldCellExecuted(Guid cellId)
     {
+        // Only the per-cell completion event fires here; see RemoteNotebookService for why the
+        // parameterless OnCellExecuted is not also raised on completion.
         OnCellExecutionCompleted?.Invoke(cellId);
-        OnCellExecuted?.Invoke();
     }
 
     private void HandleExtensionStatusChanged(string extensionId, ExtensionStatus status)

--- a/src/Verso.Blazor/Services/ServerNotebookService.cs
+++ b/src/Verso.Blazor/Services/ServerNotebookService.cs
@@ -1405,8 +1405,9 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
         // parameters form) must not mark the notebook edited when they auto-render on open.
         if (CellTypePersistsOutputs(cellId))
             SetDirty(true);
+        // Only the per-cell completion event fires here; see RemoteNotebookService for why the
+        // parameterless OnCellExecuted is not also raised on completion.
         OnCellExecutionCompleted?.Invoke(cellId);
-        OnCellExecuted?.Invoke();
     }
 
     private void HandleScaffoldKernelRestarting(string? kernelId)
@@ -1422,10 +1423,30 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
         => OnKernelHealthChanged?.Invoke(
             new KernelHealthChangedEventArgs(KernelHealth.Faulted, ex.Message));
 
+    // Coalesce whole-page output-update notifications so a burst of Display() calls during Run All
+    // raises OnOutputUpdated (and a whole-page render) at most once per window rather than per output.
+    // Cell outputs are updated synchronously by the scaffold; only the render notification is throttled.
+    private bool _outputNotifyScheduled;
+    private const int OutputNotifyCoalesceMs = 32;
+
     private void HandleScaffoldCellOutputUpdated(Guid cellId)
     {
-        OnOutputUpdated?.Invoke();
+        NotifyOutputUpdatedCoalesced();
         RaiseCellOutputUpdated(cellId);
+    }
+
+    private void NotifyOutputUpdatedCoalesced()
+    {
+        if (_outputNotifyScheduled) return;
+        _outputNotifyScheduled = true;
+        _ = FlushOutputNotifyAsync();
+    }
+
+    private async Task FlushOutputNotifyAsync()
+    {
+        await Task.Delay(OutputNotifyCoalesceMs);
+        _outputNotifyScheduled = false;
+        OnOutputUpdated?.Invoke();
     }
 
     private async Task<string?> RequestInputFromUIAsync(

--- a/src/Verso.FSharp/Kernel/FSharpKernel.cs
+++ b/src/Verso.FSharp/Kernel/FSharpKernel.cs
@@ -129,51 +129,56 @@ public sealed class FSharpKernel : ILanguageKernel, IExtensionSettings
         return result;
     }
 
-    public Task InitializeAsync()
+    public async Task InitializeAsync()
     {
-        if (_initialized) return Task.CompletedTask;
+        if (_initialized) return;
 
         // Support re-initialization after disposal (kernel restart)
         _disposed = false;
 
-        _sessionManager = new FsiSessionManager();
-        _sessionManager.Initialize(_options);
-
-        // Evaluate default open declarations silently
-        var opens = _options.DefaultOpens ?? FSharpKernelOptions.DefaultOpenNamespaces;
-        foreach (var ns in opens)
+        // Create the FSI session on a thread-pool thread (mirroring PythonKernel). FCS blocks the
+        // creating thread internally while posting async continuations to the ambient
+        // SynchronizationContext, so building the session inline on a context-bound caller (e.g.
+        // the Blazor Server renderer dispatcher during a kernel restart) deadlocks it.
+        await Task.Run(() =>
         {
-            _sessionManager.EvalSilent($"open {ns}");
-        }
+            _sessionManager = new FsiSessionManager();
+            _sessionManager.Initialize(_options);
 
-        // Add Verso.Abstractions reference so IVariableStore API is available in F# cells
-        var abstractionsAssembly = typeof(Verso.Abstractions.IVariableStore).Assembly.Location;
-        if (!string.IsNullOrEmpty(abstractionsAssembly))
-        {
-            _sessionManager.EvalSilent($"#r @\"{abstractionsAssembly}\"");
-        }
+            // Evaluate default open declarations silently
+            var opens = _options.DefaultOpens ?? FSharpKernelOptions.DefaultOpenNamespaces;
+            foreach (var ns in opens)
+            {
+                _sessionManager.EvalSilent($"open {ns}");
+            }
 
-        _variableBridge = new VariableBridge(_options);
-        _variablesInjected = false;
-        _parametersInjected = false;
-        _executionLock = new SemaphoreSlim(1, 1);
+            // Add Verso.Abstractions reference so IVariableStore API is available in F# cells
+            var abstractionsAssembly = typeof(Verso.Abstractions.IVariableStore).Assembly.Location;
+            if (!string.IsNullOrEmpty(abstractionsAssembly))
+            {
+                _sessionManager.EvalSilent($"#r @\"{abstractionsAssembly}\"");
+            }
 
-        // Initialize IntelliSense infrastructure
-        _checkerManager = new FSharpCheckerManager();
-        _checkerManager.Initialize();
+            _variableBridge = new VariableBridge(_options);
+            _variablesInjected = false;
+            _parametersInjected = false;
+            _executionLock = new SemaphoreSlim(1, 1);
 
-        _projectContext = new FSharpProjectContext(
-            opens,
-            _sessionManager.ResolvedArgs);
+            // Initialize IntelliSense infrastructure
+            _checkerManager = new FSharpCheckerManager();
+            _checkerManager.Initialize();
 
-        // Initialize NuGet and script directive processors
-        _nugetProcessor = new NuGetReferenceProcessor();
-        _nugetProcessor.ProbeNuGetSupport(_sessionManager);
-        _scriptDirectiveProcessor = new ScriptDirectiveProcessor();
+            _projectContext = new FSharpProjectContext(
+                opens,
+                _sessionManager.ResolvedArgs);
+
+            // Initialize NuGet and script directive processors
+            _nugetProcessor = new NuGetReferenceProcessor();
+            _nugetProcessor.ProbeNuGetSupport(_sessionManager);
+            _scriptDirectiveProcessor = new ScriptDirectiveProcessor();
+        }).ConfigureAwait(false);
 
         _initialized = true;
-
-        return Task.CompletedTask;
     }
 
     public async Task<IReadOnlyList<CellOutput>> ExecuteAsync(string code, IExecutionContext context)

--- a/tests/Verso.Blazor.Shared.Tests/CellTests.cs
+++ b/tests/Verso.Blazor.Shared.Tests/CellTests.cs
@@ -322,6 +322,60 @@ public sealed class CellTests : BunitTestContext
         };
     }
 
+    [TestMethod]
+    public void CellToolbar_QueriesEnabledStates_OnlyWhenInputsChange()
+    {
+        // A non-hardcoded cell-toolbar action (like the built-in Clear Output) opens the enabled-state
+        // path; run-cell is hardcoded and would not.
+        _service.ToolbarActions.Add(new ToolbarActionInfo(
+            "verso.action.clear-cell-output", "Clear Output", null, ToolbarPlacement.CellToolbar, 31));
+        _service.ActionEnabledStates["verso.action.clear-cell-output"] = true;
+
+        var cell = CreateCodeCell("var x = 1;");
+        var cut = RenderCell(cell);
+
+        // Initial render queries the host exactly once.
+        Assert.AreEqual(1, _service.GetActionEnabledStatesCallCount);
+
+        // Re-supplying identical parameters (what the parent does on every whole-notebook re-render,
+        // e.g. once per streamed output during Run All) must not re-query the host.
+        cut.SetParametersAndRender(p => p.Add(c => c.IsSelected, false));
+        cut.SetParametersAndRender(p => p.Add(c => c.IsSelected, false));
+        cut.SetParametersAndRender(p => p.Add(c => c.IsSelected, false));
+        Assert.AreEqual(1, _service.GetActionEnabledStatesCallCount);
+
+        // Changing an input that affects enablement (selection) re-queries exactly once more.
+        cut.SetParametersAndRender(p => p.Add(c => c.IsSelected, true));
+        Assert.AreEqual(2, _service.GetActionEnabledStatesCallCount);
+    }
+
+    [TestMethod]
+    public void NonEditableCell_AutoRenders_Once_AcrossReRenders()
+    {
+        // Loose JS interop so the non-editable cell's OnAfterRender lifecycle runs without stubbing
+        // every JS call; the auto-render path under test is pure C#.
+        TestContext!.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var cell = CreateCodeCell(string.Empty);
+        var runCount = 0;
+
+        var cut = RenderComponent<Cell>(p => p
+            .Add(c => c.CellData, cell)
+            .Add(c => c.IsEditable, false)
+            .Add(c => c.OnRunCell, Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Guid>(this, _ => runCount++)));
+
+        // A non-editable cell with no outputs (e.g. the parameters form) auto-renders exactly once on open.
+        Assert.AreEqual(1, runCount);
+
+        // Re-renders that occur before the first output arrives (outputs still empty, and a render-only
+        // cell never reports an executing state) must NOT re-trigger execution; otherwise the cell spins
+        // and can lock the UI. This is the regression the issue #83 fixes must not introduce.
+        cut.SetParametersAndRender(p => p.Add(c => c.IsSelected, false));
+        cut.SetParametersAndRender(p => p.Add(c => c.IsSelected, true));
+        cut.SetParametersAndRender(p => p.Add(c => c.IsSelected, false));
+        Assert.AreEqual(1, runCount);
+    }
+
     private IRenderedComponent<Cell> RenderCell(
         CellModel cell,
         bool isSelected = false,

--- a/tests/Verso.Blazor.Shared.Tests/CellTests.cs
+++ b/tests/Verso.Blazor.Shared.Tests/CellTests.cs
@@ -376,6 +376,48 @@ public sealed class CellTests : BunitTestContext
         Assert.AreEqual(1, runCount);
     }
 
+    [TestMethod]
+    public void CellToolbar_RequeriesEnabledStates_WhenHostSideStateChanges()
+    {
+        _service.ToolbarActions.Add(new ToolbarActionInfo(
+            "verso.action.clear-cell-output", "Clear Output", null, ToolbarPlacement.CellToolbar, 31));
+        _service.ActionEnabledStates["verso.action.clear-cell-output"] = true;
+
+        var cell = CreateCodeCell("var x = 1;");
+        var cut = RenderCell(cell);
+        Assert.AreEqual(1, _service.GetActionEnabledStatesCallCount);
+
+        // An extension's IsEnabled predicate can depend on host-side state (variables, other
+        // cells, kernel), so these events must re-query even though none of this cell's own
+        // render inputs changed and no parent re-render is guaranteed to follow.
+        _service.RaiseVariablesChanged();
+        cut.WaitForAssertion(() => Assert.AreEqual(2, _service.GetActionEnabledStatesCallCount));
+
+        _service.RaiseKernelRestarted();
+        cut.WaitForAssertion(() => Assert.AreEqual(3, _service.GetActionEnabledStatesCallCount));
+
+        _service.RaiseExtensionStatusChanged();
+        cut.WaitForAssertion(() => Assert.AreEqual(4, _service.GetActionEnabledStatesCallCount));
+    }
+
+    [TestMethod]
+    public void CellToolbar_RequeriesEnabledStates_WhenCellLanguageChanges()
+    {
+        _service.ToolbarActions.Add(new ToolbarActionInfo(
+            "verso.action.clear-cell-output", "Clear Output", null, ToolbarPlacement.CellToolbar, 31));
+        _service.ActionEnabledStates["verso.action.clear-cell-output"] = true;
+
+        var cell = CreateCodeCell("var x = 1;");
+        var cut = RenderCell(cell);
+        Assert.AreEqual(1, _service.GetActionEnabledStatesCallCount);
+
+        // Language-specific actions change availability with the cell language. The CellData
+        // reference stays the same, so only the language field distinguishes the signatures.
+        cell.Language = "python";
+        cut.SetParametersAndRender(p => p.Add(c => c.CellData, cell));
+        Assert.AreEqual(2, _service.GetActionEnabledStatesCallCount);
+    }
+
     private IRenderedComponent<Cell> RenderCell(
         CellModel cell,
         bool isSelected = false,

--- a/tests/Verso.Blazor.Shared.Tests/Fakes/FakeNotebookService.cs
+++ b/tests/Verso.Blazor.Shared.Tests/Fakes/FakeNotebookService.cs
@@ -246,9 +246,14 @@ public sealed class FakeNotebookService : INotebookService
     public IReadOnlyList<ToolbarActionInfo> GetToolbarActions(ToolbarPlacement placement)
         => ToolbarActions.Where(a => a.Placement == placement).ToList();
 
+    public int GetActionEnabledStatesCallCount { get; private set; }
+
     public Task<Dictionary<string, bool>> GetActionEnabledStatesAsync(
         ToolbarPlacement placement, IReadOnlyList<Guid> selectedCellIds)
-        => Task.FromResult(ActionEnabledStates);
+    {
+        GetActionEnabledStatesCallCount++;
+        return Task.FromResult(ActionEnabledStates);
+    }
 
     public List<string> ExecutedActionIds { get; } = new();
 

--- a/tests/Verso.Blazor.Shared.Tests/MonacoEditorTests.cs
+++ b/tests/Verso.Blazor.Shared.Tests/MonacoEditorTests.cs
@@ -1,0 +1,42 @@
+namespace Verso.Blazor.Shared.Tests;
+
+[TestClass]
+public sealed class MonacoEditorTests : BunitTestContext
+{
+    private IRenderedComponent<MonacoEditor> Render(string value = "var x = 1;", string language = "csharp")
+    {
+        TestContext!.JSInterop.Mode = JSRuntimeMode.Loose;
+        return TestContext.RenderComponent<MonacoEditor>(p => p
+            .Add(e => e.Value, value)
+            .Add(e => e.Language, language));
+    }
+
+    private int SetLanguageCallCount()
+        => TestContext!.JSInterop.Invocations.Count(i => i.Identifier == "versoMonaco.setLanguage");
+
+    [TestMethod]
+    public void SetLanguage_NotCalled_WhenLanguageUnchanged()
+    {
+        var cut = Render();
+
+        // The editor is created with its initial language, so re-renders with the same language
+        // must not issue another interop call. During Run All every code cell re-renders once per
+        // coalesced output flush; an unconditional call here floods the webview main thread.
+        cut.SetParametersAndRender(p => p.Add(e => e.Value, "var x = 1;"));
+        cut.SetParametersAndRender(p => p.Add(e => e.Value, "var x = 1;"));
+
+        Assert.AreEqual(0, SetLanguageCallCount());
+    }
+
+    [TestMethod]
+    public void SetLanguage_CalledOnce_WhenLanguageChanges()
+    {
+        var cut = Render();
+
+        cut.SetParametersAndRender(p => p.Add(e => e.Language, "python"));
+        Assert.AreEqual(1, SetLanguageCallCount());
+
+        cut.SetParametersAndRender(p => p.Add(e => e.Language, "python"));
+        Assert.AreEqual(1, SetLanguageCallCount());
+    }
+}

--- a/tests/Verso.Blazor.Shared.Tests/OutputViewTests.cs
+++ b/tests/Verso.Blazor.Shared.Tests/OutputViewTests.cs
@@ -124,4 +124,54 @@ public sealed class OutputViewTests : BunitTestContext
         StringAssert.Contains(outputs[0].TextContent, "first");
         StringAssert.Contains(outputs[1].TextContent, "second");
     }
+
+    [TestMethod]
+    public void ThrowingOutput_DegradesToErrorCard_WithoutTakingDownSiblings()
+    {
+        // A null MIME type is a malformed payload: the MIME dispatch throws while rendering it.
+        var outputs = new List<CellOutput>
+        {
+            CellOutput.Html("<b>before</b>"),
+            new(null!, "malformed"),
+            CellOutput.Plain("after")
+        };
+
+        var cut = Render(outputs);
+
+        // Only the bad output degrades to an error card; its siblings still render.
+        StringAssert.Contains(cut.Markup, "before");
+        StringAssert.Contains(cut.Markup, "after");
+        StringAssert.Contains(cut.Markup, "This output could not be rendered");
+    }
+
+    [TestMethod]
+    public void FaultedOutputBoundary_Recovers_WhenOutputIsReplaced()
+    {
+        var cut = Render(new List<CellOutput> { new(null!, "malformed") });
+        StringAssert.Contains(cut.Markup, "This output could not be rendered");
+
+        // Re-runs and interaction updates replace the output object; the boundary key includes
+        // the output, so the replacement recreates the boundary and recovers without user action.
+        cut.SetParametersAndRender(p => p.Add(o => o.Outputs,
+            new List<CellOutput> { CellOutput.Html("<i>fixed</i>") }));
+
+        Assert.IsFalse(cut.Markup.Contains("This output could not be rendered"));
+        StringAssert.Contains(cut.Markup, "fixed");
+    }
+
+    [TestMethod]
+    public void FaultedOutputBoundary_Recovers_OnRetryClick()
+    {
+        var outputs = new List<CellOutput> { new(null!, "malformed") };
+        var cut = Render(outputs);
+        StringAssert.Contains(cut.Markup, "This output could not be rendered");
+
+        // The outputs list is mutated in place (no parameter change reaches the component), so
+        // only the Retry button's key rotation can pick up the repaired content.
+        outputs[0] = CellOutput.Plain("now fine");
+        cut.Find("button[title='Retry rendering this output']").Click();
+
+        Assert.IsFalse(cut.Markup.Contains("This output could not be rendered"));
+        StringAssert.Contains(cut.Markup, "now fine");
+    }
 }


### PR DESCRIPTION
This pull request introduces several performance and reliability improvements to notebook cell rendering, toolbar state management, and event handling in the Verso Blazor notebook UI. The main changes focus on reducing unnecessary host queries and UI renders, improving error resilience in cell output rendering, and ensuring non-editable cells auto-render only once per open. The changes also update event handling to avoid redundant renders and add targeted tests for these behaviors.

**Performance and UI rendering improvements:**

* Cell output rendering is now wrapped in an `ErrorBoundary`, so if a single output throws during render, only that output degrades to an inline error card instead of breaking the entire notebook renderer. The boundary is keyed by execution count to recover cleanly on re-run or output clear. (`Cell.razor`) [[1]](diffhunk://#diff-58eea11af89839d5e38dde57cdbb17d71236d24c3e421914a9ef88b9bdeeea3cR146-R151) [[2]](diffhunk://#diff-58eea11af89839d5e38dde57cdbb17d71236d24c3e421914a9ef88b9bdeeea3cR209-R214) [[3]](diffhunk://#diff-58eea11af89839d5e38dde57cdbb17d71236d24c3e421914a9ef88b9bdeeea3cR245-R262)
* Whole-page output-update notifications are now coalesced: a burst of output updates (e.g., during "Run All") triggers at most one UI update per window, reducing render storms and improving responsiveness. (`RemoteNotebookService.cs`, `ServerNotebookService.cs`) [[1]](diffhunk://#diff-8473bf06f3feb09ac7cfe1a9b174960bedcb6bc31b42d7df203af7df269a56f2R60-R67) [[2]](diffhunk://#diff-8473bf06f3feb09ac7cfe1a9b174960bedcb6bc31b42d7df203af7df269a56f2L1577-R1585) [[3]](diffhunk://#diff-8473bf06f3feb09ac7cfe1a9b174960bedcb6bc31b42d7df203af7df269a56f2R1614-R1629) [[4]](diffhunk://#diff-5bf77b37e9b88e30da52a4031af507a377c6d1d3952b4ebdacb76ffca36b7477R1426-R1451)

**Toolbar and cell execution logic:**

* The cell toolbar now queries enabled states from the host only when relevant inputs change (e.g., selection, output count, execution state), preventing redundant host round-trips on every parent render. (`Cell.razor`, `CellTests.cs`, `FakeNotebookService.cs`) [[1]](diffhunk://#diff-58eea11af89839d5e38dde57cdbb17d71236d24c3e421914a9ef88b9bdeeea3cL338-R387) [[2]](diffhunk://#diff-e43b614097dc0c4fa273504c3233a503fcfdbf16f6586a6d44cdb18a45e1351aR249-R256) [[3]](diffhunk://#diff-dae91ff1e0a80a4b836361a761049b6ff6f45aa7f83969c59b3a0ede3a1f1875R325-R378)
* Non-editable cells (like parameter forms) auto-render exactly once on open when empty, using a latch to prevent repeated execution triggers during rapid re-renders. (`Cell.razor`, `CellTests.cs`) [[1]](diffhunk://#diff-58eea11af89839d5e38dde57cdbb17d71236d24c3e421914a9ef88b9bdeeea3cR285-R289) [[2]](diffhunk://#diff-58eea11af89839d5e38dde57cdbb17d71236d24c3e421914a9ef88b9bdeeea3cR396-R412) [[3]](diffhunk://#diff-dae91ff1e0a80a4b836361a761049b6ff6f45aa7f83969c59b3a0ede3a1f1875R325-R378)

**Event handling and reliability:**

* The parameterless `OnCellExecuted` event is no longer raised on cell completion—only the per-cell `OnCellExecutionCompleted` event fires, avoiding duplicate renders per finished cell and reducing UI thrash during batch operations. (`RemoteNotebookService.cs`, `NotebookService.cs`, `ServerNotebookService.cs`, `CellPropertiesPanel.razor`) [[1]](diffhunk://#diff-8473bf06f3feb09ac7cfe1a9b174960bedcb6bc31b42d7df203af7df269a56f2R1644-L1623) [[2]](diffhunk://#diff-7afdcd7821a4e83eda2d4e6778387e86a3bf7c96aec880d00a2b69832b1490b5R495-L496) [[3]](diffhunk://#diff-5bf77b37e9b88e30da52a4031af507a377c6d1d3952b4ebdacb76ffca36b7477R1408-L1409) [[4]](diffhunk://#diff-afaad43a3afee09d674602da3ffb9236ef02423c2d3784b1739d6a40ac44ab96R56-R61) [[5]](diffhunk://#diff-afaad43a3afee09d674602da3ffb9236ef02423c2d3784b1739d6a40ac44ab96R116-R120) [[6]](diffhunk://#diff-afaad43a3afee09d674602da3ffb9236ef02423c2d3784b1739d6a40ac44ab96R135)

**Testing:**

* New tests are added to verify that cell toolbar enabled-state queries and non-editable cell auto-rendering both occur only when necessary, preventing regressions. (`CellTests.cs`, `FakeNotebookService.cs`) [[1]](diffhunk://#diff-dae91ff1e0a80a4b836361a761049b6ff6f45aa7f83969c59b3a0ede3a1f1875R325-R378) [[2]](diffhunk://#diff-e43b614097dc0c4fa273504c3233a503fcfdbf16f6586a6d44cdb18a45e1351aR249-R256)

These changes collectively improve notebook UI performance, reliability, and maintainability, especially during batch operations and complex output rendering scenarios.