### PR TITLE
Target PowerShell kernel to .NET 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ dotnet run --project src/Verso.Blazor
 ### Build the VS Code Extension
 
 ```bash
-dotnet build src/Verso.Host
+dotnet build src/Verso.Host -f net10.0
 cd vscode
 npm install
 npm run build:all

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -7,10 +7,10 @@ The original copyright notices and license texts are provided for each component
 
 | Component | Version | License | Project |
 |---|---|---|---|
-| Microsoft.CodeAnalysis (Roslyn) | 4.12.0 | MIT | [dotnet/roslyn](https://github.com/dotnet/roslyn) |
+| Microsoft.CodeAnalysis (Roslyn) | 4.12.0 / 5.0.0 | MIT | [dotnet/roslyn](https://github.com/dotnet/roslyn) |
 | NuGet.Protocol | 6.9.1 | Apache-2.0 | [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) |
 | Microsoft.AspNetCore.Components | 8.0.0 | MIT | [dotnet/aspnetcore](https://github.com/dotnet/aspnetcore) |
-| Microsoft.PowerShell.SDK | 7.4.7 | MIT | [PowerShell/PowerShell](https://github.com/PowerShell/PowerShell) |
+| Microsoft.PowerShell.SDK | 7.4.15 / 7.6.4 | MIT | [PowerShell/PowerShell](https://github.com/PowerShell/PowerShell) |
 | FSharp.Compiler.Service | 43.9.100 | MIT | [dotnet/fsharp](https://github.com/dotnet/fsharp) |
 | Jint | 4.6.4 | BSD-2-Clause | [sebastienros/jint](https://github.com/sebastienros/jint) |
 | pythonnet | 3.1.0-rc.0 | MIT | [pythonnet/pythonnet](https://github.com/pythonnet/pythonnet) |

--- a/src/Verso.Host/Verso.Host.csproj
+++ b/src/Verso.Host/Verso.Host.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/Verso.PowerShell/Verso.PowerShell.csproj
+++ b/src/Verso.PowerShell/Verso.PowerShell.csproj
@@ -19,8 +19,12 @@
     <InternalsVisibleTo Include="Verso.PowerShell.Tests" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.7" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.15" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Verso/Verso.csproj
+++ b/src/Verso/Verso.csproj
@@ -23,11 +23,21 @@
 
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.37.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.9.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.12.0" />
-    <PackageReference Include="NuGet.Protocol" Version="6.9.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Verso.Host.Tests/Verso.Host.Tests.csproj
+++ b/tests/Verso.Host.Tests/Verso.Host.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/Verso.PowerShell.Tests/Verso.PowerShell.Tests.csproj
+++ b/tests/Verso.PowerShell.Tests/Verso.PowerShell.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -590,7 +590,7 @@
   },
   "scripts": {
     "build": "node esbuild.mjs",
-    "build:host": "dotnet publish ../src/Verso.Host -c Release -o host",
+    "build:host": "dotnet publish ../src/Verso.Host -c Release -f net10.0 -o host",
     "build:wasm": "dotnet publish ../src/Verso.Blazor.Wasm -c Release -o blazor-wasm",
     "build:all": "npm run build:host && npm run build:wasm && npm run build",
     "watch": "node esbuild.mjs --watch",

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -187,18 +187,21 @@ export function resolveHostPath(
 
   // Search workspace folders for the Verso.Host.dll (check Release first, then Debug)
   const configs = ["Release", "Debug"];
+  const targetFrameworks = ["net10.0", "net8.0"];
   const workspaceFolders = options.workspaceFolders ?? vscode.workspace.workspaceFolders ?? [];
   for (const folder of workspaceFolders) {
     for (const cfg of configs) {
-      const candidates = [
-        // Direct workspace is the Verso project
-        path.join(folder.uri.fsPath, "src", "Verso.Host", "bin", cfg, "net8.0", "Verso.Host.dll"),
-        // Workspace is a parent
-        path.join(folder.uri.fsPath, "tools", "Verso", "src", "Verso.Host", "bin", cfg, "net8.0", "Verso.Host.dll"),
-      ];
-      for (const candidate of candidates) {
-        if (existsSync(candidate)) {
-          return candidate;
+      for (const tfm of targetFrameworks) {
+        const candidates = [
+          // Direct workspace is the Verso project
+          path.join(folder.uri.fsPath, "src", "Verso.Host", "bin", cfg, tfm, "Verso.Host.dll"),
+          // Workspace is a parent
+          path.join(folder.uri.fsPath, "tools", "Verso", "src", "Verso.Host", "bin", cfg, tfm, "Verso.Host.dll"),
+        ];
+        for (const candidate of candidates) {
+          if (existsSync(candidate)) {
+            return candidate;
+          }
         }
       }
     }
@@ -206,9 +209,11 @@ export function resolveHostPath(
 
   // Fallback: relative to extension path (works in dev host / local install)
   for (const cfg of configs) {
-    const extensionRelative = path.join(context.extensionPath, "..", "src", "Verso.Host", "bin", cfg, "net8.0", "Verso.Host.dll");
-    if (existsSync(extensionRelative)) {
-      return extensionRelative;
+    for (const tfm of targetFrameworks) {
+      const extensionRelative = path.join(context.extensionPath, "..", "src", "Verso.Host", "bin", cfg, tfm, "Verso.Host.dll");
+      if (existsSync(extensionRelative)) {
+        return extensionRelative;
+      }
     }
   }
 

--- a/vscode/test/suite/extension.test.ts
+++ b/vscode/test/suite/extension.test.ts
@@ -86,4 +86,28 @@ suite("Extension Activation", () => {
 
     assert.strictEqual(resolved, configured);
   });
+
+  test("Workspace host resolution prefers net10 over net8", () => {
+    const extensionPath = path.join("repo", "vscode");
+    const workspacePath = path.resolve("repo", "Verso");
+    const context = {
+      extensionPath,
+      extensionMode: vscode.ExtensionMode.Production,
+    } as vscode.ExtensionContext;
+    const workspaceFolder = {
+      uri: vscode.Uri.file(workspacePath),
+      name: "Verso",
+      index: 0,
+    };
+    const workspaceFsPath = workspaceFolder.uri.fsPath;
+    const net10Host = path.join(workspaceFsPath, "src", "Verso.Host", "bin", "Debug", "net10.0", "Verso.Host.dll");
+    const net8Host = path.join(workspaceFsPath, "src", "Verso.Host", "bin", "Debug", "net8.0", "Verso.Host.dll");
+
+    const resolved = resolveHostPath(context, {
+      existsSync: candidate => candidate === net10Host || candidate === net8Host,
+      workspaceFolders: [workspaceFolder],
+    });
+
+    assert.strictEqual(resolved, net10Host);
+  });
 });


### PR DESCRIPTION
## Summary

- update `Verso.PowerShell` to use `Microsoft.PowerShell.SDK` 7.4.15 on `net8.0` and 7.6.4 on `net10.0`
- move `Verso.Host` and host/runtime-focused test projects to `net10.0`
- publish and resolve the VS Code host from the `net10.0` output path, with `net8.0` retained as a local fallback
- keep the PR scoped to the PowerShell kernel/runtime update

## Notes

- `Microsoft.PowerShell.SDK` 7.6.4 requires Roslyn 5.0.0 through its transitive dependencies, so `Verso.csproj` keeps Roslyn 4.12.0 for `net8.0` and uses 5.0.0 for `net10.0`.
- This replaces the closed #53/#54 split with a narrower PR. The notebook/sample work can stay separate.
- Build and test currently report NU1903 warnings for transitive `System.Security.Cryptography.Xml` packages from the PowerShell SDK dependency graph.

## Validation

- `dotnet build src/Verso.Host/Verso.Host.csproj -f net10.0`
- `dotnet test tests/Verso.PowerShell.Tests/Verso.PowerShell.Tests.csproj -f net10.0`
- `dotnet test tests/Verso.Host.Tests/Verso.Host.Tests.csproj -f net10.0`
- `npm run lint` from `vscode/`
- `npm run pretest` from `vscode/`