### PR TITLE
Add Markdown support and improve cell preview interaction

### DIFF
--- a/docs/extensions/extension-interfaces.md
+++ b/docs/extensions/extension-interfaces.md
@@ -309,6 +309,7 @@ Serializes and deserializes notebooks to and from file formats. The host selects
 | `SerializeAsync(NotebookModel)` | `Task<string>` | Converts a `NotebookModel` to its serialized string form. |
 | `DeserializeAsync(string)` | `Task<NotebookModel>` | Parses serialized content into a `NotebookModel`. |
 | `CanImport(string)` | `bool` | Checks if this serializer can import the file at the given path. |
+| `PreservesFormatByDefault` | `bool` | Whether this format is auto-selected on save without an explicit opt-in setting or flag. Default interface member, defaults to `false`. |
 
 ### Lifecycle
 

--- a/samples/notebooks/sample-markdown.md
+++ b/samples/notebooks/sample-markdown.md
@@ -1,0 +1,123 @@
+# The Birthday Paradox
+
+You are reading a plain Markdown file that is also a Verso notebook. On GitHub it renders as an ordinary article. Opened in Verso (right-click the file in VS Code and choose **Open in Verso**, or run `verso serve sample-markdown.md`), every fenced C# block below becomes an executable cell, so you can run the argument instead of just reading it.
+
+The question: how many people do you need in a room before it is more likely than not that two of them share a birthday?
+
+Most people guess somewhere near 180, reasoning that you need to cover half of the 365 possible days. The real answer is 23. This notebook shows why, three different ways.
+
+## 1. The exact calculation
+
+Rather than asking "what is the chance two people match", flip it around: what is the chance that *nobody* matches? Each new person must avoid every birthday already taken, so the probabilities multiply and shrink fast.
+
+```csharp
+double pAllDistinct = 1.0;
+for (int person = 1; person < 23; person++)
+    pAllDistinct *= (365.0 - person) / 365.0;
+
+Console.WriteLine($"Chance of a shared birthday among 23 people: {1 - pAllDistinct:P2}");
+```
+
+Run the cell above and you get just over 50 percent. Twenty-three people, better than a coin flip.
+
+## 2. Do not trust the algebra? Simulate it
+
+A Monte Carlo check: fill a room with 23 random birthdays, see if any collide, repeat a hundred thousand times.
+
+```csharp
+var random = new Random(2026);
+const int trials = 100_000;
+int trialsWithSharedBirthday = 0;
+
+for (int trial = 0; trial < trials; trial++)
+{
+    var seenBirthdays = new HashSet<int>();
+    for (int person = 0; person < 23; person++)
+    {
+        if (!seenBirthdays.Add(random.Next(365)))
+        {
+            trialsWithSharedBirthday++;
+            break;
+        }
+    }
+}
+
+Console.WriteLine($"Simulated over {trials:N0} trials: {(double)trialsWithSharedBirthday / trials:P2}");
+```
+
+The simulation follows this loop for every trial:
+
+```mermaid
+%%{init: {'theme':'dark'}}%%
+flowchart TD
+    A[Start a trial] --> B[Draw a random birthday]
+    B --> C{Seen this day already?}
+    C -- yes --> D[Count the trial as a shared-birthday hit]
+    C -- no --> E{23 people drawn?}
+    E -- no --> B
+    E -- yes --> F[No collision in this trial]
+    D --> G[Next trial]
+    F --> G
+```
+
+The diagram is a Mermaid cell in Verso and a Mermaid code block on GitHub, so it renders in both places. Expect the simulated figure to land within a fraction of a percent of the exact one, roughly like this:
+
+```
+Chance of a shared birthday among 23 people: 50.73%
+Simulated over 100,000 trials: 50.58%
+```
+
+That last block has no language tag, so Verso keeps it as part of the prose rather than turning it into a code cell. Untagged fences are how you quote expected output, logs, or transcripts inside a notebook.
+
+## 3. The intuition: count pairs, not people
+
+The paradox stops being paradoxical once you count the right thing. Twenty-three people do not give you 23 chances of a match. Every *pair* of people is a chance, and pairs grow quadratically.
+
+```csharp
+int people = 23;
+int pairs = people * (people - 1) / 2;
+
+Console.WriteLine($"{people} people form {pairs} distinct pairs.");
+Console.WriteLine($"Chance that none of those pairs match, approximately: {Math.Pow(364.0 / 365.0, pairs):P2}");
+```
+
+Two hundred fifty-three lottery tickets, each with a 1 in 365 chance, is a very different bet than the one your intuition priced.
+
+## How steep is the curve?
+
+The probability climbs startlingly fast. This cell sketches the whole curve as a bar chart in plain text.
+
+```csharp
+Console.WriteLine("People  Chance   ");
+for (int people = 5; people <= 70; people += 5)
+{
+    double allDistinct = 1.0;
+    for (int k = 1; k < people; k++)
+        allDistinct *= (365.0 - k) / 365.0;
+
+    var bar = new string('#', (int)Math.Round((1 - allDistinct) * 40));
+    Console.WriteLine($"{people,6}  {1 - allDistinct,7:P1}  {bar}");
+}
+```
+
+By 50 people the odds pass 97 percent. By 70 they are within rounding distance of certainty, while still covering less than a fifth of the calendar.
+
+## Try it yourself
+
+Every cell above is editable. Some experiments worth a minute each:
+
+- Change `365` to `366` in the first cell. How much does one extra day move the threshold?
+- Binary-search the first cell by hand: what head count first pushes the chance past 99 percent?
+- Change the simulation seed and rerun. How much do 100,000 trials wobble between runs?
+- Add a new C# cell that finds the smallest group where a shared birthday is more likely than not, by looping until the probability crosses 0.5.
+
+## How this file works
+
+A few rules govern how Verso reads and writes Markdown notebooks:
+
+- Prose lives in markdown cells. A top-level fenced code block whose language tag Verso recognizes (`csharp`, `fsharp`, `python`, `javascript`, `typescript`, `pwsh`, `sql`, `html`, `mermaid`, and their short aliases) becomes a cell of the matching kind.
+- Untagged or unrecognized fences, indented code, and fences nested inside quotes or lists stay part of the prose, like the expected-output block earlier.
+- Saving writes plain Markdown back to this same file, and cell outputs are never persisted, so the file stays clean in version control and readable everywhere Markdown renders.
+- When a notebook outgrows Markdown (persistent outputs, custom layouts, parameters), use **Export, then Verso** in the toolbar to produce a `.verso` copy, or run `verso convert sample-markdown.md --to verso`.
+
+That makes this format a good fit for material meant to be read and run: tutorials, runnable documentation, lab exercises, and articles like this one, whether a person wrote them or an AI did.

--- a/src/Verso.Abstractions/Extensions/INotebookSerializer.cs
+++ b/src/Verso.Abstractions/Extensions/INotebookSerializer.cs
@@ -37,4 +37,12 @@ public interface INotebookSerializer : IExtension
     /// <param name="filePath">Absolute or relative path to the file.</param>
     /// <returns><c>true</c> if this serializer can import the file; otherwise <c>false</c>.</returns>
     bool CanImport(string filePath);
+
+    /// <summary>
+    /// Whether this format is automatically selected when saving a notebook whose file path this
+    /// serializer handles, without requiring an explicit opt-in such as a preserve-format setting
+    /// or command-line flag. Defaults to <c>false</c>, which keeps the host's convert-to-native
+    /// behavior for formats that opt out.
+    /// </summary>
+    bool PreservesFormatByDefault => false;
 }

