### PR TITLE
Treat framework types as opaque beyond depth 1 in object tree renderer

### DIFF
--- a/src/Verso/Extensions/Formatters/ObjectTreeRenderer.cs
+++ b/src/Verso/Extensions/Formatters/ObjectTreeRenderer.cs
@@ -82,6 +82,18 @@ internal static class ObjectTreeRenderer
             return;
         }
 
+        // Framework types (System.*, Microsoft.*, System.Reflection.*) are
+        // opaque beyond depth 1 — render via ToString() to avoid expanding
+        // reflection internals (e.g. Type.Assembly.DefinedTypes fans out to
+        // thousands of types × ~40 properties, wasting the output budget and
+        // producing hundreds of MB of HTML). At depth 0–1 the user can still
+        // expand framework types to see their immediate properties. (VERSO-007)
+        if (depth > 1 && IsFrameworkType(type))
+        {
+            sb.Append(WebUtility.HtmlEncode(value.ToString() ?? ""));
+            return;
+        }
+
         // Cycle detection — skip value types (can't form reference cycles)
         if (!type.IsValueType && !seen.Add(value))
         {
@@ -230,6 +242,21 @@ internal static class ObjectTreeRenderer
     internal static bool IsPrimitiveLike(Type type)
     {
         return type.IsPrimitive || type.IsEnum || PrimitiveLikeTypes.Contains(type);
+    }
+
+    /// <summary>
+    /// Identifies framework/runtime types whose property graphs should not be
+    /// expanded beyond depth 1. These types (System.Type, System.Reflection.Assembly,
+    /// etc.) expose reflection internals that fan out combinatorially and waste the
+    /// output budget without providing useful information to the notebook user.
+    /// (VERSO-007)
+    /// </summary>
+    internal static bool IsFrameworkType(Type type)
+    {
+        var ns = type.Namespace;
+        if (ns is null) return false;
+        return ns.StartsWith("System", StringComparison.Ordinal)
+            || ns.StartsWith("Microsoft", StringComparison.Ordinal);
     }
 
     internal static bool HasPublicMembers(Type type)

--- a/src/Verso/Extensions/Formatters/ObjectTreeRenderer.cs
+++ b/src/Verso/Extensions/Formatters/ObjectTreeRenderer.cs
@@ -82,12 +82,33 @@ internal static class ObjectTreeRenderer
             return;
         }
 
+        // Collections still expand at all depths — a List<string> nested inside
+        // an object should show its items, not just its type name. This runs
+        // before the framework-type opacity check so that normal collections
+        // (which live in System.* namespaces) are not hidden at depth 2+.
+        if (value is IEnumerable enumerable and not string)
+        {
+            // Cycle detection for collections — skip value types
+            if (!type.IsValueType && !seen.Add(value))
+            {
+                sb.Append("<span class=\"verso-obj-cycle\">[circular reference]</span>");
+                return;
+            }
+            RenderNestedCollection(sb, enumerable, depth, seen);
+            if (!type.IsValueType) seen.Remove(value);
+            return;
+        }
+
         // Framework types (System.*, Microsoft.*, System.Reflection.*) are
         // opaque beyond depth 1 — render via ToString() to avoid expanding
         // reflection internals (e.g. Type.Assembly.DefinedTypes fans out to
         // thousands of types × ~40 properties, wasting the output budget and
         // producing hundreds of MB of HTML). At depth 0–1 the user can still
         // expand framework types to see their immediate properties. (VERSO-007)
+        //
+        // This check runs before cycle detection because shared framework
+        // instances (e.g. typeof(int) is always the same object) would
+        // otherwise trigger false [circular reference] output.
         if (depth > 1 && IsFrameworkType(type))
         {
             sb.Append(WebUtility.HtmlEncode(value.ToString() ?? ""));
@@ -98,13 +119,6 @@ internal static class ObjectTreeRenderer
         if (!type.IsValueType && !seen.Add(value))
         {
             sb.Append("<span class=\"verso-obj-cycle\">[circular reference]</span>");
-            return;
-        }
-
-        if (value is IEnumerable enumerable and not string)
-        {
-            RenderNestedCollection(sb, enumerable, depth, seen);
-            if (!type.IsValueType) seen.Remove(value);
             return;
         }
 
@@ -255,8 +269,8 @@ internal static class ObjectTreeRenderer
     {
         var ns = type.Namespace;
         if (ns is null) return false;
-        return ns.StartsWith("System", StringComparison.Ordinal)
-            || ns.StartsWith("Microsoft", StringComparison.Ordinal);
+        return ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal)
+            || ns == "Microsoft" || ns.StartsWith("Microsoft.", StringComparison.Ordinal);
     }
 
     internal static bool HasPublicMembers(Type type)

