### PR TITLE
Add PowerShell graph and MNIST notebooks

### DIFF
--- a/samples/Notebooks/powershell/micrograd/Value.format.ps1xml
+++ b/samples/Notebooks/powershell/micrograd/Value.format.ps1xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration>
+  <ViewDefinitions>
+    <View>
+      <Name>Value</Name>
+      <ViewSelectedBy>
+        <TypeName>Value</TypeName>
+      </ViewSelectedBy>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <ExpressionBinding>
+                <ScriptBlock>$_.data</ScriptBlock>
+              </ExpressionBinding>
+              <NewLine />
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </View>
+  </ViewDefinitions>
+</Configuration>

--- a/samples/Notebooks/powershell/micrograd/graphHelper.ps1
+++ b/samples/Notebooks/powershell/micrograd/graphHelper.ps1
@@ -1,0 +1,163 @@
+#Requires -Modules @{ ModuleName = 'PSQuickGraph'; ModuleVersion = '2.6.0' }
+#Requires -Modules @{ ModuleName = 'PSGraphView'; ModuleVersion = '0.2.0' }
+
+function New-ValueNode([Value]$value) {
+    [pscustomobject]@{
+        kind  = 'value'
+        value = $value
+        label = $value.label
+        data  = $value.data
+        grad  = $value.grad
+    }
+}
+
+function New-OperationNode([Value]$value) {
+    [pscustomobject]@{
+        kind      = 'op'
+        value     = $value
+        label     = $value.operation
+        operation = $value.operation
+        data      = $value.data
+    }
+}
+
+
+# visualisation
+function New-ExpressionGraph {
+    param(
+        [Value]$val,
+        $graph = $null,
+        [hashtable]$valueVertices = $null,
+        [hashtable]$operationVertices = $null
+    )
+
+    if ($null -eq $graph) {
+        $graph = New-Graph -UseNonUniqueLabels
+    }
+
+    if ($null -eq $valueVertices) {
+        $valueVertices = @{}
+    }
+
+    if ($null -eq $operationVertices) {
+        $operationVertices = @{}
+    }
+
+    if (-not $valueVertices.ContainsKey($val)) {
+        $valueVertices[$val] = Add-Vertex -Graph $graph -Vertex (New-ValueNode $val) -PassThru
+    }
+
+    $valueVertex = $valueVertices[$val]
+
+    if ($val.operation) {
+        if (-not $operationVertices.ContainsKey($val)) {
+            $operationVertices[$val] = Add-Vertex -Graph $graph -Vertex (New-OperationNode $val) -PassThru
+        }
+
+        $operationVertex = $operationVertices[$val]
+
+        Add-Edge -From $operationVertex -To $valueVertex -Graph $graph | Out-Null
+    }
+
+
+    if ($val.children) {
+        foreach ($child in $val.children) {
+            New-ExpressionGraph `
+                -val $child `
+                -graph $graph `
+                -valueVertices $valueVertices `
+                -operationVertices $operationVertices | Out-Null
+
+            $childVertex = $valueVertices[$child]
+
+            if ($val.operation) {
+                Add-Edge -From $childVertex -To $operationVertex -Graph $graph | Out-Null
+            }
+        }
+    }
+
+    return $graph
+}
+
+
+
+# backprop
+function New-BackpropagationGraph {
+    param(
+        [Value]$val,
+        $graph = $null,
+        [hashtable]$valueVertices = $null
+    )
+
+    if ($null -eq $graph) {
+        $graph = New-Graph -UseNonUniqueLabels
+    }
+
+    if ($null -eq $valueVertices) {
+        $valueVertices = @{}
+    }
+
+    if (-not $valueVertices.ContainsKey($val)) {
+        $valueVertices[$val] = Add-Vertex -Graph $graph -Vertex $val -PassThru
+    }
+
+    $currentVertex = $valueVertices[$val]
+
+    foreach ($child in $val.children) {
+        if (-not $valueVertices.ContainsKey($child)) {
+            New-BackpropagationGraph `
+                -Graph $graph `
+                -val $child `
+                -valueVertices $valueVertices | Out-Null
+        }
+
+        $childVertex = $valueVertices[$child]
+        Add-Edge -Graph $graph -From $childVertex -To $currentVertex | Out-Null
+    }
+
+    return $graph
+}
+
+
+function Show-ExpressionGraph {
+    param (
+        $graph,
+        $rankdir = "LR"
+    )
+
+    begin {
+        # node formatting lambda
+
+        $vs = {
+            $node = $_
+
+            if ($node.kind -eq 'op') {
+                @{
+                    shape = 'Ellipse'
+                    label = $node.label
+                }
+            }
+            else {
+                $name = if ($node.label) { $node.label } else { '' }
+
+                @{
+                    shape = 'Record'
+                    label = "{ $name | data $($node.data) | grad $($node.grad) }"
+                }
+            }
+        }
+
+        $dot = Export-Graph -Graph $graph -Format Graphviz -GraphScript { @{ rankdir = $rankdir; label = 'Micrograd' } } -VertexScript $vs
+
+        $svg = Export-GraphvizView -InputObject $dot -Renderer Dot -As Svg
+        Display $svg 'image/svg+xml'
+    }
+
+    process {
+
+    }
+
+    end {
+
+    }
+}

--- a/samples/Notebooks/powershell/micrograd/helpers.ps1
+++ b/samples/Notebooks/powershell/micrograd/helpers.ps1
@@ -1,0 +1,55 @@
+function Zip {
+    param(
+        [Parameter(Mandatory)]
+        [object[]]$Left,
+
+        [Parameter(Mandatory)]
+        [object[]]$Right
+    )
+
+    $count = [Math]::Min($Left.Count, $Right.Count)
+
+    for ($i = 0; $i -lt $count; $i++) {
+        [pscustomobject]@{
+            Left  = $Left[$i]
+            Right = $Right[$i]
+        }
+    }
+}
+
+function Sum-Value {
+    param([scriptblock]$Selector)
+
+    begin { $sum = [Value]::new(0.0, 'loss') }
+    process { $sum = $sum + (& $Selector $_) }
+    end { $sum }
+}
+
+function Invoke-ValueBackward {
+    param(
+        [Parameter(Mandatory)]
+        [Value]$Value
+    )
+
+    $topologicalOrder = [System.Collections.Generic.List[Value]]::new()
+    $visited = [System.Collections.Generic.HashSet[Value]]::new()
+
+    function Visit-Value([Value]$Current) {
+        if (-not $visited.Add($Current)) {
+            return
+        }
+
+        foreach ($child in $Current.children) {
+            Visit-Value $child
+        }
+
+        $topologicalOrder.Add($Current)
+    }
+
+    Visit-Value $Value
+    $Value.grad = 1.0
+
+    for ($i = $topologicalOrder.Count - 1; $i -ge 0; $i--) {
+        & $topologicalOrder[$i].backward
+    }
+}

--- a/samples/Notebooks/powershell/micrograd/helpers.ps1
+++ b/samples/Notebooks/powershell/micrograd/helpers.ps1
@@ -32,21 +32,31 @@ function Invoke-ValueBackward {
     )
 
     $topologicalOrder = [System.Collections.Generic.List[Value]]::new()
-    $visited = [System.Collections.Generic.HashSet[Value]]::new()
+    $scheduled = [System.Collections.Generic.HashSet[Value]]::new()
+    $pending = [System.Collections.Generic.Stack[object]]::new()
+    $pending.Push([pscustomobject]@{ Value = $Value; Expanded = $false })
 
-    function Visit-Value([Value]$Current) {
-        if (-not $visited.Add($Current)) {
-            return
+    while ($pending.Count -gt 0) {
+        $frame = $pending.Pop()
+        $current = [Value]$frame.Value
+
+        if ($frame.Expanded) {
+            $topologicalOrder.Add($current)
+            continue
         }
 
-        foreach ($child in $Current.children) {
-            Visit-Value $child
+        if (-not $scheduled.Add($current)) {
+            continue
         }
 
-        $topologicalOrder.Add($Current)
+        $pending.Push([pscustomobject]@{ Value = $current; Expanded = $true })
+        foreach ($child in $current.children) {
+            if (-not $scheduled.Contains($child)) {
+                $pending.Push([pscustomobject]@{ Value = $child; Expanded = $false })
+            }
+        }
     }
 
-    Visit-Value $Value
     $Value.grad = 1.0
 
     for ($i = $topologicalOrder.Count - 1; $i -ge 0; $i--) {

--- a/samples/Notebooks/powershell/micrograd/micrograd-ps.verso
+++ b/samples/Notebooks/powershell/micrograd/micrograd-ps.verso
@@ -18,14 +18,14 @@
     {
       "id": "10897b83-f777-43a3-a85c-d5719da8dd1d",
       "type": "markdown",
-      "source": "## Module Setup\n\nInstall the tested prerelease versions from PowerShell Gallery when needed, then load them from the normal PowerShell module path.",
+      "source": "## Module Setup\n\nLoad the tested prerelease modules from the normal PowerShell module path. Install missing modules from a regular PowerShell terminal before starting Verso; the embedded kernel does not provide PowerShellGet package-management commands.",
       "outputs": []
     },
     {
       "id": "92379945-af96-4131-a373-7f8fc66bcc7e",
       "type": "code",
       "language": "powershell",
-      "source": "$requirements = @{\n    PSQuickGraph = '2.6.0-beta1'\n    PSGraphView = '0.2.0-beta1'\n}\n\nforeach ($entry in $requirements.GetEnumerator()) {\n    $available = Get-Module -ListAvailable -Name $entry.Key | Where-Object {\n        $version = $_.Version.ToString()\n        $prerelease = $_.PrivateData.PSData.Prerelease\n        if ($prerelease) { $version = \"$version-$prerelease\" }\n        $version -eq $entry.Value\n    }\n\n    if (-not $available) {\n        Install-Module $entry.Key -RequiredVersion $entry.Value -AllowPrerelease -Scope CurrentUser -Force\n    }\n}\n\nImport-Module PSQuickGraph -MinimumVersion 2.6.0 -Force\nImport-Module PSGraphView -MinimumVersion 0.2.0 -Force",
+      "source": "$requirements = @(\n    [pscustomobject]@{ Name = 'PSQuickGraph'; Version = '2.6.0-beta1' }\n    [pscustomobject]@{ Name = 'PSGraphView'; Version = '0.2.0-beta1' }\n)\n\n$resolvedModules = foreach ($requirement in $requirements) {\n    $module = Get-Module -ListAvailable -Name $requirement.Name |\n        Where-Object {\n            $version = $_.Version.ToString()\n            $prerelease = $_.PrivateData.PSData.Prerelease\n            if ($prerelease) {\n                $version = \"$version-$prerelease\"\n            }\n            $version -eq $requirement.Version\n        } |\n        Select-Object -First 1\n\n    if ($module) {\n        [pscustomobject]@{\n            Requirement = $requirement\n            Module = $module\n        }\n    }\n}\n\n$missing = $requirements |\n    Where-Object Name -NotIn $resolvedModules.Requirement.Name\n\nif ($missing) {\n    $installCommands = $missing | ForEach-Object {\n        \"Install-Module $($_.Name) -RequiredVersion $($_.Version) -AllowPrerelease -Scope CurrentUser\"\n    }\n\n    throw \"Install the missing modules in a regular PowerShell terminal, restart Verso, and run this cell again:`n$($installCommands -join \"`n\")\"\n}\n\n$resolvedModules | ForEach-Object {\n    Import-Module $_.Module.Path -Force\n}",
       "outputs": []
     },
     {

--- a/samples/Notebooks/powershell/micrograd/micrograd-ps.verso
+++ b/samples/Notebooks/powershell/micrograd/micrograd-ps.verso
@@ -1,0 +1,189 @@
+{
+  "verso": "1.0",
+  "metadata": {
+    "title": "Micrograd in PowerShell with PSGraph",
+    "created": "2026-05-10T00:00:00+00:00",
+    "modified": "2026-05-10T00:00:00+00:00",
+    "defaultKernel": "powershell",
+    "activeLayout": "notebook",
+    "preferredTheme": "verso-light"
+  },
+  "cells": [
+    {
+      "id": "c10006aa-7486-4e47-9a94-dc4762c8982e",
+      "type": "markdown",
+      "source": "# Micrograd in PowerShell with PSGraph\n\nThis notebook builds a small automatic differentiation engine in PowerShell, renders its computation graphs with PSGraph/PSGraphView, and trains a tiny MLP on the classic micrograd toy dataset.",
+      "outputs": []
+    },
+    {
+      "id": "10897b83-f777-43a3-a85c-d5719da8dd1d",
+      "type": "markdown",
+      "source": "## Module Setup\n\nInstall the tested prerelease versions from PowerShell Gallery when needed, then load them from the normal PowerShell module path.",
+      "outputs": []
+    },
+    {
+      "id": "92379945-af96-4131-a373-7f8fc66bcc7e",
+      "type": "code",
+      "language": "powershell",
+      "source": "$requirements = @{\n    PSQuickGraph = '2.6.0-beta1'\n    PSGraphView = '0.2.0-beta1'\n}\n\nforeach ($entry in $requirements.GetEnumerator()) {\n    $available = Get-Module -ListAvailable -Name $entry.Key | Where-Object {\n        $version = $_.Version.ToString()\n        $prerelease = $_.PrivateData.PSData.Prerelease\n        if ($prerelease) { $version = \"$version-$prerelease\" }\n        $version -eq $entry.Value\n    }\n\n    if (-not $available) {\n        Install-Module $entry.Key -RequiredVersion $entry.Value -AllowPrerelease -Scope CurrentUser -Force\n    }\n}\n\nImport-Module PSQuickGraph -MinimumVersion 2.6.0 -Force\nImport-Module PSGraphView -MinimumVersion 0.2.0 -Force",
+      "outputs": []
+    },
+    {
+      "id": "bfc628a3-515c-4905-9458-6246caa81b2e",
+      "type": "markdown",
+      "source": "## Helpers\n\nThe implementation is split into small scripts:\n\n- `value.ps1` defines scalar `Value` objects and operator overloads.\n- `graphHelper.ps1` converts `Value` graphs into PSGraph graphs and renders them.\n- `neuronHelper.ps1` defines `Neuron`, `Layer`, and `MLP`.\n- `helpers.ps1` contains small collection helpers such as `Zip` and `Sum-Value`.",
+      "outputs": []
+    },
+    {
+      "id": "afb60472-57bb-4182-9a12-1340020a4070",
+      "type": "code",
+      "language": "powershell",
+      "source": ". ./value.ps1\n. ./graphHelper.ps1\n. ./neuronHelper.ps1\n. ./helpers.ps1",
+      "outputs": []
+    },
+    {
+      "id": "0f742849-64b1-49d9-b4e0-56f96ac103ee",
+      "type": "markdown",
+      "source": "## Scalar Computation Graph\n\nStart with a single scalar expression. `Value` objects remember their children and the operation that produced them, so PSGraph can render the expression tree.",
+      "outputs": []
+    },
+    {
+      "id": "59e70eeb-26b8-445f-9e86-690798dee592",
+      "type": "code",
+      "language": "powershell",
+      "source": "$a = [Value]::new( 2.0, 'a')\n$b = [Value]::new(-3.0, 'b')\n$c = [Value]::new(10.0, 'c')\n$e = $a * $b; $e.label = 'e'\n$d = $e + $c; $d.label = 'd'\n$f = [Value]::new(-2.0, 'f')\n$L = $d * $f; $L.label = 'L'\n\n$L",
+      "outputs": []
+    },
+    {
+      "id": "165cdfec-dfcb-4aa5-82a0-95f6f5a36cf5",
+      "type": "code",
+      "language": "powershell",
+      "source": "$scalarGraph = New-ExpressionGraph -val $L\nShow-ExpressionGraph -Graph $scalarGraph",
+      "outputs": []
+    },
+    {
+      "id": "bf07b38b-5459-4349-afb2-1f1075d28ae4",
+      "type": "markdown",
+      "source": "## Backpropagation Order\n\nFor backpropagation, build a graph directly on the original `Value` objects. A reverse topological order visits the output first and then walks back toward the leaves. After gradients are computed, rebuild the visualization graph because display nodes store a snapshot of `data` and `grad`.",
+      "outputs": []
+    },
+    {
+      "id": "f69fa599-97c7-4854-aed5-759f23a27e42",
+      "type": "code",
+      "language": "powershell",
+      "source": "$bpGraph = New-BackpropagationGraph -val $L\n$L.grad = 1.0\n\nGet-GraphTopologicalSort -Graph $bpGraph -Reverse |\n    ForEach-Object { $_.OriginalObject } |\n    ForEach-Object { & $_.backward }\n\n$scalarGraph = New-ExpressionGraph -val $L\nShow-ExpressionGraph -Graph $scalarGraph",
+      "outputs": []
+    },
+    {
+      "id": "ff725818-b4dc-4a90-9069-f4cdfb97a9cc",
+      "type": "markdown",
+      "source": "## A Single Neuron\n\nThis reproduces the micrograd neuron example: two inputs, two weights, a bias, and a `tanh` activation.",
+      "outputs": []
+    },
+    {
+      "id": "c18a9b52-1521-4b07-b805-14916f55e772",
+      "type": "code",
+      "language": "powershell",
+      "source": "$x1 = [Value]::new(2.0, 'x1')\n$x2 = [Value]::new(0.0, 'x2')\n\n$w1 = [Value]::new(-3.0, 'w1')\n$w2 = [Value]::new(1.0, 'w2')\n$b = [Value]::new(6.8813735870195432, 'b')\n\n$x1w1 = $x1 * $w1; $x1w1.label = 'x1*w1'\n$x2w2 = $x2 * $w2; $x2w2.label = 'x2*w2'\n$x1w1x2w2 = $x1w1 + $x2w2; $x1w1x2w2.label = 'x1*w1 + x2*w2'\n$n = $x1w1x2w2 + $b; $n.label = 'n'\n$o = $n.Tanh(); $o.label = 'o'\n\n$o",
+      "outputs": []
+    },
+    {
+      "id": "77fe7876-a35a-4057-aab9-3754dc02e7ad",
+      "type": "code",
+      "language": "powershell",
+      "source": "$neuronGraph = New-ExpressionGraph -val $o\nShow-ExpressionGraph -Graph $neuronGraph",
+      "outputs": []
+    },
+    {
+      "id": "9b440bcc-ed1f-4ca9-aaa9-cc58c167ef2f",
+      "type": "code",
+      "language": "powershell",
+      "source": "$bpNeuronGraph = New-BackpropagationGraph -val $o\n$o.grad = 1.0\n\nGet-GraphTopologicalSort -Graph $bpNeuronGraph -Reverse |\n    ForEach-Object { $_.OriginalObject } |\n    ForEach-Object { & $_.backward }\n\n$neuronGraph = New-ExpressionGraph -val $o\nShow-ExpressionGraph -Graph $neuronGraph",
+      "outputs": []
+    },
+    {
+      "id": "4ebbd3b8-148d-464d-af32-ba7b042e129d",
+      "type": "markdown",
+      "source": "## Layer and MLP\n\nA `Layer` applies several neurons to the same input vector. An `MLP` chains layers so each layer receives the output vector from the previous layer.",
+      "outputs": []
+    },
+    {
+      "id": "a158633b-33d6-45c0-af8f-46e135c1eff3",
+      "type": "code",
+      "language": "powershell",
+      "source": "$x = @(\n    [Value]::new(2.0, 'x1')\n    [Value]::new(3.0, 'x2')\n    [Value]::new(-1.0, 'x3')\n)\n\n$layer = [Layer]::new(3, 4)\n$layer.Invoke($x)",
+      "outputs": []
+    },
+    {
+      "id": "2f31397a-8ec1-4478-b4f7-a4dd66e93963",
+      "type": "code",
+      "language": "powershell",
+      "source": "$net = [MLP]::new(3, @(4, 4, 1))\n$res = $net.Invoke($x)\n$res",
+      "outputs": []
+    },
+    {
+      "id": "280b150c-e2eb-472d-a2fe-261ceeb41292",
+      "type": "code",
+      "language": "powershell",
+      "source": "$netGraph = New-ExpressionGraph -val $res[0]\nShow-ExpressionGraph -Graph $netGraph -rankdir 'TD' ",
+      "outputs": []
+    },
+    {
+      "id": "64896558-4a50-44b5-8c76-33b6955a7184",
+      "type": "markdown",
+      "source": "## Training Data and Loss\n\nThe training set is the small dataset from the micrograd walkthrough. The loss is the sum of squared errors between target labels and predictions.",
+      "outputs": []
+    },
+    {
+      "id": "a13c19a1-36e5-4ad1-951e-b79f7a5fc259",
+      "type": "code",
+      "language": "powershell",
+      "source": "$xs = @(\n    @([Value]::new(2.0, 'x11'), [Value]::new( 3.0, 'x12'), [Value]::new(-1.0, 'x13')),\n    @([Value]::new(3.0, 'x21'), [Value]::new(-1.0, 'x22'), [Value]::new( 0.5, 'x23')),\n    @([Value]::new(0.5, 'x31'), [Value]::new( 1.0, 'x32'), [Value]::new( 1.0, 'x33')),\n    @([Value]::new(1.0, 'x41'), [Value]::new( 1.0, 'x42'), [Value]::new(-1.0, 'x43'))\n)\n\n$ys = @(\n    [Value]::new( 1.0, 'y1'),\n    [Value]::new(-1.0, 'y2'),\n    [Value]::new(-1.0, 'y3'),\n    [Value]::new( 1.0, 'y4')\n)\n\n$net = [MLP]::new(3, @(4, 4, 1))\n\n$ypred = $xs | ForEach-Object { $net.Invoke($_)[0] }\n$loss = Zip -Left $ys -Right $ypred | Sum-Value {\n    $diff = $_.Right - $_.Left\n    $diff * $diff\n}\n\n$ypred\n$loss",
+      "outputs": []
+    },
+    {
+      "id": "e137ad0d-eaf9-4125-886e-f445d9e0c224",
+      "type": "markdown",
+      "source": "## One Training Step\n\nEach step follows the same pattern as PyTorch: clear gradients, run the forward pass, build the loss, run backpropagation in reverse topological order, then update parameters.",
+      "outputs": []
+    },
+    {
+      "id": "4fddcb91-1fc6-4d1a-af61-d40433ee2418",
+      "type": "code",
+      "language": "powershell",
+      "source": "foreach ($p in $net.parameters()) {\n    $p.grad = 0.0\n}\nforeach ($row in $xs) {\n    foreach ($v in $row) { $v.grad = 0.0 }\n}\nforeach ($y in $ys) {\n    $y.grad = 0.0\n}\n\n$ypred = $xs | ForEach-Object { $net.Invoke($_)[0] }\n$loss = Zip -Left $ys -Right $ypred | Sum-Value {\n    $diff = $_.Right - $_.Left\n    $diff * $diff\n}\n\n$loss.grad = 1.0\n$bpLossGraph = New-BackpropagationGraph -val $loss\n\nGet-GraphTopologicalSort -Graph $bpLossGraph -Reverse |\n    ForEach-Object { $_.OriginalObject } |\n    ForEach-Object { & $_.backward }\n\nforeach ($p in $net.parameters()) {\n    $p.data += -0.1 * $p.grad\n}\n\n$ypred = $xs | ForEach-Object { $net.Invoke($_)[0] }\n$loss = Zip -Left $ys -Right $ypred | Sum-Value {\n    $diff = $_.Right - $_.Left\n    $diff * $diff\n}\n\n$ypred\n$loss",
+      "outputs": []
+    },
+    {
+      "id": "0d8ebd3a-dd25-4662-ae18-67d8b6751d14",
+      "type": "markdown",
+      "source": "## Training Loop\n\nRepeat the same step to fit the tiny dataset. The final predictions should move toward the target signs, and the loss should shrink.",
+      "outputs": []
+    },
+    {
+      "id": "dd473439-856e-4f2f-96c4-e5cd3debd34b",
+      "type": "code",
+      "language": "powershell",
+      "source": "$ypred = @()\n$loss = [Value]::new(0.0, 'loss')\n\n1..200 | ForEach-Object {\n    foreach ($p in $net.parameters()) { $p.grad = 0.0 }\n    foreach ($row in $xs) { foreach ($v in $row) { $v.grad = 0.0 } }\n    foreach ($y in $ys) { $y.grad = 0.0 }\n\n    $ypred = $xs | ForEach-Object { $net.Invoke($_)[0] }\n    $loss = Zip -Left $ys -Right $ypred | Sum-Value {\n        $diff = $_.Right - $_.Left\n        $diff * $diff\n    }\n\n    $loss.grad = 1.0\n    $bpLossGraph = New-BackpropagationGraph -val $loss\n\n    Get-GraphTopologicalSort -Graph $bpLossGraph -Reverse |\n        ForEach-Object { $_.OriginalObject } |\n        ForEach-Object { & $_.backward }\n\n    foreach ($p in $net.parameters()) {\n        $p.data += -0.1 * $p.grad\n    }\n}\n\n$ypred = $xs | ForEach-Object { $net.Invoke($_)[0] }\n$loss = Zip -Left $ys -Right $ypred | Sum-Value {\n    $diff = $_.Right - $_.Left\n    $diff * $diff\n}\n\n$ypred\n$loss",
+      "outputs": []
+    },
+    {
+      "id": "a096e010-2ed5-4324-b580-9f61bd58ef8d",
+      "type": "markdown",
+      "source": "## Final Loss Graph\n\nRender the final loss graph after training. This graph is intentionally large because it contains the full computation that produced the scalar loss.",
+      "outputs": []
+    },
+    {
+      "id": "ec5c879c-0de0-4760-a294-a390d5d67f77",
+      "type": "code",
+      "language": "powershell",
+      "source": "$lossGraph = New-ExpressionGraph -val $loss\nShow-ExpressionGraph -Graph $lossGraph -rankdir 'TD' ",
+      "outputs": []
+    }
+  ],
+  "layouts": {
+    "dashboard": {
+      "cells": {}
+    }
+  }
+}

--- a/samples/Notebooks/powershell/micrograd/neuronHelper.ps1
+++ b/samples/Notebooks/powershell/micrograd/neuronHelper.ps1
@@ -1,0 +1,118 @@
+class Neuron {
+    [Value[]]$w
+    [Value]$b
+    [bool]$nonlin
+
+    Neuron([int]$nin) {
+        $this.Init($nin, $true)
+    }
+
+    Neuron([int]$nin, [bool]$nonlin) {
+        $this.Init($nin, $nonlin)
+    }
+
+    hidden [void] Init([int]$nin, [bool]$nonlin) {
+        $this.w = for ($i = 0; $i -lt $nin; $i++) {
+            [Value]::new(([Random]::Shared.NextDouble() * 2 - 1), "w$i")
+        }
+
+        $this.b = [Value]::new(([Random]::Shared.NextDouble() * 2 - 1), "b")
+        $this.nonlin = $nonlin
+    }
+
+    [Value] Invoke([Value[]]$x) {
+        if ($x.Count -ne $this.w.Count) {
+            throw "Expected $($this.w.Count) inputs, got $($x.Count)."
+        }
+
+        $sum = $this.b
+        for ($i = 0; $i -lt $this.w.Count; $i++) {
+            $sum = $sum + ($this.w[$i] * $x[$i])
+        }
+
+        if ($this.nonlin) {
+            return $sum.Tanh()
+        }
+
+        return $sum
+    }
+
+    [Value[]] parameters(){
+        return @($this.w) + @($this.b)
+    }
+}
+
+class Layer {
+    [Neuron[]]$neurons = @()
+
+    Layer([int]$nin, [int]$nout) {
+        $this.Init($nin, $nout, $true)
+    }
+
+    Layer([int]$nin, [int]$nout, [bool]$nonlin) {
+        $this.Init($nin, $nout, $nonlin)
+    }
+
+    hidden [void] Init([int]$nin, [int]$nout, [bool]$nonlin) {
+        $this.neurons = for ($i = 0; $i -lt $nout; $i++) {
+            [Neuron]::new($nin, $nonlin)
+        }
+    }
+
+    [Value[]]Invoke([Value[]]$x) {
+        $out = @()
+        $out = foreach ($neuron in $this.neurons) {
+            $neuron.Invoke($x)
+        }
+
+        return $out
+    }
+
+    [Value[]] parameters(){
+        [Value[]]$params = @()
+        foreach ($n in $this.neurons){
+            $params += $n.parameters()
+        }
+
+        return $params
+    }
+}
+
+class MLP {
+    [Layer[]]$layers = @()
+
+    MLP([int]$nin, [int[]]$nouts) {
+        $this.Init($nin, $nouts, $true)
+    }
+
+    MLP([int]$nin, [int[]]$nouts, [bool]$outputNonlinear) {
+        $this.Init($nin, $nouts, $outputNonlinear)
+    }
+
+    hidden [void] Init([int]$nin, [int[]]$nouts, [bool]$outputNonlinear) {
+        $sizes = @($nin) + $nouts
+
+        $this.layers = for ($i = 0; $i -lt $nouts.Count; $i++) {
+            $nonlin = $outputNonlinear -or $i -ne ($nouts.Count - 1)
+            [Layer]::new($sizes[$i], $sizes[$i + 1], $nonlin)
+        }
+    }
+
+    [Value[]]Invoke([Value[]]$x) {
+        $out = $x
+
+        foreach ($layer in $this.layers) {
+            $out = $layer.Invoke($out)
+        }
+
+        return $out;
+    }
+    [Value[]] parameters(){
+        [Value[]]$params = @()
+        foreach ($l in $this.layers){
+            $params += $l.parameters()
+        }
+
+        return $params
+    }
+}

--- a/samples/Notebooks/powershell/micrograd/neuronHelper.ps1
+++ b/samples/Notebooks/powershell/micrograd/neuronHelper.ps1
@@ -1,3 +1,12 @@
+<#
+Adapted from Andrej Karpathy's micrograd:
+https://github.com/karpathy/micrograd
+
+Copyright (c) 2020 Andrej Karpathy
+Licensed under the MIT License:
+https://github.com/karpathy/micrograd/blob/master/LICENSE
+#>
+
 class Neuron {
     [Value[]]$w
     [Value]$b

--- a/samples/Notebooks/powershell/micrograd/value.ps1
+++ b/samples/Notebooks/powershell/micrograd/value.ps1
@@ -1,3 +1,12 @@
+<#
+Adapted from Andrej Karpathy's micrograd:
+https://github.com/karpathy/micrograd
+
+Copyright (c) 2020 Andrej Karpathy
+Licensed under the MIT License:
+https://github.com/karpathy/micrograd/blob/master/LICENSE
+#>
+
 class Value {
     hidden [double]$data
     hidden [string]$label=""

--- a/samples/Notebooks/powershell/micrograd/value.ps1
+++ b/samples/Notebooks/powershell/micrograd/value.ps1
@@ -1,0 +1,83 @@
+class Value {
+    hidden [double]$data
+    hidden [string]$label=""
+    hidden [array]$children = @()
+    hidden [string]$operation = ""
+    hidden [double]$grad = 0.0
+    hidden $backward = {}
+
+    Value([double] $data){
+        $this.data = $data
+    }
+
+    Value([double] $data, [array] $children){
+        $this.data = $data
+        $this.children = $children
+    }
+
+    Value([double] $data, [string] $label){
+        $this.data = $data
+        $this.label = $label
+    }
+
+    Value([double] $data, $children, $operation){
+        $this.data = $data
+        $this.children = $children
+        $this.operation = $operation
+    }
+
+    Value([double] $data, [array] $children, [string] $operation, [string] $label){
+        $this.data = $data
+        $this.label = $label
+        $this.children = $children
+        $this.operation = $operation
+    }
+
+    static [Value] op_Addition([Value]$left, [Value]$right) {
+        $out = [Value]::new($left.data + $right.data, @($left, $right), "+", "+_res")
+
+        $out.backward = {
+            $left.grad += 1 * $out.grad
+            $right.grad += 1 * $out.grad
+        }.GetNewClosure()
+
+        return $out
+    }
+
+    static [Value] op_Subtraction([Value]$left, [Value]$right) {
+        $out = [Value]::new($left.data - $right.data, @($left, $right), "-", "-_res")
+
+        $out.backward = {
+            $left.grad += 1 * $out.grad
+            $right.grad += -1 * $out.grad
+        }.GetNewClosure()
+
+        return $out
+    }
+
+    static [Value] op_Multiply([Value]$left, [Value]$right) {
+        $out = [Value]::new($left.data * $right.data, @($left, $right), "*", "*_res")
+
+        $out.backward = {
+            $left.grad += $right.data * $out.grad
+            $right.grad += $left.data * $out.grad
+        }.GetNewClosure()
+
+        return $out
+    }
+
+    [Value] Tanh(){
+        $v = $this
+        $t = [Math]::Tanh($this.data)
+        $out = [Value]::new($t, @($this), "tanh")
+
+        $out.backward = {
+            $v.grad += (1 - [Math]::Pow($t, 2)) * $out.grad
+        }.GetNewClosure()
+
+        return $out
+
+    }
+}
+
+Update-FormatData -path (Join-Path $PSScriptRoot 'Value.format.ps1xml')

--- a/samples/Notebooks/powershell/mnist/mnist-ps.verso
+++ b/samples/Notebooks/powershell/mnist/mnist-ps.verso
@@ -18,14 +18,14 @@
     {
       "id": "c85daae7-542e-4c28-84c6-67012fa91913",
       "type": "markdown",
-      "source": "## Module Setup\n\nInstall the tested prerelease modules from PowerShell Gallery. The modules target .NET 8 and are also validated with PowerShell 7.6 on .NET 10.",
+      "source": "## Module Setup\n\nLoad the tested prerelease modules from the normal PowerShell module path. Install missing modules from a regular PowerShell terminal before starting Verso; the embedded kernel does not provide PowerShellGet package-management commands.",
       "outputs": []
     },
     {
       "id": "97045bd5-4e9a-4b9c-9104-93acf3d08387",
       "type": "code",
       "language": "powershell",
-      "source": "$requirements = @(\n    [pscustomobject]@{ Name = 'PSQuickGraph'; Version = '2.6.0-beta1' }\n    [pscustomobject]@{ Name = 'PSGraphView'; Version = '0.2.0-beta1' }\n    [pscustomobject]@{ Name = 'PSMnist'; Version = '0.1.0-beta1' }\n)\n\nforeach ($requirement in $requirements) {\n    $installed = Get-InstalledModule `\n        -Name $requirement.Name `\n        -RequiredVersion $requirement.Version `\n        -AllowPrerelease `\n        -ErrorAction SilentlyContinue\n\n    if (-not $installed) {\n        Install-Module `\n            -Name $requirement.Name `\n            -RequiredVersion $requirement.Version `\n            -AllowPrerelease `\n            -Scope CurrentUser `\n            -Force\n    }\n}\n\nImport-Module PSQuickGraph -MinimumVersion 2.6.0 -Force\nImport-Module PSGraphView -MinimumVersion 0.2.0 -Force\nImport-Module PSMnist -MinimumVersion 0.1.0 -Force",
+      "source": "$requirements = @(\n    [pscustomobject]@{ Name = 'PSQuickGraph'; Version = '2.6.0-beta1' }\n    [pscustomobject]@{ Name = 'PSGraphView'; Version = '0.2.0-beta1' }\n    [pscustomobject]@{ Name = 'PSMnist'; Version = '0.1.0-beta1' }\n)\n\n$resolvedModules = foreach ($requirement in $requirements) {\n    $module = Get-Module -ListAvailable -Name $requirement.Name |\n        Where-Object {\n            $version = $_.Version.ToString()\n            $prerelease = $_.PrivateData.PSData.Prerelease\n            if ($prerelease) {\n                $version = \"$version-$prerelease\"\n            }\n            $version -eq $requirement.Version\n        } |\n        Select-Object -First 1\n\n    if ($module) {\n        [pscustomobject]@{\n            Requirement = $requirement\n            Module = $module\n        }\n    }\n}\n\n$missing = $requirements |\n    Where-Object Name -NotIn $resolvedModules.Requirement.Name\n\nif ($missing) {\n    $installCommands = $missing | ForEach-Object {\n        \"Install-Module $($_.Name) -RequiredVersion $($_.Version) -AllowPrerelease -Scope CurrentUser\"\n    }\n\n    throw \"Install the missing modules in a regular PowerShell terminal, restart Verso, and run this cell again:`n$($installCommands -join \"`n\")\"\n}\n\n$resolvedModules | ForEach-Object {\n    Import-Module $_.Module.Path -Force\n}",
       "outputs": []
     },
     {

--- a/samples/Notebooks/powershell/mnist/mnist-ps.verso
+++ b/samples/Notebooks/powershell/mnist/mnist-ps.verso
@@ -25,7 +25,7 @@
       "id": "97045bd5-4e9a-4b9c-9104-93acf3d08387",
       "type": "code",
       "language": "powershell",
-      "source": "$requirements = @{\n    PSQuickGraph = '2.6.0-beta1'\n    PSGraphView = '0.2.0-beta1'\n    PSMnist = '0.1.0-beta1'\n}\n\nforeach ($entry in $requirements.GetEnumerator()) {\n    $available = Get-Module -ListAvailable -Name $entry.Key | Where-Object {\n        $version = $_.Version.ToString()\n        $prerelease = $_.PrivateData.PSData.Prerelease\n        if ($prerelease) { $version = \"$version-$prerelease\" }\n        $version -eq $entry.Value\n    }\n\n    if (-not $available) {\n        Install-Module $entry.Key -RequiredVersion $entry.Value -AllowPrerelease -Scope CurrentUser -Force\n    }\n}\n\nImport-Module PSQuickGraph -MinimumVersion 2.6.0 -Force\nImport-Module PSGraphView -MinimumVersion 0.2.0 -Force\nImport-Module PSMnist -MinimumVersion 0.1.0 -Force",
+      "source": "$requirements = @(\n    [pscustomobject]@{ Name = 'PSQuickGraph'; Version = '2.6.0-beta1' }\n    [pscustomobject]@{ Name = 'PSGraphView'; Version = '0.2.0-beta1' }\n    [pscustomobject]@{ Name = 'PSMnist'; Version = '0.1.0-beta1' }\n)\n\nforeach ($requirement in $requirements) {\n    $installed = Get-InstalledModule `\n        -Name $requirement.Name `\n        -RequiredVersion $requirement.Version `\n        -AllowPrerelease `\n        -ErrorAction SilentlyContinue\n\n    if (-not $installed) {\n        Install-Module `\n            -Name $requirement.Name `\n            -RequiredVersion $requirement.Version `\n            -AllowPrerelease `\n            -Scope CurrentUser `\n            -Force\n    }\n}\n\nImport-Module PSQuickGraph -MinimumVersion 2.6.0 -Force\nImport-Module PSGraphView -MinimumVersion 0.2.0 -Force\nImport-Module PSMnist -MinimumVersion 0.1.0 -Force",
       "outputs": []
     },
     {
@@ -38,7 +38,7 @@
       "id": "2e0577de-d4ea-40d4-9195-84e20811dddf",
       "type": "code",
       "language": "powershell",
-      "source": ". ../micrograd/value.ps1\n. ../micrograd/graphHelper.ps1\n. ../micrograd/neuronHelper.ps1\n. ../micrograd/helpers.ps1",
+      "source": ". ../micrograd/value.ps1\n. ../micrograd/graphHelper.ps1\n. ../micrograd/neuronHelper.ps1\n. ../micrograd/helpers.ps1\n\nfunction Get-HighestScoreIndex {\n    [CmdletBinding()]\n    param(\n        [Parameter(Mandatory, ValueFromPipeline)]\n        [Value]$Value\n    )\n\n    begin {\n        $index = 0\n        $scores = @()\n    }\n\n    process {\n        $scores += [pscustomobject]@{\n            Index = $index\n            Score = $Value.data\n        }\n        $index++\n    }\n\n    end {\n        $scores |\n            Sort-Object Score -Descending |\n            Select-Object -First 1 -ExpandProperty Index\n    }\n}",
       "outputs": []
     },
     {
@@ -51,7 +51,7 @@
       "id": "7f57aa47-b80c-401e-bb5d-d2b59d060dc2",
       "type": "code",
       "language": "powershell",
-      "source": "$dataRoot = [Environment]::GetFolderPath([Environment+SpecialFolder]::LocalApplicationData)\nif ([string]::IsNullOrWhiteSpace($dataRoot)) { $dataRoot = $HOME }\n$dataPath = Join-Path $dataRoot 'PSMnist/mnist'\n\nif (-not (Test-Path (Join-Path $dataPath 'train-images-idx3-ubyte'))) {\n    Save-MnistDataset -DestinationPath $dataPath\n    Expand-MnistDataset -Path $dataPath\n}\n\n$sample = Get-MnistDataset -Path $dataPath -Set Train -First 1\n$svg = $sample.Image | ConvertTo-MnistSvg -Scale 8\nDisplay $svg 'image/svg+xml'\n\n[pscustomobject]@{\n    Label = $sample.Label.Value\n    Width = $sample.Image.Width\n    Height = $sample.Image.Height\n}",
+      "source": "$dataPath = Join-Path $HOME '.psmnist/mnist'\n$imageFile = Join-Path $dataPath 'train-images-idx3-ubyte'\n\nif (-not (Test-Path -LiteralPath $imageFile)) {\n    Save-MnistDataset -DestinationPath $dataPath | Out-Null\n    Expand-MnistDataset -Path $dataPath | Out-Null\n}\n\n$sample = Get-MnistDataset -Path $dataPath -Set Train -First 1\n$sample.Image |\n    ConvertTo-MnistSvg -Scale 8 |\n    ForEach-Object { Display $_ 'image/svg+xml' }\n\n[pscustomobject]@{\n    Label = $sample.Label.Value\n    Width = $sample.Image.Width\n    Height = $sample.Image.Height\n}",
       "outputs": []
     },
     {
@@ -64,7 +64,7 @@
       "id": "064979d3-52e4-43a0-acf0-9b00cd663968",
       "type": "code",
       "language": "powershell",
-      "source": "$sampleCount = 100\n$trainingSamples = @(\n    Get-MnistDataset -Path $dataPath -Set Train -First $sampleCount |\n        ConvertTo-MnistTrainingSample -Range ZeroToOne\n)\n\n$first = $trainingSamples[0]\n[pscustomobject]@{\n    SampleCount = $trainingSamples.Count\n    InputLength = $first.X.Length\n    TargetLength = $first.Y.Length\n    Label = $first.Label.Value\n}",
+      "source": "$sampleCount = 100\n$trainingSamples = @(\n    Get-MnistDataset -Path $dataPath -Set Train -First $sampleCount |\n        ConvertTo-MnistTrainingSample -Range ZeroToOne\n)\n\n$first = $trainingSamples | Select-Object -First 1\n[pscustomobject]@{\n    SampleCount = $trainingSamples.Count\n    InputLength = $first.X.Count\n    TargetLength = $first.Y.Count\n    Label = $first.Label.Value\n}",
       "outputs": []
     },
     {
@@ -77,7 +77,7 @@
       "id": "dc076e8f-c102-43ba-a096-6931d951bb7a",
       "type": "code",
       "language": "powershell",
-      "source": "$model = [MLP]::new(784, @(16, 10), $false)\n$train = @($trainingSamples | Select-Object -First 10)\n$parameters = $model.parameters()\n$learningRate = 0.001\n$epochs = 3\n\n$history = for ($epoch = 1; $epoch -le $epochs; $epoch++) {\n    $totalLoss = 0.0\n    $correct = 0\n    $trainThisEpoch = $train | Get-Random -Count $train.Count\n\n    foreach ($example in $trainThisEpoch) {\n        foreach ($parameter in $parameters) { $parameter.grad = 0.0 }\n\n        $output = $model.Invoke($example.X)\n        $scores = [double[]]($output | ForEach-Object { $_.data })\n        $maximum = ($scores | Measure-Object -Maximum).Maximum\n        $predicted = [Array]::IndexOf($scores, $maximum)\n        if ($predicted -eq $example.Label.Value) { $correct++ }\n\n        $loss = Zip $output $example.Y | Sum-Value {\n            [Value]$prediction = $_.Left\n            $target = [Value]::new([double]$_.Right)\n            $difference = $prediction - $target\n            $difference * $difference\n        }\n\n        $totalLoss += $loss.data\n        Invoke-ValueBackward $loss\n\n        foreach ($parameter in $parameters) {\n            $parameter.data += -$learningRate * $parameter.grad\n        }\n    }\n\n    [pscustomobject]@{\n        Epoch = $epoch\n        AverageLoss = $totalLoss / $train.Count\n        Accuracy = $correct / $train.Count\n    }\n}\n\n$history",
+      "source": "$model = [MLP]::new(784, @(16, 10), $false)\n$train = @($trainingSamples | Select-Object -First 10)\n$parameters = @($model.parameters())\n$learningRate = 0.001\n$epochs = 3\n\n$history = for ($epoch = 1; $epoch -le $epochs; $epoch++) {\n    $totalLoss = 0.0\n    $correct = 0\n    $trainThisEpoch = Get-Random -InputObject $train -Count $train.Count\n\n    foreach ($example in $trainThisEpoch) {\n        foreach ($parameter in $parameters) {\n            $parameter.grad = 0.0\n        }\n\n        $output = $model.Invoke($example.X)\n        $predicted = $output | Get-HighestScoreIndex\n        if ($predicted -eq $example.Label.Value) {\n            $correct++\n        }\n\n        $loss = Zip $output $example.Y | Sum-Value {\n            [Value]$prediction = $_.Left\n            $target = [Value]::new([double]$_.Right)\n            $difference = $prediction - $target\n            $difference * $difference\n        }\n\n        $totalLoss += $loss.data\n        Invoke-ValueBackward $loss\n\n        foreach ($parameter in $parameters) {\n            $parameter.data += -$learningRate * $parameter.grad\n        }\n    }\n\n    [pscustomobject]@{\n        Epoch = $epoch\n        AverageLoss = $totalLoss / $train.Count\n        Accuracy = $correct / $train.Count\n    }\n}\n\n$history",
       "outputs": []
     },
     {
@@ -90,14 +90,14 @@
       "id": "a2a05e70-13af-41c2-bfab-84c7a87f8557",
       "type": "code",
       "language": "powershell",
-      "source": "$evaluation = foreach ($example in $train) {\n    $output = $model.Invoke($example.X)\n    $scores = [double[]]($output | ForEach-Object { $_.data })\n    $maximum = ($scores | Measure-Object -Maximum).Maximum\n    $predicted = [Array]::IndexOf($scores, $maximum)\n\n    [pscustomobject]@{\n        Index = $example.Index\n        Label = $example.Label.Value\n        Predicted = $predicted\n        Correct = $predicted -eq $example.Label.Value\n    }\n}\n\n$evaluation",
+      "source": "$evaluation = $train | ForEach-Object {\n    $example = $_\n    $output = $model.Invoke($example.X)\n    $predicted = $output | Get-HighestScoreIndex\n\n    [pscustomobject]@{\n        Index = $example.Index\n        Label = $example.Label.Value\n        Predicted = $predicted\n        Correct = $predicted -eq $example.Label.Value\n    }\n}\n\n$evaluation",
       "outputs": []
     },
     {
       "id": "47a19146-9a8b-46f2-860e-ded53a237420",
       "type": "code",
       "language": "powershell",
-      "source": "$correct = @($evaluation | Where-Object Correct).Count\n[pscustomobject]@{\n    Count = $evaluation.Count\n    Correct = $correct\n    Accuracy = $correct / $evaluation.Count\n}",
+      "source": "$correct = ($evaluation | Where-Object Correct | Measure-Object).Count\n\n[pscustomobject]@{\n    Count = $evaluation.Count\n    Correct = $correct\n    Accuracy = $correct / $evaluation.Count\n}",
       "outputs": []
     },
     {

--- a/samples/Notebooks/powershell/mnist/mnist-ps.verso
+++ b/samples/Notebooks/powershell/mnist/mnist-ps.verso
@@ -1,0 +1,115 @@
+{
+  "verso": "1.0",
+  "metadata": {
+    "title": "MNIST with Micrograd in PowerShell",
+    "created": "2026-07-30T00:00:00+00:00",
+    "modified": "2026-07-30T00:00:00+00:00",
+    "defaultKernel": "powershell",
+    "activeLayout": "notebook",
+    "preferredTheme": "verso-light"
+  },
+  "cells": [
+    {
+      "id": "3f21c88a-60e0-4c3a-b3b1-59b79ff348f1",
+      "type": "markdown",
+      "source": "# MNIST with Micrograd in PowerShell\n\nThis notebook uses `PSMnist` to prepare handwritten-digit examples and trains the scalar Micrograd implementation from the neighboring sample. It favors readable computation over performance.",
+      "outputs": []
+    },
+    {
+      "id": "c85daae7-542e-4c28-84c6-67012fa91913",
+      "type": "markdown",
+      "source": "## Module Setup\n\nInstall the tested prerelease modules from PowerShell Gallery. The modules target .NET 8 and are also validated with PowerShell 7.6 on .NET 10.",
+      "outputs": []
+    },
+    {
+      "id": "97045bd5-4e9a-4b9c-9104-93acf3d08387",
+      "type": "code",
+      "language": "powershell",
+      "source": "$requirements = @{\n    PSQuickGraph = '2.6.0-beta1'\n    PSGraphView = '0.2.0-beta1'\n    PSMnist = '0.1.0-beta1'\n}\n\nforeach ($entry in $requirements.GetEnumerator()) {\n    $available = Get-Module -ListAvailable -Name $entry.Key | Where-Object {\n        $version = $_.Version.ToString()\n        $prerelease = $_.PrivateData.PSData.Prerelease\n        if ($prerelease) { $version = \"$version-$prerelease\" }\n        $version -eq $entry.Value\n    }\n\n    if (-not $available) {\n        Install-Module $entry.Key -RequiredVersion $entry.Value -AllowPrerelease -Scope CurrentUser -Force\n    }\n}\n\nImport-Module PSQuickGraph -MinimumVersion 2.6.0 -Force\nImport-Module PSGraphView -MinimumVersion 0.2.0 -Force\nImport-Module PSMnist -MinimumVersion 0.1.0 -Force",
+      "outputs": []
+    },
+    {
+      "id": "398c571c-1a98-42b6-af28-59861cc77c27",
+      "type": "markdown",
+      "source": "## Micrograd Helpers\n\nLoad the scalar automatic-differentiation engine and MLP classes used by the Micrograd sample.",
+      "outputs": []
+    },
+    {
+      "id": "2e0577de-d4ea-40d4-9195-84e20811dddf",
+      "type": "code",
+      "language": "powershell",
+      "source": ". ../micrograd/value.ps1\n. ../micrograd/graphHelper.ps1\n. ../micrograd/neuronHelper.ps1\n. ../micrograd/helpers.ps1",
+      "outputs": []
+    },
+    {
+      "id": "7536cc79-3bba-4464-bb3a-a62b56f5cd27",
+      "type": "markdown",
+      "source": "## Download And Inspect MNIST\n\nStore the dataset under the current user's application-data directory. The download runs only when the expanded training files are absent.",
+      "outputs": []
+    },
+    {
+      "id": "7f57aa47-b80c-401e-bb5d-d2b59d060dc2",
+      "type": "code",
+      "language": "powershell",
+      "source": "$dataRoot = [Environment]::GetFolderPath([Environment+SpecialFolder]::LocalApplicationData)\nif ([string]::IsNullOrWhiteSpace($dataRoot)) { $dataRoot = $HOME }\n$dataPath = Join-Path $dataRoot 'PSMnist/mnist'\n\nif (-not (Test-Path (Join-Path $dataPath 'train-images-idx3-ubyte'))) {\n    Save-MnistDataset -DestinationPath $dataPath\n    Expand-MnistDataset -Path $dataPath\n}\n\n$sample = Get-MnistDataset -Path $dataPath -Set Train -First 1\n$svg = $sample.Image | ConvertTo-MnistSvg -Scale 8\nDisplay $svg 'image/svg+xml'\n\n[pscustomobject]@{\n    Label = $sample.Label.Value\n    Width = $sample.Image.Width\n    Height = $sample.Image.Height\n}",
+      "outputs": []
+    },
+    {
+      "id": "06c3f921-851e-4c0c-94d8-edc7fdbe82d4",
+      "type": "markdown",
+      "source": "## Prepare Training Samples\n\nNormalize each 28 by 28 image to a 784-element `0..1` vector and convert its label to a ten-element one-hot target.",
+      "outputs": []
+    },
+    {
+      "id": "064979d3-52e4-43a0-acf0-9b00cd663968",
+      "type": "code",
+      "language": "powershell",
+      "source": "$sampleCount = 100\n$trainingSamples = @(\n    Get-MnistDataset -Path $dataPath -Set Train -First $sampleCount |\n        ConvertTo-MnistTrainingSample -Range ZeroToOne\n)\n\n$first = $trainingSamples[0]\n[pscustomobject]@{\n    SampleCount = $trainingSamples.Count\n    InputLength = $first.X.Length\n    TargetLength = $first.Y.Length\n    Label = $first.Label.Value\n}",
+      "outputs": []
+    },
+    {
+      "id": "c643618a-eb0c-4818-b834-f8b45bcf9bad",
+      "type": "markdown",
+      "source": "## Train A Small Classifier\n\nUse ten examples and three epochs so the scalar graph remains practical in an educational notebook. The final layer is linear; hidden neurons retain `tanh` activation.",
+      "outputs": []
+    },
+    {
+      "id": "dc076e8f-c102-43ba-a096-6931d951bb7a",
+      "type": "code",
+      "language": "powershell",
+      "source": "$model = [MLP]::new(784, @(16, 10), $false)\n$train = @($trainingSamples | Select-Object -First 10)\n$parameters = $model.parameters()\n$learningRate = 0.001\n$epochs = 3\n\n$history = for ($epoch = 1; $epoch -le $epochs; $epoch++) {\n    $totalLoss = 0.0\n    $correct = 0\n    $trainThisEpoch = $train | Get-Random -Count $train.Count\n\n    foreach ($example in $trainThisEpoch) {\n        foreach ($parameter in $parameters) { $parameter.grad = 0.0 }\n\n        $output = $model.Invoke($example.X)\n        $scores = [double[]]($output | ForEach-Object { $_.data })\n        $maximum = ($scores | Measure-Object -Maximum).Maximum\n        $predicted = [Array]::IndexOf($scores, $maximum)\n        if ($predicted -eq $example.Label.Value) { $correct++ }\n\n        $loss = Zip $output $example.Y | Sum-Value {\n            [Value]$prediction = $_.Left\n            $target = [Value]::new([double]$_.Right)\n            $difference = $prediction - $target\n            $difference * $difference\n        }\n\n        $totalLoss += $loss.data\n        Invoke-ValueBackward $loss\n\n        foreach ($parameter in $parameters) {\n            $parameter.data += -$learningRate * $parameter.grad\n        }\n    }\n\n    [pscustomobject]@{\n        Epoch = $epoch\n        AverageLoss = $totalLoss / $train.Count\n        Accuracy = $correct / $train.Count\n    }\n}\n\n$history",
+      "outputs": []
+    },
+    {
+      "id": "a830caa6-c034-4d66-81ac-1160f4cae0da",
+      "type": "markdown",
+      "source": "## Evaluate The Training Subset\n\nRun a fresh forward pass and compare the largest output score with each label.",
+      "outputs": []
+    },
+    {
+      "id": "a2a05e70-13af-41c2-bfab-84c7a87f8557",
+      "type": "code",
+      "language": "powershell",
+      "source": "$evaluation = foreach ($example in $train) {\n    $output = $model.Invoke($example.X)\n    $scores = [double[]]($output | ForEach-Object { $_.data })\n    $maximum = ($scores | Measure-Object -Maximum).Maximum\n    $predicted = [Array]::IndexOf($scores, $maximum)\n\n    [pscustomobject]@{\n        Index = $example.Index\n        Label = $example.Label.Value\n        Predicted = $predicted\n        Correct = $predicted -eq $example.Label.Value\n    }\n}\n\n$evaluation",
+      "outputs": []
+    },
+    {
+      "id": "47a19146-9a8b-46f2-860e-ded53a237420",
+      "type": "code",
+      "language": "powershell",
+      "source": "$correct = @($evaluation | Where-Object Correct).Count\n[pscustomobject]@{\n    Count = $evaluation.Count\n    Correct = $correct\n    Accuracy = $correct / $evaluation.Count\n}",
+      "outputs": []
+    },
+    {
+      "id": "0b3f3da4-a04a-4668-85dc-4279821ac877",
+      "type": "markdown",
+      "source": "The scalar implementation makes every arithmetic operation a graph node. It is useful for examining automatic differentiation, but larger datasets should use vectorized tensor operations and a production ML runtime.",
+      "outputs": []
+    }
+  ],
+  "layouts": {
+    "dashboard": {
+      "cells": {}
+    }
+  }
+}

--- a/samples/Notebooks/psgraphview-powershell-gallery.verso
+++ b/samples/Notebooks/psgraphview-powershell-gallery.verso
@@ -12,19 +12,19 @@
     {
       "id": "b8bb92ff-a510-4a55-9e7b-3e53d62f3201",
       "type": "markdown",
-      "source": "# PSGraph and PSGraphView from PowerShell Gallery\n\nThis notebook installs tested prerelease versions of the graph modules, builds a graph with PSGraph, and renders it with PSGraphView.\n\nThe PowerShell Gallery package for the PSGraph graph/algorithm module is \u0060PSQuickGraph\u0060. \u0060PSGraphView\u0060 provides the rendering cmdlets."
+      "source": "# PSGraph and PSGraphView from PowerShell Gallery\n\nThis notebook loads tested prerelease versions of the graph modules, builds a graph with PSGraph, and renders it with PSGraphView.\n\nThe PowerShell Gallery package for the PSGraph graph/algorithm module is \u0060PSQuickGraph\u0060. \u0060PSGraphView\u0060 provides the rendering cmdlets. Install missing modules from a regular PowerShell terminal before starting Verso; the embedded kernel does not provide PowerShellGet package-management commands."
     },
     {
       "id": "d208c1d7-72ce-4e6d-8d9d-0db9be0378f5",
       "type": "code",
       "language": "powershell",
-      "source": "$ErrorActionPreference = \u0027Stop\u0027\n\n$requirements = @{\n    PSQuickGraph = \u00272.6.0-beta1\u0027\n    PSGraphView = \u00270.2.0-beta1\u0027\n}\n\nforeach ($entry in $requirements.GetEnumerator()) {\n    Install-Module $entry.Key \u0060\n        -RequiredVersion $entry.Value \u0060\n        -AllowPrerelease \u0060\n        -Scope CurrentUser \u0060\n        -Repository PSGallery \u0060\n        -Force \u0060\n        -AllowClobber\n}"
+      "source": "$ErrorActionPreference = \u0027Stop\u0027\n\n$requirements = @(\n    [pscustomobject]@{ Name = \u0027PSQuickGraph\u0027; Version = \u00272.6.0-beta1\u0027 }\n    [pscustomobject]@{ Name = \u0027PSGraphView\u0027; Version = \u00270.2.0-beta1\u0027 }\n)\n\n$resolvedModules = foreach ($requirement in $requirements) {\n    $module = Get-Module -ListAvailable -Name $requirement.Name |\n        Where-Object {\n            $version = $_.Version.ToString()\n            $prerelease = $_.PrivateData.PSData.Prerelease\n            if ($prerelease) {\n                $version = \u0022$version-$prerelease\u0022\n            }\n            $version -eq $requirement.Version\n        } |\n        Select-Object -First 1\n\n    if ($module) {\n        [pscustomobject]@{\n            Requirement = $requirement\n            Module = $module\n        }\n    }\n}\n\n$missing = $requirements |\n    Where-Object Name -NotIn $resolvedModules.Requirement.Name\n\nif ($missing) {\n    $installCommands = $missing | ForEach-Object {\n        \u0022Install-Module $($_.Name) -RequiredVersion $($_.Version) -AllowPrerelease -Scope CurrentUser\u0022\n    }\n\n    throw \u0022Install the missing modules in a regular PowerShell terminal, restart Verso, and run this cell again:\u0060n$($installCommands -join \u0022\u0060n\u0022)\u0022\n}\n\n$resolvedModules | ForEach-Object {\n    Import-Module $_.Module.Path -Force\n}"
     },
     {
       "id": "dd69032d-556c-4195-a6b7-3551c61b1c10",
       "type": "code",
       "language": "powershell",
-      "source": "$ErrorActionPreference = \u0027Stop\u0027\n\nImport-Module PSQuickGraph -MinimumVersion 2.6.0 -Force\nImport-Module PSGraphView -MinimumVersion 0.2.0 -Force\n\nGet-Module PSQuickGraph, PSGraphView |\n    Select-Object Name, Version, ModuleBase"
+      "source": "Get-Module PSQuickGraph, PSGraphView |\n    Select-Object Name, Version, ModuleBase"
     },
     {
       "id": "db086baa-97b6-40e6-9a47-c1201143d245",

--- a/samples/Notebooks/psgraphview-powershell-gallery.verso
+++ b/samples/Notebooks/psgraphview-powershell-gallery.verso
@@ -1,0 +1,79 @@
+{
+  "verso": "1.0",
+  "metadata": {
+    "title": "PSGraph and PSGraphView from PowerShell Gallery",
+    "created": "2026-05-10T00:00:00+00:00",
+    "modified": "2026-05-10T00:00:00+00:00",
+    "defaultKernel": "powershell",
+    "activeLayout": "notebook",
+    "preferredTheme": "verso-light"
+  },
+  "cells": [
+    {
+      "id": "b8bb92ff-a510-4a55-9e7b-3e53d62f3201",
+      "type": "markdown",
+      "source": "# PSGraph and PSGraphView from PowerShell Gallery\n\nThis notebook installs tested prerelease versions of the graph modules, builds a graph with PSGraph, and renders it with PSGraphView.\n\nThe PowerShell Gallery package for the PSGraph graph/algorithm module is \u0060PSQuickGraph\u0060. \u0060PSGraphView\u0060 provides the rendering cmdlets."
+    },
+    {
+      "id": "d208c1d7-72ce-4e6d-8d9d-0db9be0378f5",
+      "type": "code",
+      "language": "powershell",
+      "source": "$ErrorActionPreference = \u0027Stop\u0027\n\n$requirements = @{\n    PSQuickGraph = \u00272.6.0-beta1\u0027\n    PSGraphView = \u00270.2.0-beta1\u0027\n}\n\nforeach ($entry in $requirements.GetEnumerator()) {\n    Install-Module $entry.Key \u0060\n        -RequiredVersion $entry.Value \u0060\n        -AllowPrerelease \u0060\n        -Scope CurrentUser \u0060\n        -Repository PSGallery \u0060\n        -Force \u0060\n        -AllowClobber\n}"
+    },
+    {
+      "id": "dd69032d-556c-4195-a6b7-3551c61b1c10",
+      "type": "code",
+      "language": "powershell",
+      "source": "$ErrorActionPreference = \u0027Stop\u0027\n\nImport-Module PSQuickGraph -MinimumVersion 2.6.0 -Force\nImport-Module PSGraphView -MinimumVersion 0.2.0 -Force\n\nGet-Module PSQuickGraph, PSGraphView |\n    Select-Object Name, Version, ModuleBase"
+    },
+    {
+      "id": "db086baa-97b6-40e6-9a47-c1201143d245",
+      "type": "markdown",
+      "source": "## Build a graph with PSGraph\n\nThe graph object is created and queried by PSGraph. This cell also exports the graph to Graphviz DOT text, which stays in the PSGraph module boundary."
+    },
+    {
+      "id": "74a79272-0364-49d0-8309-d5e5941ae45b",
+      "type": "code",
+      "language": "powershell",
+      "source": "$g = New-Graph\n\n$edges = @(\n    @{ From = \u0027Ingest\u0027;    To = \u0027Validate\u0027 }\n    @{ From = \u0027Validate\u0027;  To = \u0027Transform\u0027 }\n    @{ From = \u0027Transform\u0027; To = \u0027Persist\u0027 }\n    @{ From = \u0027Persist\u0027;   To = \u0027Report\u0027 }\n    @{ From = \u0027Validate\u0027;  To = \u0027Reject\u0027 }\n    @{ From = \u0027Reject\u0027;    To = \u0027Report\u0027 }\n)\n\nforeach ($edge in $edges) {\n    Add-Edge -Graph $g -From $edge.From -To $edge.To | Out-Null\n}\n\n[PSCustomObject]@{\n    VertexCount = $g.VertexCount\n    EdgeCount = $g.EdgeCount\n    HasIngestToReportPath = Test-GraphPath -Graph $g -From ([PSGraph.Model.PSVertex]::new(\u0027Ingest\u0027)) -To ([PSGraph.Model.PSVertex]::new(\u0027Report\u0027))\n}\n\n$dot = Export-Graph -Graph $g -Format Graphviz\n$dot"
+    },
+    {
+      "id": "c80905f0-1f06-4a2c-a059-198a5d0d2693",
+      "type": "markdown",
+      "source": "## Render the graph with PSGraphView\n\n\u0060Export-GraphvizView\u0060 uses the Graphviz path in PSGraphView and returns SVG that Verso can display inline."
+    },
+    {
+      "id": "c72c82d1-1dfe-433d-8d41-5b1b2a54a06a",
+      "type": "code",
+      "language": "powershell",
+      "source": "$svg = Export-GraphvizView -InputObject $dot -Renderer Dot -As Svg\nDisplay $svg \u0027image/svg\u002Bxml\u0027"
+    },
+    {
+      "id": "d99adc3d-b615-4b0d-98d8-7ee8475271d3",
+      "type": "markdown",
+      "source": "## Raster output\n\nThis cell renders the same graph as PNG and sends the image bytes to Verso as \u0060image/png\u0060."
+    },
+    {
+      "id": "d1f8332c-a589-465e-abf0-acb448469267",
+      "type": "code",
+      "language": "powershell",
+      "source": "$pngPath = Join-Path ([IO.Path]::GetTempPath()) \u0027psgraphview-gallery-sample.png\u0027\nExport-GraphvizView -InputObject $dot -Renderer Dot -As Png -OutputPath $pngPath\n[Convert]::ToBase64String([IO.File]::ReadAllBytes($pngPath)) | Display -MimeType \u0027image/png\u0027"
+    },
+    {
+      "id": "cdf30ba0-d8ba-42b4-8c2f-3572f697a8d0",
+      "type": "markdown",
+      "source": "## DSM smoke check\n\nPSGraph can wrap the same graph as a design structure matrix. PSGraphView can render that DSM as SVG."
+    },
+    {
+      "id": "d58435c7-f373-4293-960b-61087af10cc0",
+      "type": "code",
+      "language": "powershell",
+      "source": "$dsm = New-DSM -Graph $g\n$dsmSvg = Export-DSMView -Dsm $dsm -Renderer DsmMatrixSvg -As Svg\nDisplay $dsmSvg \u0027image/svg\u002Bxml\u0027"
+    }
+  ],
+  "layouts": {
+    "dashboard": {
+      "cells": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a PowerShell Gallery sample for PSQuickGraph and PSGraphView
- add the PowerShell Micrograd notebook and its helper scripts
- add an MNIST notebook that uses PSMnist with the Micrograd model
- load exact tested prerelease module versions without requiring PowerShellGet inside the embedded kernel
- use iterative post-order traversal for backpropagation so MNIST-sized graphs do not exceed the PowerShell call-depth limit

## Runtime compatibility

The notebooks are verified with the current Verso PowerShell kernel on .NET 8. Their published module dependencies target .NET 8, and the notebook code uses stable PowerShell language and module-loading APIs rather than Verso host or SDK-specific APIs.

They are therefore expected to continue working when Verso moves to a newer PowerShell SDK and .NET runtime. That future combination should still be revalidated when the kernel upgrade lands; this PR intentionally does not change Verso.Host, the PowerShell SDK, or VS Code behavior.

## Validation

- all 65 `Verso.PowerShell.Tests` tests pass on `net8.0`
- `verso run --fail-fast` executes the complete Gallery notebook: 11/11 cells
- `verso run --fail-fast` executes the complete Micrograd notebook: 26/26 cells
- `verso run --fail-fast` executes the complete MNIST notebook: 15/15 cells, including training and evaluation
- all three module setup cells execute through `Verso.PowerShell.Kernel.PowerShellKernel`, using the embedded `InitialSessionState.CreateDefault2()` runspace
- all added notebook files parse as valid JSON, and all PowerShell cells pass parser validation
- setup cells contain no calls to `Install-Module` or `Get-InstalledModule`; missing dependencies produce terminal installation instructions instead

All commits include DCO sign-off.