--- a/src/Verso.Blazor.Shared/wwwroot/js/cell-interact-interop.js
+++ b/src/Verso.Blazor.Shared/wwwroot/js/cell-interact-interop.js
@@ -150,14 +150,20 @@ window.versoCellMenu = (function () {
  *
  * A rendered (collapsed-input) cell shows its output as a preview, and a single click on that
  * preview selects the cell, which swaps in the editor. That is the right gesture for plain
- * content, but it also fires when the output contains interactive controls (a button, an input,
- * a link, a web component), so clicking a widget would yank the cell into edit mode instead of
- * letting the widget respond.
+ * content, but two kinds of click must not trigger it:
  *
- * This installs one listener that, when a click lands on an interactive element inside a
- * clickable preview, stops the event before it reaches the notebook's delegated click handler.
- * The control still receives the click in the target phase, so it works normally; the cell just
- * stays rendered. Clicking any non-interactive part of the preview still enters edit mode.
+ *   - A click on an interactive control inside the output (a button, an input, a link, a web
+ *     component). The widget should respond; the cell should stay rendered.
+ *   - The click that ends a drag-selection of preview text. Selecting the cell unmounts the
+ *     preview DOM to make room for the editor, which destroys the highlight before it can be
+ *     copied. A plain click is unaffected because the browser collapses any selection on
+ *     mousedown, so by the time its click event fires there is no live selection; only a drag
+ *     (or a shift-click extension) reaches the click event with one.
+ *
+ * This installs one listener that stops such clicks before they reach the notebook's delegated
+ * click handler. For the interactive case the control still receives the click in the target
+ * phase, so it works normally. Clicking any non-interactive part of the preview without a live
+ * selection still enters edit mode.
  *
  * The walk uses event.composedPath() rather than event.target so it sees through Shadow DOM:
  * clicks inside a web component's shadow root are retargeted to the host element by the time they
@@ -176,6 +182,19 @@ window.versoCellMenu = (function () {
         '[contenteditable=""], [contenteditable="true"], ' +
         '[role="button"], [role="link"], [role="checkbox"], [role="tab"], ' +
         '[data-verso-interactive]';
+
+    function hasSelectionWithin(previewEl) {
+        var sel = window.getSelection ? window.getSelection() : null;
+        if (!sel || sel.isCollapsed || sel.rangeCount === 0) return false;
+        // Only honor a selection that actually involves this preview. A leftover selection
+        // elsewhere on the page (mousedown normally clears one, but not in every engine and
+        // not for shift-clicks) should not block editing this cell.
+        for (var i = 0; i < sel.rangeCount; i++) {
+            var range = sel.getRangeAt(i);
+            if (range.intersectsNode && range.intersectsNode(previewEl)) return true;
+        }
+        return false;
+    }
 
     function isInteractive(el) {
         // A standard control, an ARIA control, or an author opt-in.
@@ -197,9 +216,10 @@ window.versoCellMenu = (function () {
             var node = path[i];
             if (!node || node.nodeType !== 1) continue;        // elements only
             if (node.classList && node.classList.contains(PREVIEW_CLASS)) {
-                // Reached the edit-trigger surface. If anything below it was interactive, let the
-                // control keep the click and leave the cell rendered.
-                if (sawInteractive) e.stopPropagation();
+                // Reached the edit-trigger surface. If anything below it was interactive, or the
+                // click is the tail of a drag that selected text in this preview, leave the cell
+                // rendered.
+                if (sawInteractive || hasSelectionWithin(node)) e.stopPropagation();
                 return;
             }
             if (isInteractive(node)) sawInteractive = true;

--- a/src/Verso.Blazor/Components/DiffSourcePickerDialog.razor
+++ b/src/Verso.Blazor/Components/DiffSourcePickerDialog.razor
@@ -51,7 +51,7 @@
 
     private string Prompt => IsGitRef
         ? "Branch, tag, or commit"
-        : "Path to a notebook file (.verso, .ipynb, .dib)";
+        : "Path to a notebook file (.verso, .ipynb, .md, .dib)";
 
     private string Placeholder => IsGitRef ? "main" : "/path/to/notebook.verso";
 

--- a/src/Verso.Blazor/Components/Pages/NotebookPage.razor
+++ b/src/Verso.Blazor/Components/Pages/NotebookPage.razor
@@ -106,7 +106,7 @@
     {
         <div class="verso-welcome">
             <h1>Verso Notebook</h1>
-            <p>Create a new notebook or open an existing <code>.verso</code> or <code>.ipynb</code> file to get started.</p>
+            <p>Create a new notebook or open an existing <code>.verso</code>, <code>.ipynb</code>, or <code>.md</code> file to get started.</p>
             <button class="verso-welcome-btn" @onclick="HandleNew">New Notebook</button>
         </div>
     }
@@ -866,7 +866,8 @@
         {
             _error = null;
 
-            if (!path.EndsWith(".verso", StringComparison.OrdinalIgnoreCase))
+            var preservesFormat = Service is ServerNotebookService svc && svc.PreservesFormat(path);
+            if (!preservesFormat && !path.EndsWith(".verso", StringComparison.OrdinalIgnoreCase))
                 path = System.IO.Path.ChangeExtension(path, ".verso");
 
             await Service.SaveAsync(path);

--- a/src/Verso.Blazor/Services/BlazorToolbarActionContext.cs
+++ b/src/Verso.Blazor/Services/BlazorToolbarActionContext.cs
@@ -58,7 +58,7 @@ public sealed class BlazorToolbarActionContext : IToolbarActionContext
         public BlazorNotebookMetadata(Scaffold scaffold) => _scaffold = scaffold;
         public string? Title => _scaffold.Title;
         public string? DefaultKernelId => _scaffold.DefaultKernelId;
-        public string? FilePath => null;
+        public string? FilePath => _scaffold.FilePath;
         public Dictionary<string, NotebookParameterDefinition>? Parameters => _scaffold.Notebook.Parameters;
     }
 }

--- a/src/Verso.Blazor/Services/ServerNotebookService.cs
+++ b/src/Verso.Blazor/Services/ServerNotebookService.cs
@@ -473,19 +473,28 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
     {
         if (_scaffold is null) return;
 
-        var json = await PrepareSerializedContentAsync();
+        var json = await PrepareSerializedContentAsync(filePath);
         await File.WriteAllTextAsync(filePath, json);
         _filePath = filePath;
+        _scaffold.SetFilePath(filePath);
         SetDirty(false);
     }
 
     public async Task<string?> GetSerializedContentAsync()
     {
         if (_scaffold is null) return null;
-        return await PrepareSerializedContentAsync();
+        return await PrepareSerializedContentAsync(_filePath);
     }
 
-    private async Task<string> PrepareSerializedContentAsync()
+    /// <summary>
+    /// Whether saving to <paramref name="path"/> keeps that file's own format instead of
+    /// converting to the native .verso format.
+    /// </summary>
+    public bool PreservesFormat(string path) =>
+        _extensionHost?.GetSerializers()
+            .Any(s => s.CanImport(path) && s.PreservesFormatByDefault) ?? false;
+
+    private async Task<string> PrepareSerializedContentAsync(string? targetPath)
     {
         if (_scaffold!.LayoutManager is { } lm)
             await lm.SaveMetadataAsync(_scaffold.Notebook);
@@ -494,15 +503,23 @@ public sealed partial class ServerNotebookService : IIsolatedLayoutHost, IAsyncD
             await sm.SaveSettingsAsync(_scaffold.Notebook);
 
         _scaffold.Notebook.Modified = DateTimeOffset.UtcNow;
-        INotebookSerializer serializer = ResolveSerializer();
+        INotebookSerializer serializer = ResolveSerializer(targetPath);
         return await serializer.SerializeAsync(_scaffold.Notebook);
     }
 
-    private INotebookSerializer ResolveSerializer()
+    private INotebookSerializer ResolveSerializer(string? filePath)
     {
+        if (!string.IsNullOrEmpty(filePath))
+        {
+            var preserving = _extensionHost?.GetSerializers()
+                .FirstOrDefault(s => s.CanImport(filePath) && s.PreservesFormatByDefault);
+            if (preserving is not null)
+                return preserving;
+        }
+
         if (_options.PreserveFormat
-            && !string.IsNullOrEmpty(_filePath)
-            && _filePath.EndsWith(".ipynb", StringComparison.OrdinalIgnoreCase))
+            && !string.IsNullOrEmpty(filePath)
+            && filePath.EndsWith(".ipynb", StringComparison.OrdinalIgnoreCase))
         {
             return new JupyterSerializer();
         }

--- a/src/Verso.Cli/Commands/ConvertCommand.cs
+++ b/src/Verso.Cli/Commands/ConvertCommand.cs
@@ -13,15 +13,15 @@ public static class ConvertCommand
     {
         var inputArg = new Argument<FileInfo>("input", "Path to the source notebook file.");
 
-        var toOption = new Option<string>("--to", "Target format: verso, ipynb, or dib.")
+        var toOption = new Option<string>("--to", "Target format: verso, ipynb, md, or dib.")
         {
             IsRequired = true
         };
         toOption.AddValidator(result =>
         {
             var value = result.GetValueForOption(toOption);
-            if (value is not ("verso" or "ipynb" or "dib"))
-                result.ErrorMessage = $"Unsupported format '{value}'. Supported: verso, ipynb, dib";
+            if (value is not ("verso" or "ipynb" or "md" or "dib"))
+                result.ErrorMessage = $"Unsupported format '{value}'. Supported: verso, ipynb, md, dib";
         });
 
         var outputOption = new Option<FileInfo?>("--output",

--- a/src/Verso.Cli/Repl/Meta/Commands/SaveMeta.cs
+++ b/src/Verso.Cli/Repl/Meta/Commands/SaveMeta.cs
@@ -30,9 +30,14 @@ public sealed class SaveMeta : IMetaCommand
 
         // Implicit-target saves on a non-.verso path: when the user has not asked to preserve
         // the original format, route to a sibling .verso file (matching the VS Code default).
-        // Explicit `.save foo.ipynb` always honors the path the user typed.
+        // Explicit `.save foo.ipynb` always honors the path the user typed. Formats whose
+        // serializer preserves by default (e.g. Markdown) skip the conversion entirely.
+        var preservesByDefault = context.Session.ExtensionHost.GetSerializers()
+            .Any(s => s.CanImport(targetPath) && s.PreservesFormatByDefault);
+
         if (!explicitTarget
             && !context.Session.PreserveFormat
+            && !preservesByDefault
             && !targetPath.EndsWith(".verso", StringComparison.OrdinalIgnoreCase))
         {
             context.Console.MarkupLine(

--- a/src/Verso.Cli/Utilities/SerializerResolver.cs
+++ b/src/Verso.Cli/Utilities/SerializerResolver.cs
@@ -23,7 +23,7 @@ public static class SerializerResolver
         {
             var extension = Path.GetExtension(filePath);
             throw new SerializerNotFoundException(
-                $"Unsupported notebook format '{extension}'. Supported formats: .verso, .ipynb, .dib");
+                $"Unsupported notebook format '{extension}'. Supported formats: .verso, .ipynb, .md, .dib");
         }
 
         return serializer;
@@ -39,6 +39,7 @@ public static class SerializerResolver
         var formatId = format.ToLowerInvariant() switch
         {
             "ipynb" => "jupyter",
+            "md" => "markdown",
             _ => format.ToLowerInvariant()
         };
 
@@ -48,7 +49,7 @@ public static class SerializerResolver
         if (serializer is null)
         {
             throw new SerializerNotFoundException(
-                $"Unsupported output format '{format}'. Supported formats: verso, ipynb, dib");
+                $"Unsupported output format '{format}'. Supported formats: verso, ipynb, md, dib");
         }
 
         return serializer;

--- a/src/Verso.Host/Handlers/NotebookHandler.cs
+++ b/src/Verso.Host/Handlers/NotebookHandler.cs
@@ -295,7 +295,7 @@ public static class NotebookHandler
 
     public static async Task<NotebookSaveResult> HandleSaveAsync(NotebookSession ns, JsonElement? @params)
     {
-        var format = "verso";
+        string? format = null;
         if (@params is { ValueKind: JsonValueKind.Object } p
             && p.TryGetProperty("format", out var fmtEl)
             && fmtEl.ValueKind == JsonValueKind.String
@@ -303,6 +303,18 @@ public static class NotebookHandler
         {
             format = fmtEl.GetString()!;
         }
+
+        // Implicit saves (no explicit format, e.g. kernel-restart snapshots or clients that
+        // rely on host-side defaults) prefer a serializer that preserves this notebook's own
+        // file format over the native default, so a round trip through save and reopen never
+        // reinterprets content in the wrong format.
+        if (format is null && ns.Scaffold.FilePath is { Length: > 0 } scaffoldPath)
+        {
+            format = ns.ExtensionHost.GetSerializers()
+                .FirstOrDefault(s => s.CanImport(scaffoldPath) && s.PreservesFormatByDefault)
+                ?.FormatId;
+        }
+        format ??= "verso";
 
         // Flush layout metadata (grid positions, etc.) and extension settings into the
         // notebook model; both live in their managers until saved.

--- a/src/Verso.Host/Handlers/ToolbarHandler.cs
+++ b/src/Verso.Host/Handlers/ToolbarHandler.cs
@@ -117,7 +117,7 @@ public static class ToolbarHandler
             public HostNotebookMetadata(Scaffold scaffold) => _scaffold = scaffold;
             public string? Title => _scaffold.Title;
             public string? DefaultKernelId => _scaffold.DefaultKernelId;
-            public string? FilePath => null;
+            public string? FilePath => _scaffold.FilePath;
             public Dictionary<string, NotebookParameterDefinition>? Parameters => _scaffold.Notebook.Parameters;
         }
     }

--- a/src/Verso.Testing/Stubs/StubToolbarActionContext.cs
+++ b/src/Verso.Testing/Stubs/StubToolbarActionContext.cs
@@ -20,8 +20,9 @@ public sealed class StubToolbarActionContext : IToolbarActionContext
     public IThemeContext Theme { get; } = new StubThemeContext();
     public LayoutCapabilities LayoutCapabilities { get; set; } = LayoutCapabilities.None;
     public IExtensionHostContext ExtensionHost { get; set; } = new StubExtensionHostContext(() => Array.Empty<ILanguageKernel>());
-    public INotebookMetadata NotebookMetadata { get; } = new NotebookMetadataContext(new NotebookModel());
+    public INotebookMetadata NotebookMetadata { get; set; } = new NotebookMetadataContext(new NotebookModel());
     public INotebookOperations Notebook { get; set; } = new StubNotebookOperations();
+    public string? ActiveLayoutId { get; set; }
 
     public List<CellOutput> WrittenOutputs { get; } = new();
     public List<(string FileName, string ContentType, byte[] Data)> DownloadedFiles { get; } = new();

--- a/src/Verso/Extensions/ToolbarActions/ExportVersoAction.cs
+++ b/src/Verso/Extensions/ToolbarActions/ExportVersoAction.cs
@@ -1,0 +1,86 @@
+using System.Text;
+using Verso.Abstractions;
+using Verso.Serializers;
+
+namespace Verso.Extensions.ToolbarActions;
+
+/// <summary>
+/// Toolbar action that exports the notebook as a native <c>.verso</c> file. Shown only for
+/// notebooks opened from a Markdown file while the default notebook layout is active, as the
+/// escape hatch for notebooks that outgrow what plain Markdown can persist (outputs, layouts,
+/// parameters, and custom cell state).
+/// </summary>
+[VersoExtension]
+public sealed class ExportVersoAction : IToolbarAction
+{
+    // --- IExtension ---
+
+    public string ExtensionId => "verso.action.export-verso";
+    public string Name => "Export Verso";
+    public string Version => "1.0.0";
+    public string? Author => "Verso Contributors";
+    public string? Description => "Exports a Markdown-backed notebook as a native .verso file.";
+
+    public Task OnLoadedAsync(IExtensionHostContext context) => Task.CompletedTask;
+    public Task OnUnloadedAsync() => Task.CompletedTask;
+
+    // --- IToolbarAction ---
+
+    public string ActionId => "verso.action.export-verso";
+    public string DisplayName => "Verso";
+    public string? Icon => null;
+    public ToolbarPlacement Placement => ToolbarPlacement.ExportMenu;
+    public int Order => 66;
+
+    public Task<bool> IsEnabledAsync(IToolbarActionContext context)
+    {
+        var hasCells = context.NotebookCells.Count > 0;
+        var fromMarkdown = context.NotebookMetadata.FilePath?
+            .EndsWith(".md", StringComparison.OrdinalIgnoreCase) == true;
+        var onNotebookLayout = context.ActiveLayoutId is null
+            || string.Equals(context.ActiveLayoutId, LayoutDefaults.LayoutId, StringComparison.OrdinalIgnoreCase);
+
+        return Task.FromResult(hasCells && fromMarkdown && onNotebookLayout);
+    }
+
+    public async Task ExecuteAsync(IToolbarActionContext context)
+    {
+        var metadata = context.NotebookMetadata;
+        var notebook = new NotebookModel
+        {
+            Title = metadata.Title,
+            DefaultKernelId = metadata.DefaultKernelId,
+            Parameters = metadata.Parameters,
+        };
+
+        foreach (var cell in context.NotebookCells)
+        {
+            notebook.Cells.Add(new CellModel
+            {
+                Id = cell.Id,
+                Type = cell.Type,
+                Language = cell.Language,
+                Source = cell.Source,
+                Outputs = new List<CellOutput>(cell.Outputs),
+                // Markdown bookkeeping keys describe the source file's fence layout and have
+                // no meaning in the native format.
+                Metadata = cell.Metadata
+                    .Where(kv => !kv.Key.StartsWith("md.", StringComparison.Ordinal))
+                    .ToDictionary(kv => kv.Key, kv => kv.Value),
+            });
+        }
+
+        var serializer = new VersoSerializer(context.ExtensionHost.GetCellTypes());
+        var json = await serializer.SerializeAsync(notebook).ConfigureAwait(false);
+        var data = Encoding.UTF8.GetBytes(json);
+
+        var fileName = metadata.FilePath is { Length: > 0 } path
+            ? Path.GetFileNameWithoutExtension(path) + ".verso"
+            : ExportHtmlAction.SanitizeFileName(metadata.Title, ".verso");
+
+        // Deliberately not application/json: save dialogs append the extension registered
+        // for the content type when it disagrees with the file name, which would turn
+        // notebook.verso into notebook.verso.json.
+        await context.RequestFileDownloadAsync(fileName, "application/octet-stream", data).ConfigureAwait(false);
+    }
+}

--- a/src/Verso/Scaffold.cs
+++ b/src/Verso/Scaffold.cs
@@ -115,6 +115,11 @@ public sealed class Scaffold : IAsyncDisposable
         _metadata.FilePath = filePath;
     }
 
+    /// <summary>
+    /// The notebook's current file path, or <c>null</c> when the notebook has no backing file.
+    /// </summary>
+    public string? FilePath => _metadata.FilePath;
+
     // --- Subsystem initialization ---
 
     /// <summary>

--- a/src/Verso/Serializers/DibSerializer.cs
+++ b/src/Verso/Serializers/DibSerializer.cs
@@ -14,30 +14,6 @@ public sealed class DibSerializer : INotebookSerializer
         @"^#!(\w[\w#-]*)$",
         RegexOptions.Compiled);
 
-    private static readonly Dictionary<string, (string Type, string? Language)> DirectiveMap =
-        new(StringComparer.OrdinalIgnoreCase)
-        {
-            ["markdown"] = ("markdown", null),
-            ["csharp"] = ("code", "csharp"),
-            ["cs"] = ("code", "csharp"),
-            ["c#"] = ("code", "csharp"),
-            ["fsharp"] = ("code", "fsharp"),
-            ["fs"] = ("code", "fsharp"),
-            ["f#"] = ("code", "fsharp"),
-            ["pwsh"] = ("code", "powershell"),
-            ["powershell"] = ("code", "powershell"),
-            ["python"] = ("code", "python"),
-            ["py"] = ("code", "python"),
-            ["javascript"] = ("code", "javascript"),
-            ["js"] = ("code", "javascript"),
-            ["typescript"] = ("code", "typescript"),
-            ["ts"] = ("code", "typescript"),
-            ["html"] = ("html", null),
-            ["mermaid"] = ("mermaid", null),
-            ["sql"] = ("sql", null),
-            ["value"] = ("code", "value"),
-        };
-
     // --- IExtension ---
 
     public string ExtensionId => "verso.serializer.dib";
@@ -192,7 +168,7 @@ public sealed class DibSerializer : INotebookSerializer
 
                 var directive = match.Groups[1].Value;
 
-                if (DirectiveMap.TryGetValue(directive, out var mapped))
+                if (LanguageDirectiveMap.Aliases.TryGetValue(directive, out var mapped))
                 {
                     currentType = mapped.Type;
                     currentLanguage = mapped.Language;

--- a/src/Verso/Serializers/LanguageDirectiveMap.cs
+++ b/src/Verso/Serializers/LanguageDirectiveMap.cs
@@ -1,0 +1,56 @@
+namespace Verso.Serializers;
+
+/// <summary>
+/// Shared alias table mapping a language token to a cell (Type, Language) pair. The tokens match
+/// the Polyglot Notebook <c>#!</c> directive names, and the same set is recognized in the info
+/// string of a fenced code block when importing Markdown notebooks.
+/// </summary>
+public static class LanguageDirectiveMap
+{
+    /// <summary>
+    /// Maps a language token (case-insensitive) to the cell type and kernel language it produces.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, (string Type, string? Language)> Aliases =
+        new Dictionary<string, (string Type, string? Language)>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["markdown"] = ("markdown", null),
+            ["csharp"] = ("code", "csharp"),
+            ["cs"] = ("code", "csharp"),
+            ["c#"] = ("code", "csharp"),
+            ["fsharp"] = ("code", "fsharp"),
+            ["fs"] = ("code", "fsharp"),
+            ["f#"] = ("code", "fsharp"),
+            ["pwsh"] = ("code", "powershell"),
+            ["powershell"] = ("code", "powershell"),
+            ["python"] = ("code", "python"),
+            ["py"] = ("code", "python"),
+            ["javascript"] = ("code", "javascript"),
+            ["js"] = ("code", "javascript"),
+            ["typescript"] = ("code", "typescript"),
+            ["ts"] = ("code", "typescript"),
+            ["html"] = ("html", null),
+            ["mermaid"] = ("mermaid", null),
+            ["sql"] = ("sql", null),
+            ["value"] = ("code", "value"),
+        };
+
+    /// <summary>
+    /// Canonical fence tag for a cell's type and language, used when a cell has no remembered
+    /// opening fence line to reuse (for example a newly created cell). Falls back to the language,
+    /// then the type, verbatim.
+    /// </summary>
+    public static string ToFenceTag(string type, string? language) =>
+        (type.ToLowerInvariant(), language?.ToLowerInvariant()) switch
+        {
+            ("code", "csharp") => "csharp",
+            ("code", "fsharp") => "fsharp",
+            ("code", "powershell") => "powershell",
+            ("code", "python") => "python",
+            ("code", "javascript") => "javascript",
+            ("code", "typescript") => "typescript",
+            ("html", _) => "html",
+            ("mermaid", _) => "mermaid",
+            ("sql", _) => "sql",
+            _ => language ?? type,
+        };
+}

--- a/src/Verso/Serializers/MarkdownSerializer.cs
+++ b/src/Verso/Serializers/MarkdownSerializer.cs
@@ -1,0 +1,247 @@
+using Markdig;
+using Markdig.Syntax;
+using Verso.Abstractions;
+
+namespace Verso.Serializers;
+
+/// <summary>
+/// Serializer for Markdown (<c>.md</c>) notebooks. Continuous prose becomes markdown cells and
+/// top-level fenced code blocks with a recognized language tag become code cells; everything else
+/// (bare or unknown fences, indented code, fences nested in quotes or lists) stays inline as
+/// prose. Saving writes plain Markdown back, so the file remains readable anywhere Markdown
+/// renders. Cell outputs are not persisted in this format.
+/// </summary>
+[VersoExtension]
+public sealed class MarkdownSerializer : INotebookSerializer
+{
+    private const string SettingsExtensionId = "verso.serializer.markdown";
+    private const string LineEndingSettingKey = "lineEnding";
+
+    /// <summary>
+    /// Cell metadata key holding the verbatim opening fence line a code cell was parsed from,
+    /// reused on save so the author's fence style and tag never churn.
+    /// </summary>
+    public const string FenceMetadataKey = "md.fence";
+
+    private static readonly MarkdownPipeline Pipeline =
+        new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+
+    // --- IExtension ---
+
+    public string ExtensionId => "verso.serializer.markdown";
+    public string Name => "Markdown Serializer";
+    public string Version => "1.0.0";
+    public string? Author => "Verso Contributors";
+    public string? Description => "Serializer for Markdown (.md) notebooks with fenced code cells.";
+
+    public Task OnLoadedAsync(IExtensionHostContext context) => Task.CompletedTask;
+    public Task OnUnloadedAsync() => Task.CompletedTask;
+
+    // --- INotebookSerializer ---
+
+    public string FormatId => "markdown";
+    public IReadOnlyList<string> FileExtensions => new[] { ".md" };
+    public bool PreservesFormatByDefault => true;
+
+    public bool CanImport(string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        return filePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public Task<NotebookModel> DeserializeAsync(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        var hadCrLf = content.Contains("\r\n", StringComparison.Ordinal);
+        var text = hadCrLf ? content.Replace("\r\n", "\n") : content;
+
+        var notebook = new NotebookModel { FormatVersion = NotebookFormatVersion.Current };
+        var lineStarts = ComputeLineStarts(text);
+        var document = Markdown.Parse(text, Pipeline);
+
+        int regionStart = 0;
+
+        void FlushMarkdown(int endExclusive)
+        {
+            if (endExclusive <= regionStart)
+                return;
+
+            var trimmed = TrimBlankLines(text.Substring(regionStart, endExclusive - regionStart));
+            if (trimmed.Length > 0)
+                notebook.Cells.Add(new CellModel { Type = "markdown", Source = trimmed });
+        }
+
+        // Only the document's direct children are considered, so fences nested inside quotes,
+        // lists, or other containers never split the surrounding prose.
+        foreach (var block in document)
+        {
+            if (block is not FencedCodeBlock fenced)
+                continue;
+
+            var info = (fenced.Info ?? "").Trim();
+            if (info.Length == 0 || !LanguageDirectiveMap.Aliases.TryGetValue(info, out var mapped))
+                continue;
+
+            // A fence tagged "markdown" is a literal Markdown example, not a cell boundary.
+            // Turning it into a markdown cell would dissolve the fence into prose on save.
+            if (string.Equals(mapped.Type, "markdown", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            int openLineIdx = fenced.Line;
+            FlushMarkdown(lineStarts[openLineIdx]);
+
+            var (openLine, interior, nextLineStart) = SliceFence(text, lineStarts, fenced);
+
+            var cell = new CellModel
+            {
+                Type = mapped.Type,
+                Language = mapped.Language,
+                Source = interior,
+            };
+            cell.Metadata[FenceMetadataKey] = openLine;
+            notebook.Cells.Add(cell);
+
+            regionStart = nextLineStart;
+        }
+
+        FlushMarkdown(text.Length);
+
+        if (hadCrLf)
+        {
+            notebook.ExtensionSettings[SettingsExtensionId] =
+                new Dictionary<string, object?> { [LineEndingSettingKey] = "crlf" };
+        }
+
+        return Task.FromResult(notebook);
+    }
+
+    public Task<string> SerializeAsync(NotebookModel notebook)
+    {
+        ArgumentNullException.ThrowIfNull(notebook);
+
+        var parts = new List<string>();
+        foreach (var cell in notebook.Cells)
+        {
+            if (string.Equals(cell.Type, "markdown", StringComparison.OrdinalIgnoreCase))
+            {
+                var trimmed = TrimBlankLines(cell.Source ?? "");
+                if (trimmed.Length > 0)
+                    parts.Add(trimmed);
+                continue;
+            }
+
+            parts.Add(RenderFence(cell));
+        }
+
+        var body = string.Join("\n\n", parts);
+        var result = body.Length > 0 ? body + "\n" : "";
+
+        if (UsesCrLf(notebook))
+            result = result.Replace("\n", "\r\n");
+
+        return Task.FromResult(result);
+    }
+
+    // --- Parsing helpers ---
+
+    private static (string OpenLine, string Interior, int NextLineStart) SliceFence(
+        string text, int[] lineStarts, FencedCodeBlock fenced)
+    {
+        int openLineIdx = fenced.Line;
+        int openLineEnd = LineEnd(text, lineStarts, openLineIdx);
+        var openLine = text[lineStarts[openLineIdx]..openLineEnd];
+
+        int interiorStart = Math.Min(openLineEnd + 1, text.Length);
+
+        if (fenced.ClosingFencedCharCount == 0)
+        {
+            // Unterminated fence: the content runs to the end of the file, and the block's
+            // Span is not reliable in this case, so slice directly to the end of the text.
+            var tail = interiorStart < text.Length ? text[interiorStart..] : "";
+            return (openLine, tail, text.Length);
+        }
+
+        // Closed fence: the span ends on the closing fence line, which is excluded from the
+        // cell source and rederived on save from the opening fence characters.
+        int closeLineIdx = LineIndexOfOffset(lineStarts, Math.Min(fenced.Span.End, Math.Max(text.Length - 1, 0)));
+        int interiorEnd = Math.Max(lineStarts[closeLineIdx] - 1, interiorStart);
+        var interior = interiorEnd > interiorStart ? text[interiorStart..interiorEnd] : "";
+        int nextLineStart = closeLineIdx + 1 < lineStarts.Length ? lineStarts[closeLineIdx + 1] : text.Length;
+        return (openLine, interior, nextLineStart);
+    }
+
+    private static int LineEnd(string text, int[] lineStarts, int lineIdx) =>
+        lineIdx + 1 < lineStarts.Length ? lineStarts[lineIdx + 1] - 1 : text.Length;
+
+    private static int[] ComputeLineStarts(string text)
+    {
+        var starts = new List<int> { 0 };
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] == '\n')
+                starts.Add(i + 1);
+        }
+
+        return starts.ToArray();
+    }
+
+    private static int LineIndexOfOffset(int[] lineStarts, int offset)
+    {
+        int idx = Array.BinarySearch(lineStarts, offset);
+        return idx >= 0 ? idx : ~idx - 1;
+    }
+
+    private static string TrimBlankLines(string source)
+    {
+        var lines = source.Split('\n');
+
+        int start = 0;
+        while (start < lines.Length && string.IsNullOrWhiteSpace(lines[start]))
+            start++;
+
+        int end = lines.Length - 1;
+        while (end >= start && string.IsNullOrWhiteSpace(lines[end]))
+            end--;
+
+        if (start > end)
+            return "";
+
+        return string.Join('\n', lines, start, end - start + 1);
+    }
+
+    // --- Serialization helpers ---
+
+    private static string RenderFence(CellModel cell)
+    {
+        var openLine = cell.Metadata.TryGetValue(FenceMetadataKey, out var stored)
+            && stored is string s && s.Length > 0
+            ? s
+            : "```" + LanguageDirectiveMap.ToFenceTag(cell.Type, cell.Language);
+
+        var (fenceChar, count) = ParseFenceChars(openLine);
+        var closeLine = new string(fenceChar, count);
+
+        var source = cell.Source ?? "";
+        var bodyText = source.Length == 0 ? "" : source + "\n";
+        return openLine + "\n" + bodyText + closeLine;
+    }
+
+    private static (char Char, int Count) ParseFenceChars(string openLine)
+    {
+        var trimmed = openLine.TrimStart(' ');
+        char fenceChar = trimmed.Length > 0 && trimmed[0] == '~' ? '~' : '`';
+        int count = 0;
+        while (count < trimmed.Length && trimmed[count] == fenceChar)
+            count++;
+
+        // Floor of three keeps the output a valid fence even for a malformed stored line.
+        return (fenceChar, Math.Max(count, 3));
+    }
+
+    private static bool UsesCrLf(NotebookModel notebook) =>
+        notebook.ExtensionSettings.TryGetValue(SettingsExtensionId, out var settings)
+        && settings.TryGetValue(LineEndingSettingKey, out var value)
+        && value is string ending
+        && string.Equals(ending, "crlf", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Verso/Serializers/MarkdownSerializer.cs
+++ b/src/Verso/Serializers/MarkdownSerializer.cs
@@ -56,6 +56,13 @@ public sealed class MarkdownSerializer : INotebookSerializer
         var hadCrLf = content.Contains("\r\n", StringComparison.Ordinal);
         var text = hadCrLf ? content.Replace("\r\n", "\n") : content;
 
+        // Markdig counts a lone \r as a line break (per CommonMark), so any carriage return
+        // left behind after the \r\n pass would desynchronize block line numbers from the
+        // line-start table computed below, corrupting cell slices or indexing past the end
+        // of the table. Normalize them so both sides count lines the same way.
+        if (text.Contains('\r'))
+            text = text.Replace('\r', '\n');
+
         var notebook = new NotebookModel { FormatVersion = NotebookFormatVersion.Current };
         var lineStarts = ComputeLineStarts(text);
         var document = Markdown.Parse(text, Pipeline);

--- a/tests/Verso.Tests/Extensions/BuiltInExtensionDiscoveryTests.cs
+++ b/tests/Verso.Tests/Extensions/BuiltInExtensionDiscoveryTests.cs
@@ -13,7 +13,7 @@ public sealed class BuiltInExtensionDiscoveryTests
         await host.LoadBuiltInExtensionsAsync();
 
         var all = host.GetLoadedExtensions();
-        Assert.AreEqual(41, all.Count, $"Expected 41 extensions, got {all.Count}: {string.Join(", ", all.Select(e => e.ExtensionId))}");
+        Assert.AreEqual(43, all.Count, $"Expected 43 extensions, got {all.Count}: {string.Join(", ", all.Select(e => e.ExtensionId))}");
 
     }
 

--- a/tests/Verso.Tests/Extensions/ToolbarActions/ToolbarActionTests.cs
+++ b/tests/Verso.Tests/Extensions/ToolbarActions/ToolbarActionTests.cs
@@ -1,4 +1,6 @@
+using System.Text;
 using Verso.Abstractions;
+using Verso.Contexts;
 using Verso.Extensions.ToolbarActions;
 using Verso.Testing.Stubs;
 using Verso.Testing.Fakes;
@@ -357,6 +359,82 @@ public sealed class ToolbarActionTests
         Assert.IsTrue(context.DownloadedFiles[0].FileName.EndsWith(".md"));
         Assert.AreEqual("text/markdown", context.DownloadedFiles[0].ContentType);
         Assert.IsTrue(context.DownloadedFiles[0].Data.Length > 0);
+    }
+
+    // --- ExportVersoAction ---
+
+    [TestMethod]
+    public void ExportVerso_Metadata_IsCorrect()
+    {
+        var action = new ExportVersoAction();
+        Assert.AreEqual("verso.action.export-verso", action.ActionId);
+        Assert.AreEqual(ToolbarPlacement.ExportMenu, action.Placement);
+        Assert.AreEqual(66, action.Order);
+    }
+
+    [TestMethod]
+    public async Task ExportVerso_IsEnabled_WhenMdFileAndDefaultLayout()
+    {
+        var action = new ExportVersoAction();
+        var context = CreateContext(cells: new[] { new CellModel() });
+        context.NotebookMetadata = new NotebookMetadataContext(new NotebookModel(), "/notes/sample.md");
+
+        context.ActiveLayoutId = null;
+        Assert.IsTrue(await action.IsEnabledAsync(context));
+
+        context.ActiveLayoutId = LayoutDefaults.LayoutId;
+        Assert.IsTrue(await action.IsEnabledAsync(context));
+    }
+
+    [TestMethod]
+    public async Task ExportVerso_IsDisabled_WhenNotMdFile()
+    {
+        var action = new ExportVersoAction();
+        var context = CreateContext(cells: new[] { new CellModel() });
+        context.NotebookMetadata = new NotebookMetadataContext(new NotebookModel(), "/notes/sample.verso");
+
+        Assert.IsFalse(await action.IsEnabledAsync(context));
+    }
+
+    [TestMethod]
+    public async Task ExportVerso_IsDisabled_WhenNoFilePath()
+    {
+        var action = new ExportVersoAction();
+        var context = CreateContext(cells: new[] { new CellModel() });
+
+        Assert.IsFalse(await action.IsEnabledAsync(context));
+    }
+
+    [TestMethod]
+    public async Task ExportVerso_IsDisabled_WhenCustomLayoutActive()
+    {
+        var action = new ExportVersoAction();
+        var context = CreateContext(cells: new[] { new CellModel() });
+        context.NotebookMetadata = new NotebookMetadataContext(new NotebookModel(), "/notes/sample.md");
+        context.ActiveLayoutId = "grid";
+
+        Assert.IsFalse(await action.IsEnabledAsync(context));
+    }
+
+    [TestMethod]
+    public async Task ExportVerso_Execute_DownloadsVersoAndStripsMarkdownMetadata()
+    {
+        var action = new ExportVersoAction();
+        var cell = new CellModel { Type = "code", Language = "csharp", Source = "var x = 1;" };
+        cell.Metadata["md.fence"] = "```cs";
+        cell.Metadata["keep"] = "kept-value";
+        var context = CreateContext(cells: new[] { cell });
+        context.NotebookMetadata = new NotebookMetadataContext(new NotebookModel(), "/notes/sample.md");
+
+        await action.ExecuteAsync(context);
+
+        Assert.AreEqual(1, context.DownloadedFiles.Count);
+        Assert.AreEqual("sample.verso", context.DownloadedFiles[0].FileName);
+        Assert.AreEqual("application/octet-stream", context.DownloadedFiles[0].ContentType);
+
+        var json = Encoding.UTF8.GetString(context.DownloadedFiles[0].Data);
+        StringAssert.Contains(json, "kept-value");
+        Assert.IsFalse(json.Contains("md.fence"));
     }
 
     // --- Helper ---

--- a/tests/Verso.Tests/Serializers/LanguageDirectiveMapTests.cs
+++ b/tests/Verso.Tests/Serializers/LanguageDirectiveMapTests.cs
@@ -1,0 +1,64 @@
+using Verso.Serializers;
+
+namespace Verso.Tests.Serializers;
+
+[TestClass]
+public sealed class LanguageDirectiveMapTests
+{
+    [TestMethod]
+    public void Aliases_ContainExactExpectedEntries()
+    {
+        var expected = new Dictionary<string, (string Type, string? Language)>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["markdown"] = ("markdown", null),
+            ["csharp"] = ("code", "csharp"),
+            ["cs"] = ("code", "csharp"),
+            ["c#"] = ("code", "csharp"),
+            ["fsharp"] = ("code", "fsharp"),
+            ["fs"] = ("code", "fsharp"),
+            ["f#"] = ("code", "fsharp"),
+            ["pwsh"] = ("code", "powershell"),
+            ["powershell"] = ("code", "powershell"),
+            ["python"] = ("code", "python"),
+            ["py"] = ("code", "python"),
+            ["javascript"] = ("code", "javascript"),
+            ["js"] = ("code", "javascript"),
+            ["typescript"] = ("code", "typescript"),
+            ["ts"] = ("code", "typescript"),
+            ["html"] = ("html", null),
+            ["mermaid"] = ("mermaid", null),
+            ["sql"] = ("sql", null),
+            ["value"] = ("code", "value"),
+        };
+
+        Assert.AreEqual(expected.Count, LanguageDirectiveMap.Aliases.Count);
+        foreach (var (key, value) in expected)
+        {
+            Assert.IsTrue(LanguageDirectiveMap.Aliases.TryGetValue(key, out var actual), $"Missing alias '{key}'.");
+            Assert.AreEqual(value, actual, $"Alias '{key}' maps to an unexpected pair.");
+        }
+    }
+
+    [TestMethod]
+    public void Aliases_AreCaseInsensitive()
+    {
+        Assert.IsTrue(LanguageDirectiveMap.Aliases.ContainsKey("CSharp"));
+        Assert.IsTrue(LanguageDirectiveMap.Aliases.ContainsKey("PY"));
+    }
+
+    [TestMethod]
+    public void ToFenceTag_KnownPairs_ProduceCanonicalTags()
+    {
+        Assert.AreEqual("csharp", LanguageDirectiveMap.ToFenceTag("code", "csharp"));
+        Assert.AreEqual("powershell", LanguageDirectiveMap.ToFenceTag("code", "powershell"));
+        Assert.AreEqual("mermaid", LanguageDirectiveMap.ToFenceTag("mermaid", null));
+        Assert.AreEqual("sql", LanguageDirectiveMap.ToFenceTag("sql", null));
+    }
+
+    [TestMethod]
+    public void ToFenceTag_UnknownPairs_FallBackToLanguageThenType()
+    {
+        Assert.AreEqual("ruby", LanguageDirectiveMap.ToFenceTag("code", "ruby"));
+        Assert.AreEqual("chart", LanguageDirectiveMap.ToFenceTag("chart", null));
+    }
+}

--- a/tests/Verso.Tests/Serializers/MarkdownSerializerTests.cs
+++ b/tests/Verso.Tests/Serializers/MarkdownSerializerTests.cs
@@ -330,6 +330,35 @@ public sealed class MarkdownSerializerTests
     }
 
     [TestMethod]
+    public async Task Deserialize_BareCarriageReturns_ParseAsLineBreaks()
+    {
+        // Markdig counts a lone \r as a line break; the offset math must agree with it
+        // or fence positions land on the wrong lines (or past the end of the table).
+        var md = "A\rB\rC\rD\r```csharp\nvar x = 1;\n```\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(2, notebook.Cells.Count);
+        Assert.AreEqual("A\nB\nC\nD", notebook.Cells[0].Source);
+        Assert.AreEqual("var x = 1;", notebook.Cells[1].Source);
+        Assert.AreEqual("```csharp", notebook.Cells[1].Metadata[MarkdownSerializer.FenceMetadataKey]);
+    }
+
+    [TestMethod]
+    public async Task Deserialize_SingleBareCarriageReturn_KeepsFenceContentIntact()
+    {
+        var md = "Intro\r```csharp\nvar x = 1;\n```\nAfter.\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(3, notebook.Cells.Count);
+        Assert.AreEqual("Intro", notebook.Cells[0].Source);
+        Assert.AreEqual("var x = 1;", notebook.Cells[1].Source);
+        Assert.AreEqual("```csharp", notebook.Cells[1].Metadata[MarkdownSerializer.FenceMetadataKey]);
+        Assert.AreEqual("After.", notebook.Cells[2].Source);
+    }
+
+    [TestMethod]
     public async Task RoundTrip_UnknownFenceInProse_Preserved()
     {
         var md = "Before.\n\n```json\n{ \"a\": 1 }\n```\n\nAfter.\n";

--- a/tests/Verso.Tests/Serializers/MarkdownSerializerTests.cs
+++ b/tests/Verso.Tests/Serializers/MarkdownSerializerTests.cs
@@ -1,0 +1,342 @@
+using Verso.Serializers;
+
+namespace Verso.Tests.Serializers;
+
+[TestClass]
+public sealed class MarkdownSerializerTests
+{
+    private readonly MarkdownSerializer _serializer = new();
+
+    // --- Metadata and CanImport ---
+
+    [TestMethod]
+    public void ExtensionMetadata_IsCorrect()
+    {
+        Assert.AreEqual("verso.serializer.markdown", _serializer.ExtensionId);
+        Assert.AreEqual("markdown", _serializer.FormatId);
+        Assert.AreEqual(1, _serializer.FileExtensions.Count);
+        Assert.AreEqual(".md", _serializer.FileExtensions[0]);
+        Assert.IsTrue(_serializer.PreservesFormatByDefault);
+    }
+
+    [TestMethod]
+    public void CanImport_Md_ReturnsTrue()
+    {
+        Assert.IsTrue(_serializer.CanImport("notes.md"));
+        Assert.IsTrue(_serializer.CanImport("README.MD"));
+    }
+
+    [TestMethod]
+    public void CanImport_NonMd_ReturnsFalse()
+    {
+        Assert.IsFalse(_serializer.CanImport("notebook.verso"));
+        Assert.IsFalse(_serializer.CanImport("notebook.ipynb"));
+        Assert.IsFalse(_serializer.CanImport("notebook.dib"));
+    }
+
+    // --- Deserialization: fence recognition ---
+
+    [TestMethod]
+    public async Task Deserialize_CSharpFence_BecomesCodeCell()
+    {
+        var md = "# Title\n\n```csharp\nvar x = 1;\n```\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(2, notebook.Cells.Count);
+        Assert.AreEqual("markdown", notebook.Cells[0].Type);
+        Assert.AreEqual("# Title", notebook.Cells[0].Source);
+        Assert.AreEqual("code", notebook.Cells[1].Type);
+        Assert.AreEqual("csharp", notebook.Cells[1].Language);
+        Assert.AreEqual("var x = 1;", notebook.Cells[1].Source);
+        Assert.AreEqual("```csharp", notebook.Cells[1].Metadata[MarkdownSerializer.FenceMetadataKey]);
+    }
+
+    [TestMethod]
+    public async Task Deserialize_AliasTag_MapsLanguageAndKeepsFence()
+    {
+        var md = "```cs\nvar x = 1;\n```\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(1, notebook.Cells.Count);
+        Assert.AreEqual("csharp", notebook.Cells[0].Language);
+        Assert.AreEqual("```cs", notebook.Cells[0].Metadata[MarkdownSerializer.FenceMetadataKey]);
+    }
+
+    [TestMethod]
+    public async Task Deserialize_CellTypeTags_MapToCellTypes()
+    {
+        var md = "```mermaid\ngraph TD;\n```\n\n```sql\nSELECT 1;\n```\n\n```html\n<b>hi</b>\n```\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(3, notebook.Cells.Count);
+        Assert.AreEqual("mermaid", notebook.Cells[0].Type);
+        Assert.IsNull(notebook.Cells[0].Language);
+        Assert.AreEqual("sql", notebook.Cells[1].Type);
+        Assert.AreEqual("html", notebook.Cells[2].Type);
+    }
+
+    [TestMethod]
+    public async Task Deserialize_UnknownFence_StaysInline()
+    {
+        var md = "Before.\n\n```json\n{ \"a\": 1 }\n```\n\nAfter.\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(1, notebook.Cells.Count);
+        Assert.AreEqual("markdown", notebook.Cells[0].Type);
+        StringAssert.Contains(notebook.Cells[0].Source, "```json");
+    }
+
+    [TestMethod]
+    public async Task Deserialize_BareFence_StaysInline()
+    {
+        var md = "Text.\n\n```\nplain output\n```\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(1, notebook.Cells.Count);
+        Assert.AreEqual("markdown", notebook.Cells[0].Type);
+    }
+
+    [TestMethod]
+    public async Task Deserialize_MarkdownTaggedFence_StaysInline()
+    {
+        var md = "Example:\n\n```markdown\n# Sample heading\n```\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(1, notebook.Cells.Count);
+        Assert.AreEqual("markdown", notebook.Cells[0].Type);
+        StringAssert.Contains(notebook.Cells[0].Source, "```markdown");
+    }
+
+    [TestMethod]
+    public async Task Deserialize_BlockquoteNestedFence_StaysInline()
+    {
+        var md = "> quoted\n> ```csharp\n> var x = 1;\n> ```\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(1, notebook.Cells.Count);
+        Assert.AreEqual("markdown", notebook.Cells[0].Type);
+    }
+
+    [TestMethod]
+    public async Task Deserialize_ListNestedFence_StaysInline()
+    {
+        var md = "- item\n\n  ```csharp\n  var x = 1;\n  ```\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(1, notebook.Cells.Count);
+        Assert.AreEqual("markdown", notebook.Cells[0].Type);
+    }
+
+    [TestMethod]
+    public async Task Deserialize_IndentedCodeBlock_StaysInline()
+    {
+        var md = "Text.\n\n    var x = 1;\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(1, notebook.Cells.Count);
+        Assert.AreEqual("markdown", notebook.Cells[0].Type);
+    }
+
+    [TestMethod]
+    public async Task Deserialize_FourBacktickFence_KeepsInnerBackticks()
+    {
+        var md = "````csharp\n```\nvar x = 1;\n```\n````\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(1, notebook.Cells.Count);
+        Assert.AreEqual("code", notebook.Cells[0].Type);
+        Assert.AreEqual("```\nvar x = 1;\n```", notebook.Cells[0].Source);
+        Assert.AreEqual("````csharp", notebook.Cells[0].Metadata[MarkdownSerializer.FenceMetadataKey]);
+    }
+
+    [TestMethod]
+    public async Task Deserialize_TildeFence_BecomesCodeCell()
+    {
+        var md = "~~~python\nprint(1)\n~~~\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(1, notebook.Cells.Count);
+        Assert.AreEqual("python", notebook.Cells[0].Language);
+        Assert.AreEqual("print(1)", notebook.Cells[0].Source);
+        Assert.AreEqual("~~~python", notebook.Cells[0].Metadata[MarkdownSerializer.FenceMetadataKey]);
+    }
+
+    [TestMethod]
+    public async Task Deserialize_UnterminatedFence_RunsToEndOfFile()
+    {
+        var md = "Before.\n\n```csharp\nvar x = 1;";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(2, notebook.Cells.Count);
+        Assert.AreEqual("markdown", notebook.Cells[0].Type);
+        Assert.AreEqual("var x = 1;", notebook.Cells[1].Source);
+    }
+
+    [TestMethod]
+    public async Task Deserialize_FenceAtStart_NoLeadingMarkdownCell()
+    {
+        var md = "```csharp\nvar x = 1;\n```\n\nAfter.\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+
+        Assert.AreEqual(2, notebook.Cells.Count);
+        Assert.AreEqual("code", notebook.Cells[0].Type);
+        Assert.AreEqual("markdown", notebook.Cells[1].Type);
+        Assert.AreEqual("After.", notebook.Cells[1].Source);
+    }
+
+    [TestMethod]
+    public async Task Deserialize_EmptyContent_NoCells()
+    {
+        var notebook = await _serializer.DeserializeAsync("");
+
+        Assert.AreEqual(0, notebook.Cells.Count);
+    }
+
+    // --- Serialization ---
+
+    [TestMethod]
+    public async Task Serialize_EmptyNotebook_EmptyString()
+    {
+        var result = await _serializer.SerializeAsync(new NotebookModel());
+
+        Assert.AreEqual("", result);
+    }
+
+    [TestMethod]
+    public async Task Serialize_OutputsDropped()
+    {
+        var notebook = new NotebookModel();
+        notebook.Cells.Add(new CellModel
+        {
+            Type = "code",
+            Language = "csharp",
+            Source = "var x = 1;",
+            Outputs = { new CellOutput("text/plain", "the output value") },
+        });
+
+        var result = await _serializer.SerializeAsync(notebook);
+
+        Assert.IsFalse(result.Contains("the output value"));
+    }
+
+    [TestMethod]
+    public async Task Serialize_NewCodeCell_CanonicalFenceTag()
+    {
+        var notebook = new NotebookModel();
+        notebook.Cells.Add(new CellModel { Type = "code", Language = "powershell", Source = "Get-Date" });
+
+        var result = await _serializer.SerializeAsync(notebook);
+
+        Assert.AreEqual("```powershell\nGet-Date\n```\n", result);
+    }
+
+    [TestMethod]
+    public async Task Serialize_UnrepresentableCell_TaggedFence()
+    {
+        var notebook = new NotebookModel();
+        notebook.Cells.Add(new CellModel { Type = "chart", Language = null, Source = "{ \"kind\": \"bar\" }" });
+        notebook.Cells.Add(new CellModel { Type = "code", Language = "ruby", Source = "puts 1" });
+
+        var result = await _serializer.SerializeAsync(notebook);
+
+        StringAssert.Contains(result, "```chart\n{ \"kind\": \"bar\" }\n```");
+        StringAssert.Contains(result, "```ruby\nputs 1\n```");
+    }
+
+    [TestMethod]
+    public async Task Serialize_AdjacentMarkdownCells_MergeOnReload()
+    {
+        var notebook = new NotebookModel();
+        notebook.Cells.Add(new CellModel { Type = "markdown", Source = "First." });
+        notebook.Cells.Add(new CellModel { Type = "markdown", Source = "Second." });
+
+        var serialized = await _serializer.SerializeAsync(notebook);
+        var reloaded = await _serializer.DeserializeAsync(serialized);
+
+        Assert.AreEqual("First.\n\nSecond.", serialized.TrimEnd('\n'));
+        Assert.AreEqual(1, reloaded.Cells.Count);
+        Assert.AreEqual("First.\n\nSecond.", reloaded.Cells[0].Source);
+    }
+
+    [TestMethod]
+    public async Task Serialize_EmptyCodeCell_NoExtraBlankLine()
+    {
+        var notebook = await _serializer.DeserializeAsync("```csharp\n```\n");
+
+        Assert.AreEqual(1, notebook.Cells.Count);
+        Assert.AreEqual("", notebook.Cells[0].Source);
+        Assert.AreEqual("```csharp\n```\n", await _serializer.SerializeAsync(notebook));
+    }
+
+    // --- Round trips ---
+
+    [TestMethod]
+    public async Task RoundTrip_CanonicalFile_ByteIdentical()
+    {
+        var md = "# Title\n\nSome prose.\n\n```csharp\nvar x = 1;\n```\n\nMore prose with `inline code`.\n\n~~~python\nprint(1)\n~~~\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+        var result = await _serializer.SerializeAsync(notebook);
+
+        Assert.AreEqual(md, result);
+    }
+
+    [TestMethod]
+    public async Task RoundTrip_AliasFenceTag_DoesNotChurn()
+    {
+        var md = "```cs\nvar x = 1;\n```\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+        var result = await _serializer.SerializeAsync(notebook);
+
+        Assert.AreEqual(md, result);
+    }
+
+    [TestMethod]
+    public async Task RoundTrip_OddSpacing_NormalizesOnceThenFixedPoint()
+    {
+        var md = "# Title\n\n\n\n```csharp\nvar x = 1;\n```";
+
+        var first = await _serializer.SerializeAsync(await _serializer.DeserializeAsync(md));
+        var second = await _serializer.SerializeAsync(await _serializer.DeserializeAsync(first));
+
+        Assert.AreEqual("# Title\n\n```csharp\nvar x = 1;\n```\n", first);
+        Assert.AreEqual(first, second);
+    }
+
+    [TestMethod]
+    public async Task RoundTrip_CrLf_Preserved()
+    {
+        var md = "# Title\r\n\r\n```csharp\r\nvar x = 1;\r\n```\r\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+        var result = await _serializer.SerializeAsync(notebook);
+
+        Assert.AreEqual("var x = 1;", notebook.Cells[1].Source);
+        Assert.AreEqual(md, result);
+    }
+
+    [TestMethod]
+    public async Task RoundTrip_UnknownFenceInProse_Preserved()
+    {
+        var md = "Before.\n\n```json\n{ \"a\": 1 }\n```\n\nAfter.\n";
+
+        var notebook = await _serializer.DeserializeAsync(md);
+        var result = await _serializer.SerializeAsync(notebook);
+
+        Assert.AreEqual(md, result);
+    }
+}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -110,7 +110,7 @@
       "explorer/context": [
         {
           "command": "verso.openInVerso",
-          "when": "resourceExtname == .md",
+          "when": "resourceExtname == .md && config.verso.showOpenInVersoMenu",
           "group": "navigation"
         }
       ]
@@ -168,6 +168,11 @@
           "type": "boolean",
           "default": false,
           "description": "When opening an .ipynb file, save changes back to .ipynb instead of converting to .verso. Cell outputs are preserved. Default off keeps the existing convert-on-save behavior. Markdown (.md) notebooks always save back to .md regardless of this setting."
+        },
+        "verso.showOpenInVersoMenu": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the 'Open in Verso' entry in the Explorer context menu for Markdown (.md) files. Disabling this hides the menu entry only; .md files can still be opened in Verso through the editor's 'Reopen Editor With...' picker."
         }
       }
     },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -64,8 +64,10 @@
   ],
   "activationEvents": [
     "onCustomEditor:verso.blazorNotebook",
+    "onCustomEditor:verso.markdownNotebook",
     "onCommand:verso.newNotebook",
-    "onCommand:verso.compareWithBaseline"
+    "onCommand:verso.compareWithBaseline",
+    "onCommand:verso.openInVerso"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -80,19 +82,35 @@
         "title": "Compare Notebook with...",
         "category": "Verso",
         "icon": "$(diff)"
+      },
+      {
+        "command": "verso.openInVerso",
+        "title": "Open in Verso",
+        "category": "Verso"
       }
     ],
     "menus": {
       "commandPalette": [
         {
           "command": "verso.compareWithBaseline",
-          "when": "activeCustomEditorId == verso.blazorNotebook"
+          "when": "activeCustomEditorId == verso.blazorNotebook || activeCustomEditorId == verso.markdownNotebook"
+        },
+        {
+          "command": "verso.openInVerso",
+          "when": "false"
         }
       ],
       "editor/title": [
         {
           "command": "verso.compareWithBaseline",
-          "when": "activeCustomEditorId == verso.blazorNotebook",
+          "when": "activeCustomEditorId == verso.blazorNotebook || activeCustomEditorId == verso.markdownNotebook",
+          "group": "navigation"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "verso.openInVerso",
+          "when": "resourceExtname == .md",
           "group": "navigation"
         }
       ]
@@ -113,6 +131,16 @@
           }
         ],
         "priority": "default"