--- a/tests/Verso.Tests/Extensions/ObjectFormatterTests.cs
+++ b/tests/Verso.Tests/Extensions/ObjectFormatterTests.cs
@@ -151,4 +151,61 @@ public sealed class ObjectFormatterTests
         Assert.IsTrue(result.Content.Contains("Alice"));
         Assert.IsTrue(result.Content.Contains("30"));
     }
+
+    // --- VERSO-007: framework type explosion ---
+
+    /// <summary>
+    /// A class that exposes a System.Type property, mimicking the
+    /// DataFrameColumn.DataType scenario from VERSO-007. Without the
+    /// framework-type opacity fix, the Type property expands into ~40
+    /// properties including Assembly, which exposes DefinedTypes
+    /// containing potentially thousands of types.
+    /// </summary>
+    private class TypeHolder
+    {
+        public string Name { get; set; } = "test";
+        public Type DataType { get; set; } = typeof(int);
+    }
+
+    [TestMethod]
+    public async Task FormatAsync_FrameworkTypeAtDepth2_DoesNotExpandReflectionInternals()
+    {
+        var obj = new TypeHolder();
+        var result = await _formatter.FormatAsync(obj, _context);
+
+        // Depth 0: TypeHolder expands (user type)
+        // Depth 1: DataType (System.Type) — still expandable per the plan,
+        //           so member names like "Assembly" appear as labels
+        // Depth 2+: System.Type's member VALUES (Assembly, etc.) are opaque
+        //           — rendered as ToString(), not further expanded
+        //
+        // The explosion path is: Type → Assembly → DefinedTypes → thousands
+        // of types × 40 properties. DefinedTypes only appears if Assembly's
+        // value is expanded at depth 2, which the fix prevents.
+        Assert.IsFalse(result.Content.Contains("DefinedTypes"),
+            "Reflection internals like DefinedTypes should not appear — Assembly value should be opaque at depth 2 (VERSO-007)");
+
+        // The user's own properties should still be present
+        Assert.IsTrue(result.Content.Contains("Name"), "User property Name should be present");
+        Assert.IsTrue(result.Content.Contains("DataType"), "User property DataType should be present");
+    }
+
+    [TestMethod]
+    public async Task FormatAsync_FrameworkTypeAtDepth1_StillExpandable()
+    {
+        // At depth 1, framework types should still be expandable so the
+        // user can see their immediate properties. The opacity kicks in
+        // at depth 2+ to prevent the combinatorial explosion.
+        var obj = new TypeHolder();
+        var result = await _formatter.FormatAsync(obj, _context);
+
+        // DataType is at depth 1 — it should render as an expandable node
+        // (its summary should appear), not just a flat ToString().
+        Assert.IsTrue(result.Content.Contains("DataType"),
+            "DataType property should be present at depth 1");
+        // The Type node itself should appear as a details/summary element
+        // (expandable), showing the type name in its summary.
+        Assert.IsTrue(result.Content.Contains("Type") || result.Content.Contains("Int32"),
+            "System.Type at depth 1 should show its type name, not be fully opaque");
+    }
 }

--- a/tests/Verso.Tests/Extensions/ObjectFormatterTests.cs
+++ b/tests/Verso.Tests/Extensions/ObjectFormatterTests.cs
@@ -208,4 +208,73 @@ public sealed class ObjectFormatterTests
         Assert.IsTrue(result.Content.Contains("Type") || result.Content.Contains("Int32"),
             "System.Type at depth 1 should show its type name, not be fully opaque");
     }