+      },
+      {
+        "viewType": "verso.markdownNotebook",
+        "displayName": "Verso Notebook",
+        "selector": [
+          {
+            "filenamePattern": "*.md"
+          }
+        ],
+        "priority": "option"
       }
     ],
     "configuration": {
@@ -139,7 +167,7 @@
         "verso.preserveOriginalFormat": {
           "type": "boolean",
           "default": false,
-          "description": "When opening an .ipynb file, save changes back to .ipynb instead of converting to .verso. Cell outputs are preserved. Default off keeps the existing convert-on-save behavior."
+          "description": "When opening an .ipynb file, save changes back to .ipynb instead of converting to .verso. Cell outputs are preserved. Default off keeps the existing convert-on-save behavior. Markdown (.md) notebooks always save back to .md regardless of this setting."
         }
       }
     },

--- a/vscode/src/blazor/blazorBridge.ts
+++ b/vscode/src/blazor/blazorBridge.ts
@@ -504,6 +504,9 @@ export class BlazorBridge implements vscode.Disposable {
       case "text/markdown":
         return { "Markdown Files": ["md"], "All Files": ["*"] };
       default:
+        if (ext === "verso") {
+          return { "Verso Notebooks": ["verso"], "All Files": ["*"] };
+        }
         if (ext) {
           return { Files: [ext], "All Files": ["*"] };
         }

--- a/vscode/src/blazor/blazorEditorProvider.ts
+++ b/vscode/src/blazor/blazorEditorProvider.ts
@@ -42,6 +42,9 @@ export class BlazorEditorProvider
   implements vscode.CustomEditorProvider<VersoDocument>
 {
   public static readonly viewType = "verso.blazorNotebook";
+  /** Secondary registration used for Markdown notebooks, declared with priority
+   *  "option" so Verso never claims .md files as their default editor. */
+  public static readonly markdownViewType = "verso.markdownNotebook";
 
   private readonly bridges = new Map<vscode.WebviewPanel, BlazorBridge>();
   private readonly hosts = new Map<vscode.WebviewPanel, HostProcess>();
@@ -489,9 +492,14 @@ export class BlazorEditorProvider
 
   // Extensions Verso can write back in their original format. Anything not listed
   // here falls through to the convert-to-.verso path even when the
-  // verso.preserveOriginalFormat setting is on.
-  private static readonly preservableFormats: Record<string, string> = {
-    ".ipynb": "jupyter",
+  // verso.preserveOriginalFormat setting is on. Entries with `always: true`
+  // round-trip unconditionally, without consulting the setting.
+  private static readonly preservableFormats: Record<
+    string,
+    { format: string; always: boolean }
+  > = {
+    ".ipynb": { format: "jupyter", always: false },
+    ".md": { format: "markdown", always: true },
   };
 
   async saveCustomDocument(
@@ -514,8 +522,9 @@ export class BlazorEditorProvider
     const ext = path.extname(fsPath).toLowerCase();
     const preserveSetting = vscode.workspace.getConfiguration("verso")
       .get<boolean>("preserveOriginalFormat", false);
-    const preservableFormat = BlazorEditorProvider.preservableFormats[ext];
-    const shouldPreserve = ext !== ".verso" && preserveSetting && preservableFormat !== undefined;
+    const preservable = BlazorEditorProvider.preservableFormats[ext];
+    const shouldPreserve =
+      ext !== ".verso" && preservable !== undefined && (preservable.always || preserveSetting);
 
     // Source isn't .verso and the user hasn't opted in to preservation (or the
     // format isn't writable back): redirect to a sibling .verso file.
@@ -542,7 +551,7 @@ export class BlazorEditorProvider
       return;
     }
 
-    const format = ext === ".verso" ? "verso" : preservableFormat;
+    const format = ext === ".verso" ? "verso" : preservable?.format;
     const result = await host.sendRequest<NotebookSaveResult>(
       "notebook/save",
       { notebookId, format }
@@ -568,15 +577,16 @@ export class BlazorEditorProvider
     const destExt = path.extname(destination.fsPath).toLowerCase();
     const preserveSetting = vscode.workspace.getConfiguration("verso")
       .get<boolean>("preserveOriginalFormat", false);
-    const preservableFormat = BlazorEditorProvider.preservableFormats[destExt];
-    const shouldPreserve = destExt !== ".verso" && preserveSetting && preservableFormat !== undefined;
+    const preservable = BlazorEditorProvider.preservableFormats[destExt];
+    const shouldPreserve =
+      destExt !== ".verso" && preservable !== undefined && (preservable.always || preserveSetting);
 
     let targetUri = destination;
     let format = "verso";
     if (destExt === ".verso") {
       format = "verso";
     } else if (shouldPreserve) {
-      format = preservableFormat;
+      format = preservable.format;
     } else {
       // Destination isn't writable in its requested format: coerce to .verso.
       const versoPath = destination.fsPath.replace(/\.[^.]+$/, ".verso");

--- a/vscode/src/copilot/participant.ts
+++ b/vscode/src/copilot/participant.ts
@@ -293,7 +293,7 @@ const handler: vscode.ChatRequestHandler = async (
   // Check if any notebook is open
   if (hostRegistry.size === 0) {
     stream.markdown(
-      "No Verso notebook is currently open. Open a `.verso`, `.ipynb`, or `.dib` file first."
+      "No Verso notebook is currently open. Open a `.verso`, `.ipynb`, `.md`, or `.dib` file first."
     );
     return {};
   }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -39,6 +39,31 @@ export async function activate(
     )
   );
 
+  // Second registration of the same provider for Markdown notebooks. Declared with
+  // priority "option" in package.json so Verso never becomes the default editor for
+  // .md files; users reach it via "Open With..." or the explorer context command.
+  context.subscriptions.push(
+    vscode.window.registerCustomEditorProvider(
+      BlazorEditorProvider.markdownViewType,
+      blazorProvider,
+      { webviewOptions: { retainContextWhenHidden: true } }
+    )
+  );
+
+  // Explorer right-click entry for .md files (also callable with the active editor's file).
+  context.subscriptions.push(
+    vscode.commands.registerCommand("verso.openInVerso", (uri?: vscode.Uri) => {
+      const target = uri ?? vscode.window.activeTextEditor?.document.uri;
+      if (target) {
+        return vscode.commands.executeCommand(
+          "vscode.openWith",
+          target,
+          BlazorEditorProvider.markdownViewType
+        );
+      }
+    })
+  );
+
   // Command-palette entry to start a blank notebook without first creating a
   // file. Opens a scratch .verso the provider cleans up if it's never kept.
   context.subscriptions.push(


### PR DESCRIPTION
This pull request introduces Markdown notebook support in Verso, allowing `.md` files to be opened, edited, and saved as runnable notebooks alongside `.verso` and `.ipynb` files. It also refines the notebook format selection logic so that formats like Markdown, which are designed to round-trip cleanly, are preserved by default on save—unless explicitly overridden. Additionally, there are usability improvements to cell interaction and updates to documentation and UI to reflect these changes.

**Markdown notebook support and format preservation:**

* Verso now treats `.md` (Markdown) files as runnable notebooks, updating UI prompts, file dialogs, and CLI commands to include `.md` as a supported format. (`src/Verso.Blazor/Components/Pages/NotebookPage.razor`, `src/Verso.Blazor/Components/DiffSourcePickerDialog.razor`, `src/Verso.Cli/Commands/ConvertCommand.cs`, `src/Verso.Cli/Utilities/SerializerResolver.cs`, [[1]](diffhunk://#diff-4d80564157e55f873f36c6f8951f7e9967377f42b731ed906a478e8bdd069788L109-R109) [[2]](diffhunk://#diff-c0c9caf2a327447ccaced3e36eaf22ca1831842b1b93397ea00ff058d54fddf6L54-R54) [[3]](diffhunk://#diff-dc56b433e4ac05f32cfcfbef3fd60268c3a10f2ff6e0c8ebc9125c7b4f4810a5L16-R24) [[4]](diffhunk://#diff-7472fdd44cda95657198d9688f7ff9d27040a035ed5d7252d9702f4a9f64f997L26-R26) [[5]](diffhunk://#diff-7472fdd44cda95657198d9688f7ff9d27040a035ed5d7252d9702f4a9f64f997R42) [[6]](diffhunk://#diff-7472fdd44cda95657198d9688f7ff9d27040a035ed5d7252d9702f4a9f64f997L51-R52)
* Introduces the `PreservesFormatByDefault` property to the `INotebookSerializer` interface, enabling serializers (like Markdown) to indicate that their format should be preserved by default on save. (`src/Verso.Abstractions/Extensions/INotebookSerializer.cs`, `docs/extensions/extension-interfaces.md`, [[1]](diffhunk://#diff-e83fe20048044dc9e3ec5e91873ee683fd9632de02b9d9d18c57d7440ef51bc9R40-R47) [[2]](diffhunk://#diff-772bb20d8e2cc4852f268f64bdad9683209946956a81593bfcdb98f974c0a675R312)
* Updates the save logic in both the Blazor frontend and CLI/host to honor serializers that preserve format by default, preventing unwanted conversion to `.verso` unless explicitly requested. (`src/Verso.Blazor/Components/Pages/NotebookPage.razor`, `src/Verso.Blazor/Services/ServerNotebookService.cs`, `src/Verso.Cli/Repl/Meta/Commands/SaveMeta.cs`, `src/Verso.Host/Handlers/NotebookHandler.cs`, [[1]](diffhunk://#diff-4d80564157e55f873f36c6f8951f7e9967377f42b731ed906a478e8bdd069788L869-R870) [[2]](diffhunk://#diff-5bf77b37e9b88e30da52a4031af507a377c6d1d3952b4ebdacb76ffca36b7477L476-R497) [[3]](diffhunk://#diff-5bf77b37e9b88e30da52a4031af507a377c6d1d3952b4ebdacb76ffca36b7477L497-R522) [[4]](diffhunk://#diff-abe6e00398a23bb145b9acfecaac0a672c841042aa86e40b37828dc6c4fe1e55L33-R40) [[5]](diffhunk://#diff-f8e7b7938730f3fc273528fb4c206ddfe9e05ce26164b03b78efd7b356c26089L298-R298) [[6]](diffhunk://#diff-f8e7b7938730f3fc273528fb4c206ddfe9e05ce26164b03b78efd7b356c26089R307-R318)

**Cell interaction and UI improvements:**

* Enhances cell preview interaction: prevents cell selection from triggering when clicking on interactive controls or when ending a drag-selection of output text, improving usability for copying and interacting with cell outputs. (`src/Verso.Blazor.Shared/wwwroot/js/cell-interact-interop.js`, [[1]](diffhunk://#diff-4f10beac35f8f49e78d220058144d251662b8ddfa8c4a2bf0860b2fc22eabbc5L153-R166) [[2]](diffhunk://#diff-4f10beac35f8f49e78d220058144d251662b8ddfa8c4a2bf0860b2fc22eabbc5R186-R198) [[3]](diffhunk://#diff-4f10beac35f8f49e78d220058144d251662b8ddfa8c4a2bf0860b2fc22eabbc5L200-R222)
* Ensures notebook metadata correctly tracks the file path for open notebooks. (`src/Verso.Blazor/Services/BlazorToolbarActionContext.cs`, [src/Verso.Blazor/Services/BlazorToolbarActionContext.csL61-R61](diffhunk://#diff-746ce150954a0aa932ae7f78e760bb8dba4bc1dede649e39cfe76f5f65b9e05bL61-R61))

**Documentation and samples:**

* Adds a comprehensive Markdown notebook sample (`sample-markdown.md`) that demonstrates executable code, prose, diagrams, and the new round-tripping behavior. (`samples/notebooks/sample-markdown.md`, [samples/notebooks/sample-markdown.mdR1-R123](diffhunk://#diff-06afa6ec7e1ae02f913dd247e595b40b6871eda6e72ac8a064ac5b4b139612f3R1-R123))

These changes make Verso more flexible for authoring and sharing notebooks in Markdown, improve the user experience for file handling and cell interaction, and clarify the behavior for extension authors and users.