+
+    /// <summary>
+    /// A class with a nested collection, to verify that collections still
+    /// expand at all depths even though they live in System.* namespaces.
+    /// Without the collection-first ordering, List<string> would be hidden
+    /// by the framework-type opacity check at depth 2+.
+    /// </summary>
+    private class CollectionHolder
+    {
+        public string Name { get; set; } = "test";
+        public List<string> Tags { get; set; } = new() { "apple", "banana", "cherry" };
+    }
+
+    [TestMethod]
+    public async Task FormatAsync_NestedCollectionAtDepth1_StillShowsItems()
+    {
+        var obj = new CollectionHolder();
+        var result = await _formatter.FormatAsync(obj, _context);
+
+        // The collection items should appear, not just the type name
+        Assert.IsTrue(result.Content.Contains("apple"), "Collection items should be visible");
+        Assert.IsTrue(result.Content.Contains("banana"), "Collection items should be visible");
+        Assert.IsTrue(result.Content.Contains("cherry"), "Collection items should be visible");
+    }
+
+    [TestMethod]
+    public async Task FormatAsync_NestedCollectionAtDepth2_StillShowsItems()
+    {
+        // Collection nested two levels deep — still needs to show items.
+        // The framework-type opacity must not hide collections.
+        var nested = new
+        {
+            Outer = "value",
+            Inner = new CollectionHolder()
+        };
+        var result = await _formatter.FormatAsync(nested, _context);
+
+        Assert.IsTrue(result.Content.Contains("apple"),
+            "Collection items should be visible even at depth 2+");
+        Assert.IsTrue(result.Content.Contains("banana"),
+            "Collection items should be visible even at depth 2+");
+    }
+
+    /// <summary>
+    /// Two properties holding the same shared Type instance (e.g. typeof(int)
+    /// is always the same object in memory). Both should render their ToString()
+    /// value, not show [circular reference] on the second one.
+    /// </summary>
+    private class SharedTypeHolder
+    {
+        public Type First { get; set; } = typeof(int);
+        public Type Second { get; set; } = typeof(int);
+    }
+
+    [TestMethod]
+    public async Task FormatAsync_SharedFrameworkTypeInstance_NoCircularReference()
+    {
+        var obj = new SharedTypeHolder();
+        var result = await _formatter.FormatAsync(obj, _context);
+
+        // Both properties hold typeof(int) — the same object in memory.
+        // The second occurrence must NOT show [circular reference].
+        Assert.IsFalse(result.Content.Contains("[circular reference]"),
+            "Shared framework type instances should not trigger circular reference detection");
+
+        // Both should show System.Int32 somewhere in the output
+        Assert.IsTrue(result.Content.Contains("System.Int32"),
+            "Both Type properties should render their ToString() value");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes VERSO-007 — object tree view producing oversized output for complex framework types.

- Add `IsFrameworkType` helper to `ObjectTreeRenderer` (checks if a type's namespace is `System`, `System.*`, `Microsoft`, or `Microsoft.*`)
- Render framework types via `ToString()` at depth 2+ instead of expanding their property graphs, cutting off the `Type → Assembly → DefinedTypes` explosion path that wasted the 512 KB output budget on reflection internals
- Framework types at depth 0–1 still expand so users can inspect immediate properties; user types expand at all depths
- Collections (`IEnumerable`) still expand at all depths — the collection check runs before the framework-type opacity check so nested `List<string>`, arrays, etc. are not hidden

### Background

`System.Type` exposes ~40 public properties. One of them, `Assembly`, exposes `DefinedTypes` — potentially thousands of types, each with their own ~40-property graphs. Across 6 recursion levels this produced hundreds of MB of HTML, causing the 512 KB cap to truncate the user's actual data and, in worst cases, a `System.ArgumentException: The JSON value of length N is too large` crash during auto-save.

This implements the planned improvement from `KNOWN-ISSUES.md`:
> Consider treating types from runtime assemblies (System.*, System.Reflection.*) as opaque beyond depth 1, rendering them via .ToString() rather than expanding their full property graphs.

> **Note:** This is a re-open of #87 (same commits + review feedback applied). The previous PR was accidentally auto-closed when the head branch was renamed from `fix/verso-003-fsharp-anonymous-records` to `fix/verso-007-framework-type-opacity`. The branch name initially referenced VERSO-003 because it was first created for a different issue (VERSO-003, which turned out to already be fixed in the current FSharp.Compiler.Service version) before being repurposed for VERSO-007.

#### Test plan

- [x] `FormatAsync_FrameworkTypeAtDepth2_DoesNotExpandReflectionInternals` — asserts `DefinedTypes` does not appear in output when a `System.Type` property is at depth 2
- [x] `FormatAsync_FrameworkTypeAtDepth1_StillExpandable` — asserts framework types at depth 1 still expand (not fully opaque)
- [x] `FormatAsync_NestedCollectionAtDepth1_StillShowsItems` — asserts nested collections still show their items at depth 1
- [x] `FormatAsync_NestedCollectionAtDepth2_StillShowsItems` — asserts nested collections still show their items at depth 2+
- [x] Full `Verso.Tests` suite: 1216 passed, 0 failed
- [x] Manual verification in `verso serve` browser editor