### PR TITLE
Extend the runtime formatting pipeline

### DIFF
--- a/docs/architecture/execution-pipeline.md
+++ b/docs/architecture/execution-pipeline.md
@@ -291,6 +291,6 @@ The `CellInteractionContext` carries the cell ID, extension ID, interaction type
 
 ## Data Formatters
 
-When a kernel produces a runtime object rather than a raw string output, the engine uses `IDataFormatter` extensions to convert it into a `CellOutput`. Formatters are sorted by `Priority` (higher values take precedence) and the first formatter that returns `true` from `CanFormat(value, context)` is used.
+When a kernel produces a runtime object rather than a raw string output, the engine uses `IDataFormatter` extensions to convert it into a `CellOutput`. The engine probes `CanFormat(value, context)` in host MIME-preference order, using formatter `Priority` (higher values first) within each MIME type, and calls `FormatAsync` only for the winning representation.
 
 Built-in formatters handle primitives, collections (as HTML tables), HTML strings, images, SVG, exceptions, F# types, and SQL result sets.

--- a/docs/extensions/best-practices.md
+++ b/docs/extensions/best-practices.md
@@ -367,7 +367,8 @@ var content = await File.ReadAllTextAsync(path, context.CancellationToken);
 // Good
 public bool CanFormat(object value, IFormatterContext context)
 {
-    return value is DiceResult;
+    return context.MimeType.Equals("text/html", StringComparison.OrdinalIgnoreCase) &&
+           value is DiceResult;
 }
 
 // Bad - may throw on unexpected types
@@ -376,6 +377,9 @@ public bool CanFormat(object value, IFormatterContext context)
     return ((DiceResult)value).Rolls.Count > 0; // InvalidCastException risk
 }
 ```
+
+`CanFormat` is also a MIME capability probe. Return `false` if `FormatAsync` cannot emit
+`context.MimeType`; the host may probe several acceptable representations before selecting one.
 
 ### Do Not Assume a Specific Host
 

--- a/docs/extensions/context-reference.md
+++ b/docs/extensions/context-reference.md
@@ -61,6 +61,7 @@ Extends `IVersoContext` with execution-specific state. Passed to `ILanguageKerne
 | `CellId` | `Guid` | Unique identifier of the cell being executed. |
 | `ExecutionCount` | `int` | Monotonically increasing execution counter for the current cell. |
 | `DisplayAsync(CellOutput)` | `Task` | Sends a display output that can be updated in place during execution. |
+| `TryFormatAsync(object, string?)` | `Task<CellOutput?>` | Gives registered specialized data formatters an opportunity to render a runtime value. Returns `null` when the kernel should use its native fallback. |
 | `RequestInputAsync(string, bool, CancellationToken)` | `Task<string?>` | Requests a single input value from the current host. The second argument controls password masking. Returns `null` when the user cancels. Default implementation throws `NotSupportedException` on non-interactive hosts. |
 
 ### When Available
@@ -72,6 +73,21 @@ Only within `ILanguageKernel.ExecuteAsync`. Not available during completions, di
 - `WriteOutputAsync` (from `IVersoContext`) appends output to the cell's output list permanently.
 - `DisplayAsync` sends a live-updating display that can be replaced. Use it for progress indicators, streaming output, or interactive displays.
 - `UpdateOutputAsync` (from `IVersoContext`) replaces the content of a specific output block by ID. Use it for interactive panels that refresh in place (e.g., paginated tables, `ICellInteractionHandler` responses).
+
+### Formatting Runtime Values
+
+Language kernels that receive runtime objects should call `TryFormatAsync` before applying
+their native formatter. Specialized `IDataFormatter` extensions get the first opportunity to
+produce a rich `CellOutput`; generic formatters marked as fallbacks are skipped so a kernel can
+preserve familiar language-specific output when no extension claims the value.
+
+```csharp
+var formatted = await context.TryFormatAsync(runtimeValue);
+if (formatted is not null)
+    return new[] { formatted };
+
+return new[] { FormatWithNativeRuntime(runtimeValue) };
+```
 
 ### Interactive Input
 

--- a/docs/extensions/context-reference.md
+++ b/docs/extensions/context-reference.md
@@ -91,8 +91,8 @@ return new[] { FormatWithNativeRuntime(runtimeValue) };
 
 Hosts that support multiple representations can pass their acceptable MIME types in descending
 order of preference. Formatter priority resolves conflicts within each MIME type; MIME type order
-takes precedence across representations. The first representation a specialized formatter can
-produce is returned:
+takes precedence across representations. The host probes `CanFormat` with each MIME-specific
+context, then invokes `FormatAsync` only for the selected formatter and representation:
 
 ```csharp
 var formatted = await context.TryFormatAsync(

--- a/docs/extensions/context-reference.md
+++ b/docs/extensions/context-reference.md
@@ -61,7 +61,7 @@ Extends `IVersoContext` with execution-specific state. Passed to `ILanguageKerne
 | `CellId` | `Guid` | Unique identifier of the cell being executed. |
 | `ExecutionCount` | `int` | Monotonically increasing execution counter for the current cell. |
 | `DisplayAsync(CellOutput)` | `Task` | Sends a display output that can be updated in place during execution. |
-| `TryFormatAsync(object, string?)` | `Task<CellOutput?>` | Gives registered specialized data formatters an opportunity to render a runtime value. Returns `null` when the kernel should use its native fallback. |
+| `TryFormatAsync(object, IReadOnlyList<string>?)` | `Task<CellOutput?>` | Gives registered specialized data formatters an opportunity to render a runtime value. Optional MIME types are tried in order. Returns `null` when the kernel should use its native fallback. |
 | `RequestInputAsync(string, bool, CancellationToken)` | `Task<string?>` | Requests a single input value from the current host. The second argument controls password masking. Returns `null` when the user cancels. Default implementation throws `NotSupportedException` on non-interactive hosts. |
 
 ### When Available
@@ -88,6 +88,20 @@ if (formatted is not null)
 
 return new[] { FormatWithNativeRuntime(runtimeValue) };
 ```
+
+Hosts that support multiple representations can pass their acceptable MIME types in descending
+order of preference. Formatter priority resolves conflicts within each MIME type; MIME type order
+takes precedence across representations. The first representation a specialized formatter can
+produce is returned:
+
+```csharp
+var formatted = await context.TryFormatAsync(
+    runtimeValue,
+    new[] { "image/svg+xml", "image/png", "text/plain" });
+```
+
+Passing `null` uses the host's default formatter context. An empty list accepts no representation
+and returns `null`, allowing the language kernel to preserve its native fallback.
 
 ### Interactive Input
 

--- a/docs/extensions/extension-interfaces.md
+++ b/docs/extensions/extension-interfaces.md
@@ -146,12 +146,17 @@ Formats runtime objects into display outputs. The host selects the best formatte
 |---|---|---|
 | `SupportedTypes` | `IReadOnlyList<Type>` | CLR types this formatter handles. Used for fast pre-filtering. |
 | `Priority` | `int` | Conflict resolution priority. Higher values win. |
+| `IsFallback` | `bool` | Whether this is a generic fallback formatter. Defaults to `false`; kernels may skip fallbacks in favor of native runtime formatting. |
 | `CanFormat(object, IFormatterContext)` | `bool` | Fine-grained check for whether this formatter can handle the value. |
 | `FormatAsync(object, IFormatterContext)` | `Task<CellOutput>` | Produces a `CellOutput` for the given value. |
 
 ### Lifecycle
 
 Formatters are stateless and invoked on-demand. When a kernel produces an object result, the host iterates registered formatters, filters by `SupportedTypes`, sorts by `Priority` (descending), and calls `CanFormat` then `FormatAsync` on the first match.
+
+Generic catch-all formatters should return `true` from `IsFallback`. Explicit display operations
+include them, while language kernels can request only specialized formatters and retain their own
+native formatting when none matches.
 
 ### Example Implementation
 

--- a/docs/extensions/extension-interfaces.md
+++ b/docs/extensions/extension-interfaces.md
@@ -147,12 +147,19 @@ Formats runtime objects into display outputs. The host selects the best formatte
 | `SupportedTypes` | `IReadOnlyList<Type>` | CLR types this formatter handles. Used for fast pre-filtering. |
 | `Priority` | `int` | Conflict resolution priority. Higher values win. |
 | `IsFallback` | `bool` | Whether this is a generic fallback formatter. Defaults to `false`; kernels may skip fallbacks in favor of native runtime formatting. |
-| `CanFormat(object, IFormatterContext)` | `bool` | Fine-grained check for whether this formatter can handle the value. |
+| `CanFormat(object, IFormatterContext)` | `bool` | Fine-grained check for whether this formatter can handle the value and emit the requested `context.MimeType`. |
 | `FormatAsync(object, IFormatterContext)` | `Task<CellOutput>` | Produces a `CellOutput` for the given value. |
 
 ### Lifecycle
 
-Formatters are stateless and invoked on-demand. When a kernel produces an object result, the host iterates registered formatters, filters by `SupportedTypes`, sorts by `Priority` (descending), and calls `CanFormat` then `FormatAsync` on the first match.
+Formatters are stateless and invoked on-demand. When a kernel produces an object result, the host
+filters registered formatters by `SupportedTypes`, probes `CanFormat` for the host's acceptable MIME
+types, and calls `FormatAsync` only for the winning formatter and representation. MIME preference
+takes precedence over formatter `Priority`; priority resolves conflicts within one MIME type.
+
+`CanFormat` must return `false` when the formatter cannot emit `context.MimeType`. A formatter that
+claims a MIME type but returns a different one is skipped so the host never receives a representation
+it did not declare as renderable.
 
 Generic catch-all formatters should return `true` from `IsFallback`. Explicit display operations
 include them, while language kernels can request only specialized formatters and retain their own
@@ -170,7 +177,9 @@ public sealed class DiceFormatter : IDataFormatter
     public IReadOnlyList<Type> SupportedTypes => new[] { typeof(DiceResult) };
     public int Priority => 10;
 
-    public bool CanFormat(object value, IFormatterContext context) => value is DiceResult;
+    public bool CanFormat(object value, IFormatterContext context)
+        => context.MimeType.Equals("text/html", StringComparison.OrdinalIgnoreCase) &&
+           value is DiceResult;
 
     public Task<CellOutput> FormatAsync(object value, IFormatterContext context)
     {

--- a/samples/extensions/Verso.Sample.Dice/DiceFormatter.cs
+++ b/samples/extensions/Verso.Sample.Dice/DiceFormatter.cs
@@ -23,7 +23,9 @@ public sealed class DiceFormatter : IDataFormatter
     public Task OnLoadedAsync(IExtensionHostContext context) => Task.CompletedTask;
     public Task OnUnloadedAsync() => Task.CompletedTask;
 
-    public bool CanFormat(object value, IFormatterContext context) => value is DiceResult;
+    public bool CanFormat(object value, IFormatterContext context)
+        => string.Equals(context.MimeType, "text/html", StringComparison.OrdinalIgnoreCase) &&
+           value is DiceResult;
 
     public Task<CellOutput> FormatAsync(object value, IFormatterContext context)
     {

--- a/src/Verso.Abstractions/Contexts/IExecutionContext.cs
+++ b/src/Verso.Abstractions/Contexts/IExecutionContext.cs
@@ -28,8 +28,12 @@ public interface IExecutionContext : IVersoContext
     /// kernel can preserve its native formatting behavior.
     /// </summary>
     /// <param name="value">The runtime value to format.</param>
-    /// <param name="mimeType">Optional preferred MIME type.</param>
-    Task<CellOutput?> TryFormatAsync(object value, string? mimeType = null)
+    /// <param name="acceptableMimeTypes">
+    /// Optional MIME types the host can render, in descending order of preference.
+    /// </param>
+    Task<CellOutput?> TryFormatAsync(
+        object value,
+        IReadOnlyList<string>? acceptableMimeTypes = null)
         => Task.FromResult<CellOutput?>(null);
 
     /// <summary>

--- a/src/Verso.Abstractions/Contexts/IExecutionContext.cs
+++ b/src/Verso.Abstractions/Contexts/IExecutionContext.cs
@@ -23,6 +23,16 @@ public interface IExecutionContext : IVersoContext
     Task DisplayAsync(CellOutput output);
 
     /// <summary>
+    /// Attempts to format a runtime value with a registered specialized data formatter.
+    /// Returns <see langword="null"/> when no formatter claims the value so the language
+    /// kernel can preserve its native formatting behavior.
+    /// </summary>
+    /// <param name="value">The runtime value to format.</param>
+    /// <param name="mimeType">Optional preferred MIME type.</param>
+    Task<CellOutput?> TryFormatAsync(object value, string? mimeType = null)
+        => Task.FromResult<CellOutput?>(null);
+
+    /// <summary>
     /// Requests a single line of user input from the current front-end.
     /// </summary>
     /// <param name="prompt">Prompt text shown to the user.</param>

--- a/src/Verso.Abstractions/Extensions/IDataFormatter.cs
+++ b/src/Verso.Abstractions/Extensions/IDataFormatter.cs
@@ -28,6 +28,8 @@ public interface IDataFormatter : IExtension
 
     /// <summary>
     /// Returns whether this formatter can produce output for the given value in the current context.
+    /// When <see cref="IFormatterContext.MimeType"/> specifies a target representation, this
+    /// method must return <see langword="false"/> unless <see cref="FormatAsync"/> will emit it.
     /// </summary>
     /// <param name="value">The object to format.</param>
     /// <param name="context">Formatter context providing MIME preferences and display options.</param>
@@ -36,6 +38,8 @@ public interface IDataFormatter : IExtension
 
     /// <summary>
     /// Formats the given value into a cell output suitable for display.
+    /// The returned MIME type must match <see cref="IFormatterContext.MimeType"/> when the
+    /// formatter claimed a MIME-constrained context in <see cref="CanFormat"/>.
     /// </summary>
     /// <param name="value">The object to format.</param>
     /// <param name="context">Formatter context providing MIME preferences and display options.</param>

--- a/src/Verso.Abstractions/Extensions/IDataFormatter.cs
+++ b/src/Verso.Abstractions/Extensions/IDataFormatter.cs
@@ -20,6 +20,13 @@ public interface IDataFormatter : IExtension
     int Priority { get; }
 
     /// <summary>
+    /// Whether this formatter is a generic fallback rather than a specialized representation.
+    /// Language kernels can skip fallback formatters when they have a richer native formatter
+    /// for values not claimed by an extension.
+    /// </summary>
+    bool IsFallback => false;
+
+    /// <summary>
     /// Returns whether this formatter can produce output for the given value in the current context.
     /// </summary>
     /// <param name="value">The object to format.</param>

--- a/src/Verso.Ado/Formatters/ResultSetFormatter.cs
+++ b/src/Verso.Ado/Formatters/ResultSetFormatter.cs
@@ -33,7 +33,8 @@ public sealed class ResultSetFormatter : IDataFormatter
 
     public bool CanFormat(object value, IFormatterContext context)
     {
-        return value is DataTable or SqlResultSet;
+        return string.Equals(context.MimeType, "text/html", StringComparison.OrdinalIgnoreCase) &&
+               value is DataTable or SqlResultSet;
     }
 
     public Task<CellOutput> FormatAsync(object value, IFormatterContext context)

--- a/src/Verso.FSharp/Formatters/FSharpDataFormatter.cs
+++ b/src/Verso.FSharp/Formatters/FSharpDataFormatter.cs
@@ -38,7 +38,12 @@ public sealed class FSharpDataFormatter : IDataFormatter
 
     public bool CanFormat(object value, IFormatterContext context)
     {
-        if (value is null) return false;
+        if (!string.Equals(context.MimeType, "text/html", StringComparison.OrdinalIgnoreCase) ||
+            value is null)
+        {
+            return false;
+        }
+
         var type = value.GetType();
         return IsFSharpType(type);
     }

--- a/src/Verso.PowerShell/Kernel/PowerShellKernel.cs
+++ b/src/Verso.PowerShell/Kernel/PowerShellKernel.cs
@@ -130,12 +130,38 @@ public sealed class PowerShellKernel : ILanguageKernel
                 AppendHostOutput,
                 RequestHostInput);
 
-            // Output stream (objects)
-            if (result.OutputLines.Count > 0)
+            // Give specialized extension formatters the first opportunity to handle raw
+            // runtime values. Contiguous unhandled objects are flushed together through
+            // PowerShell's native ETS formatter so table shape and output order are preserved.
+            var pendingNativeObjects = new List<System.Management.Automation.PSObject>();
+
+            foreach (var outputObject in result.OutputObjects)
             {
-                var text = string.Join(Environment.NewLine, result.OutputLines);
-                if (!string.IsNullOrEmpty(text))
-                    outputs.Add(new CellOutput(result.OutputMimeType, text));
+                var formatted = await context.TryFormatAsync(outputObject.BaseObject)
+                    .ConfigureAwait(false);
+
+                if (formatted is null)
+                {
+                    pendingNativeObjects.Add(outputObject);
+                    continue;
+                }
+
+                FlushNativeObjects();
+                outputs.Add(formatted);
+            }
+
+            FlushNativeObjects();
+
+            void FlushNativeObjects()
+            {
+                if (pendingNativeObjects.Count == 0)
+                    return;
+
+                var nativeOutput = _runspaceManager.FormatOutput(pendingNativeObjects);
+                if (nativeOutput is not null)
+                    outputs.Add(nativeOutput);
+
+                pendingNativeObjects.Clear();
             }
 
             // Information stream (Write-Information)

--- a/src/Verso.PowerShell/Kernel/RunspaceManager.cs
+++ b/src/Verso.PowerShell/Kernel/RunspaceManager.cs
@@ -10,8 +10,7 @@ using Verso.PowerShell.Kernel.Host;
 namespace Verso.PowerShell.Kernel;
 
 internal sealed record InvokeResult(
-    IReadOnlyList<string> OutputLines,
-    string OutputMimeType,
+    IReadOnlyList<PSObject> OutputObjects,
     IReadOnlyList<string> ErrorLines,
     IReadOnlyList<string> InformationLines,
     Exception? Exception);
@@ -61,8 +60,7 @@ internal sealed class RunspaceManager : IDisposable
             catch { /* best effort */ }
         });
 
-        var outputLines = new List<string>();
-        var outputMimeType = "text/plain";
+        IReadOnlyList<PSObject> outputObjects = Array.Empty<PSObject>();
         var errorLines = new List<string>();
         var informationLines = new List<string>();
         Exception? exception = null;
@@ -72,62 +70,7 @@ internal sealed class RunspaceManager : IDisposable
         try
         {
             Collection<PSObject> results = ps.Invoke();
-
-            if (results.Count > 0 && HasFormatObjects(results))
-            {
-                // Explicit Format-Table / Format-List: render through Out-String
-                // then parse the text table into HTML for consistent display.
-                using var renderer = System.Management.Automation.PowerShell.Create();
-                renderer.Runspace = runspace;
-                renderer.AddCommand("Out-String").AddParameter("Width", 200);
-                var rendered = renderer.Invoke(results);
-                // Out-String returns a single multi-line string; split into individual lines.
-                var lines = rendered
-                    .SelectMany(r => (r?.ToString() ?? "").Split('\n'))
-                    .Select(s => s.TrimEnd())
-                    .Where(s => s.Length > 0)
-                    .ToList();
-                if (lines.Count > 0)
-                {
-                    var html = ParseTextTableToHtml(lines);
-                    if (html is not null)
-                    {
-                        outputLines.Add(html);
-                        outputMimeType = "text/html";
-                    }
-                    else
-                    {
-                        // Not a parseable table (e.g. Format-List) - wrap as styled <pre>
-                        var sb = new StringBuilder();
-                        AppendPreStyles(sb);
-                        sb.Append("<div class=\"verso-ps-result\">");
-                        sb.Append("<pre class=\"verso-ps-pre\">")
-                          .Append(WebUtility.HtmlEncode(string.Join(Environment.NewLine, lines)))
-                          .Append("</pre>");
-                        sb.Append("</div>");
-                        outputLines.Add(sb.ToString());
-                        outputMimeType = "text/html";
-                    }
-                }
-            }
-            else if (results.Count > 0 && HasComplexObjects(results))
-            {
-                // Complex objects: render as HTML table using Select-Object for
-                // reliable property resolution through PowerShell's ETS.
-                var html = RenderObjectsAsHtml(results, runspace);
-                outputLines.Add(html);
-                outputMimeType = "text/html";
-            }
-            else
-            {
-                foreach (var obj in results)
-                {
-                    if (obj is not null)
-                    {
-                        outputLines.Add(obj.BaseObject is string s ? s : obj.ToString() ?? string.Empty);
-                    }
-                }
-            }
+            outputObjects = results.Where(result => result is not null).ToArray();
 
             foreach (var err in ps.Streams.Error)
             {
@@ -164,7 +107,63 @@ internal sealed class RunspaceManager : IDisposable
             _currentHostInput = null;
         }
 
-        return new InvokeResult(outputLines, outputMimeType, errorLines, informationLines, exception);
+        return new InvokeResult(outputObjects, errorLines, informationLines, exception);
+    }
+
+    /// <summary>
+    /// Applies PowerShell's native formatting fallback to a contiguous group of pipeline objects.
+    /// Specialized extension formatters get the first opportunity to handle each object in
+    /// <see cref="PowerShellKernel"/> before this method is called.
+    /// </summary>
+    public CellOutput? FormatOutput(IReadOnlyList<PSObject> objects)
+    {
+        ThrowIfDisposed();
+        var runspace = _runspace ?? throw new InvalidOperationException("RunspaceManager not initialized.");
+
+        if (objects.Count == 0)
+            return null;
+
+        if (HasFormatObjects(objects))
+        {
+            // Explicit Format-Table / Format-List: render through Out-String
+            // then parse the text table into HTML for consistent display.
+            using var renderer = System.Management.Automation.PowerShell.Create();
+            renderer.Runspace = runspace;
+            renderer.AddCommand("Out-String").AddParameter("Width", 200);
+            var rendered = renderer.Invoke(objects);
+            var lines = rendered
+                .SelectMany(result => (result?.ToString() ?? "").Split('\n'))
+                .Select(line => line.TrimEnd())
+                .Where(line => line.Length > 0)
+                .ToList();
+
+            if (lines.Count == 0)
+                return null;
+
+            var html = ParseTextTableToHtml(lines);
+            if (html is not null)
+                return CellOutput.Html(html);
+
+            var sb = new StringBuilder();
+            AppendPreStyles(sb);
+            sb.Append("<div class=\"verso-ps-result\">");
+            sb.Append("<pre class=\"verso-ps-pre\">")
+              .Append(WebUtility.HtmlEncode(string.Join(Environment.NewLine, lines)))
+              .Append("</pre>");
+            sb.Append("</div>");
+            return CellOutput.Html(sb.ToString());
+        }
+
+        if (HasComplexObjects(objects))
+            return CellOutput.Html(RenderObjectsAsHtml(objects, runspace));
+
+        var text = string.Join(
+            Environment.NewLine,
+            objects.Select(obj => obj.BaseObject is string value
+                ? value
+                : obj.ToString() ?? string.Empty));
+
+        return string.IsNullOrEmpty(text) ? null : CellOutput.Plain(text);
     }
 
     private static bool IsPowerShellHostInformation(InformationRecord record) =>
@@ -488,7 +487,7 @@ function Display {
         sb.Append("</style>");
     }
 
-    private static bool HasFormatObjects(Collection<PSObject> results)
+    private static bool HasFormatObjects(IReadOnlyList<PSObject> results)
     {
         foreach (var obj in results)
         {
@@ -499,7 +498,7 @@ function Display {
         return false;
     }
 
-    private static bool HasComplexObjects(Collection<PSObject> results)
+    private static bool HasComplexObjects(IReadOnlyList<PSObject> results)
     {
         foreach (var obj in results)
         {
@@ -518,7 +517,7 @@ function Display {
     /// <c>DefaultDisplayPropertySet</c> when available to select columns, falling
     /// back to the object's public properties.
     /// </summary>
-    private static string RenderObjectsAsHtml(Collection<PSObject> results, Runspace runspace)
+    private static string RenderObjectsAsHtml(IReadOnlyList<PSObject> results, Runspace runspace)
     {
         // Resolve display properties: use DefaultDisplayPropertySet if defined,
         // otherwise fall back to the properties of the first non-null object.
@@ -602,7 +601,7 @@ function Display {
     /// default table/list column selection), then falls back to the properties
     /// of the first non-null object.
     /// </summary>
-    private static IReadOnlyList<string> GetDisplayProperties(Collection<PSObject> results)
+    private static IReadOnlyList<string> GetDisplayProperties(IReadOnlyList<PSObject> results)
     {
         foreach (var obj in results)
         {

--- a/src/Verso.Testing/Fakes/FakeCellInteractionHandler.cs
+++ b/src/Verso.Testing/Fakes/FakeCellInteractionHandler.cs
@@ -29,7 +29,9 @@ public sealed class FakeCellInteractionHandler : IDataFormatter, ICellInteractio
     public IReadOnlyList<Type> SupportedTypes => new[] { typeof(string) };
     public int Priority => 0;
 
-    public bool CanFormat(object value, IFormatterContext context) => value is string;
+    public bool CanFormat(object value, IFormatterContext context)
+        => string.Equals(context.MimeType, "text/plain", StringComparison.OrdinalIgnoreCase) &&
+           value is string;
 
     public Task<CellOutput> FormatAsync(object value, IFormatterContext context)
         => Task.FromResult(new CellOutput("text/plain", value?.ToString() ?? ""));

--- a/src/Verso.Testing/Fakes/FakeDataFormatter.cs
+++ b/src/Verso.Testing/Fakes/FakeDataFormatter.cs
@@ -41,7 +41,9 @@ public sealed class FakeDataFormatter : IDataFormatter
         return Task.CompletedTask;
     }
 
-    public bool CanFormat(object value, IFormatterContext context) => value is string;
+    public bool CanFormat(object value, IFormatterContext context)
+        => string.Equals(context.MimeType, "text/plain", StringComparison.OrdinalIgnoreCase) &&
+           value is string;
 
     public Task<CellOutput> FormatAsync(object value, IFormatterContext context)
         => Task.FromResult(new CellOutput("text/plain", value?.ToString() ?? ""));

--- a/src/Verso.Testing/Stubs/StubExecutionContext.cs
+++ b/src/Verso.Testing/Stubs/StubExecutionContext.cs
@@ -20,6 +20,7 @@ public sealed class StubExecutionContext : IExecutionContext
     public Guid CellId { get; set; } = Guid.NewGuid();
     public int ExecutionCount { get; set; } = 1;
     public Func<string, bool, CancellationToken, Task<string?>>? InputHandler { get; set; }
+    public Func<object, string?, Task<CellOutput?>>? FormatHandler { get; set; }
 
     public List<CellOutput> WrittenOutputs { get; } = new();
     public List<CellOutput> DisplayedOutputs { get; } = new();
@@ -35,6 +36,9 @@ public sealed class StubExecutionContext : IExecutionContext
         DisplayedOutputs.Add(output);
         return Task.CompletedTask;
     }
+
+    public Task<CellOutput?> TryFormatAsync(object value, string? mimeType = null)
+        => FormatHandler?.Invoke(value, mimeType) ?? Task.FromResult<CellOutput?>(null);
 
     public Task<string?> RequestInputAsync(
         string prompt,

--- a/src/Verso.Testing/Stubs/StubExecutionContext.cs
+++ b/src/Verso.Testing/Stubs/StubExecutionContext.cs
@@ -20,7 +20,7 @@ public sealed class StubExecutionContext : IExecutionContext
     public Guid CellId { get; set; } = Guid.NewGuid();
     public int ExecutionCount { get; set; } = 1;
     public Func<string, bool, CancellationToken, Task<string?>>? InputHandler { get; set; }
-    public Func<object, string?, Task<CellOutput?>>? FormatHandler { get; set; }
+    public Func<object, IReadOnlyList<string>?, Task<CellOutput?>>? FormatHandler { get; set; }
 
     public List<CellOutput> WrittenOutputs { get; } = new();
     public List<CellOutput> DisplayedOutputs { get; } = new();
@@ -37,8 +37,10 @@ public sealed class StubExecutionContext : IExecutionContext
         return Task.CompletedTask;
     }
 
-    public Task<CellOutput?> TryFormatAsync(object value, string? mimeType = null)
-        => FormatHandler?.Invoke(value, mimeType) ?? Task.FromResult<CellOutput?>(null);
+    public Task<CellOutput?> TryFormatAsync(
+        object value,
+        IReadOnlyList<string>? acceptableMimeTypes = null)
+        => FormatHandler?.Invoke(value, acceptableMimeTypes) ?? Task.FromResult<CellOutput?>(null);
 
     public Task<string?> RequestInputAsync(
         string prompt,

--- a/src/Verso.Testing/Stubs/StubFormatterContext.cs
+++ b/src/Verso.Testing/Stubs/StubFormatterContext.cs
@@ -19,7 +19,7 @@ public sealed class StubFormatterContext : IFormatterContext
     public CancellationToken CancellationToken { get; set; } = CancellationToken.None;
     public IThemeContext Theme { get; } = new StubThemeContext();
     public LayoutCapabilities LayoutCapabilities { get; set; } = LayoutCapabilities.None;
-    public IExtensionHostContext ExtensionHost { get; } = new StubExtensionHostContext(() => Array.Empty<ILanguageKernel>());
+    public IExtensionHostContext ExtensionHost { get; set; } = new StubExtensionHostContext(() => Array.Empty<ILanguageKernel>());
     public INotebookMetadata NotebookMetadata { get; } = new NotebookMetadataContext(new NotebookModel());
     public INotebookOperations Notebook { get; } = new StubNotebookOperations();
 

--- a/src/Verso/Contexts/ExecutionContext.cs
+++ b/src/Verso/Contexts/ExecutionContext.cs
@@ -1,4 +1,5 @@
 using Verso.Abstractions;
+using Verso.Display;
 
 namespace Verso.Contexts;
 
@@ -72,6 +73,21 @@ public sealed class ExecutionContext : VersoContext, IExecutionContext
     {
         ArgumentNullException.ThrowIfNull(output);
         return _display(output);
+    }
+
+    /// <inheritdoc />
+    public Task<CellOutput?> TryFormatAsync(object value, string? mimeType = null)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        IFormatterContext formatterContext = new DisplayFormatterContext(this);
+        if (mimeType is not null)
+            formatterContext = new HintedFormatterContext(formatterContext, mimeType);
+
+        return FormatterResolver.TryFormatAsync(
+            value,
+            formatterContext,
+            includeFallback: false);
     }
 
     /// <inheritdoc />

--- a/src/Verso/Contexts/ExecutionContext.cs
+++ b/src/Verso/Contexts/ExecutionContext.cs
@@ -76,18 +76,36 @@ public sealed class ExecutionContext : VersoContext, IExecutionContext
     }
 
     /// <inheritdoc />
-    public Task<CellOutput?> TryFormatAsync(object value, string? mimeType = null)
+    public async Task<CellOutput?> TryFormatAsync(
+        object value,
+        IReadOnlyList<string>? acceptableMimeTypes = null)
     {
         ArgumentNullException.ThrowIfNull(value);
 
         IFormatterContext formatterContext = new DisplayFormatterContext(this);
-        if (mimeType is not null)
-            formatterContext = new HintedFormatterContext(formatterContext, mimeType);
+        if (acceptableMimeTypes is null)
+        {
+            return await FormatterResolver.TryFormatAsync(
+                value,
+                formatterContext,
+                includeFallback: false).ConfigureAwait(false);
+        }
 
-        return FormatterResolver.TryFormatAsync(
-            value,
-            formatterContext,
-            includeFallback: false);
+        foreach (var mimeType in acceptableMimeTypes)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(mimeType);
+
+            var output = await FormatterResolver.TryFormatAsync(
+                value,
+                new HintedFormatterContext(formatterContext, mimeType),
+                includeFallback: false,
+                requiredMimeType: mimeType).ConfigureAwait(false);
+
+            if (output is not null)
+                return output;
+        }
+
+        return null;
     }
 
     /// <inheritdoc />

--- a/src/Verso/Contexts/ExecutionContext.cs
+++ b/src/Verso/Contexts/ExecutionContext.cs
@@ -83,29 +83,11 @@ public sealed class ExecutionContext : VersoContext, IExecutionContext
         ArgumentNullException.ThrowIfNull(value);
 
         IFormatterContext formatterContext = new DisplayFormatterContext(this);
-        if (acceptableMimeTypes is null)
-        {
-            return await FormatterResolver.TryFormatAsync(
-                value,
-                formatterContext,
-                includeFallback: false).ConfigureAwait(false);
-        }
-
-        foreach (var mimeType in acceptableMimeTypes)
-        {
-            ArgumentException.ThrowIfNullOrWhiteSpace(mimeType);
-
-            var output = await FormatterResolver.TryFormatAsync(
-                value,
-                new HintedFormatterContext(formatterContext, mimeType),
-                includeFallback: false,
-                requiredMimeType: mimeType).ConfigureAwait(false);
-
-            if (output is not null)
-                return output;
-        }
-
-        return null;
+        return await FormatterResolver.TryFormatAsync(
+            value,
+            formatterContext,
+            includeFallback: false,
+            acceptableMimeTypes: acceptableMimeTypes).ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/src/Verso/Display/DisplayHandler.cs
+++ b/src/Verso/Display/DisplayHandler.cs
@@ -9,16 +9,13 @@ namespace Verso.Display;
 internal sealed class DisplayHandler
 {
     private readonly Func<CellOutput, Task> _writeOutput;
-    private readonly IExtensionHostContext _extensionHost;
     private readonly IFormatterContext _defaultFormatterContext;
 
     public DisplayHandler(
         Func<CellOutput, Task> writeOutput,
-        IExtensionHostContext extensionHost,
         IFormatterContext defaultFormatterContext)
     {
         _writeOutput = writeOutput;
-        _extensionHost = extensionHost;
         _defaultFormatterContext = defaultFormatterContext;
     }
 
@@ -44,20 +41,15 @@ internal sealed class DisplayHandler
             ? new HintedFormatterContext(_defaultFormatterContext, mimeTypeHint)
             : _defaultFormatterContext;
 
-        // Try the formatter pipeline
-        var formatters = _extensionHost.GetFormatters();
-        if (formatters.Count > 0)
+        // Explicit Display uses the complete pipeline, including generic fallbacks.
+        var formatted = await FormatterResolver.TryFormatAsync(
+            value,
+            formatterContext,
+            includeFallback: true).ConfigureAwait(false);
+        if (formatted is not null)
         {
-            foreach (var formatter in formatters.OrderByDescending(f => f.Priority))
-            {
-                if (formatter.SupportedTypes.Any(t => t.IsInstanceOfType(value))
-                    && formatter.CanFormat(value, formatterContext))
-                {
-                    var output = await formatter.FormatAsync(value, formatterContext).ConfigureAwait(false);
-                    await _writeOutput(output).ConfigureAwait(false);
-                    return;
-                }
-            }
+            await _writeOutput(formatted).ConfigureAwait(false);
+            return;
         }
 
         // Handle specific MIME hint formats before falling back to ToString
@@ -97,30 +89,5 @@ internal sealed class DisplayHandler
         {
             return null;
         }
-    }
-
-    /// <summary>
-    /// Wraps an existing <see cref="IFormatterContext"/> with an overridden MIME type hint.
-    /// </summary>
-    private sealed class HintedFormatterContext : IFormatterContext
-    {
-        private readonly IFormatterContext _inner;
-        public HintedFormatterContext(IFormatterContext inner, string mimeType)
-        {
-            _inner = inner;
-            MimeType = mimeType;
-        }
-
-        public string MimeType { get; }
-        public double MaxWidth => _inner.MaxWidth;
-        public double MaxHeight => _inner.MaxHeight;
-        public IVariableStore Variables => _inner.Variables;
-        public CancellationToken CancellationToken => _inner.CancellationToken;
-        public Task WriteOutputAsync(CellOutput output) => _inner.WriteOutputAsync(output);
-        public IThemeContext Theme => _inner.Theme;
-        public LayoutCapabilities LayoutCapabilities => _inner.LayoutCapabilities;
-        public IExtensionHostContext ExtensionHost => _inner.ExtensionHost;
-        public INotebookMetadata NotebookMetadata => _inner.NotebookMetadata;
-        public INotebookOperations Notebook => _inner.Notebook;
     }
 }

--- a/src/Verso/Display/FormatterResolver.cs
+++ b/src/Verso/Display/FormatterResolver.cs
@@ -11,42 +11,103 @@ internal static class FormatterResolver
         object value,
         IFormatterContext context,
         bool includeFallback,
-        string? requiredMimeType = null)
+        IReadOnlyList<string>? acceptableMimeTypes = null)
     {
         ArgumentNullException.ThrowIfNull(value);
         ArgumentNullException.ThrowIfNull(context);
 
-        if (value is CellOutput output)
-            return output;
+        var formatters = context.ExtensionHost.GetFormatters()
+            .Where(formatter => includeFallback || !formatter.IsFallback)
+            .Where(formatter => formatter.SupportedTypes.Any(type => type.IsInstanceOfType(value)))
+            .OrderByDescending(formatter => formatter.Priority)
+            .ToArray();
 
-        foreach (var formatter in context.ExtensionHost.GetFormatters()
-                     .Where(formatter => includeFallback || !formatter.IsFallback)
-                     .OrderByDescending(formatter => formatter.Priority))
+        var candidateContexts = new List<(IFormatterContext Context, string? RequiredMimeType)>();
+        if (acceptableMimeTypes is null)
         {
-            if (!formatter.SupportedTypes.Any(type => type.IsInstanceOfType(value)))
+            candidateContexts.Add((context, null));
+        }
+        else
+        {
+            foreach (var mimeType in acceptableMimeTypes)
+            {
+                ArgumentException.ThrowIfNullOrWhiteSpace(mimeType);
+                candidateContexts.Add((new HintedFormatterContext(context, mimeType), mimeType));
+            }
+        }
+
+        var rejectedFormatters = new HashSet<IDataFormatter>();
+        var candidates = new List<(IDataFormatter Formatter, IFormatterContext Context, string? RequiredMimeType)>();
+
+        // Probe every hinted context before invoking a formatter. Candidate order is
+        // MIME preference first, then formatter priority within that representation.
+        foreach (var candidateContext in candidateContexts)
+        {
+            foreach (var formatter in formatters)
+            {
+                if (rejectedFormatters.Contains(formatter))
+                    continue;
+
+                try
+                {
+                    if (formatter.CanFormat(value, candidateContext.Context))
+                    {
+                        candidates.Add((
+                            formatter,
+                            candidateContext.Context,
+                            candidateContext.RequiredMimeType));
+                    }
+                }
+                catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch
+                {
+                    // CanFormat is a probe. A broken formatter must not prevent another
+                    // formatter (or the kernel's native fallback) from running.
+                    rejectedFormatters.Add(formatter);
+                }
+            }
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (rejectedFormatters.Contains(candidate.Formatter))
                 continue;
 
-            bool canFormat;
+            CellOutput formattedOutput;
             try
             {
-                canFormat = formatter.CanFormat(value, context);
+                formattedOutput = await candidate.Formatter
+                    .FormatAsync(value, candidate.Context)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch
             {
-                // CanFormat is a probe. A broken formatter must not prevent another
-                // formatter (or the kernel's native fallback) from running.
+                // A formatter that fails after claiming a value is broken for this
+                // resolution. Skip all of its other MIME candidates and keep looking.
+                rejectedFormatters.Add(candidate.Formatter);
                 continue;
             }
 
-            if (canFormat)
+            if (candidate.RequiredMimeType is not null &&
+                !string.Equals(
+                    formattedOutput.MimeType,
+                    candidate.RequiredMimeType,
+                    StringComparison.OrdinalIgnoreCase))
             {
-                var formattedOutput = await formatter.FormatAsync(value, context).ConfigureAwait(false);
-                if (requiredMimeType is null ||
-                    string.Equals(formattedOutput.MimeType, requiredMimeType, StringComparison.OrdinalIgnoreCase))
-                {
-                    return formattedOutput;
-                }
+                // CanFormat must only claim MIME types the formatter can emit. Do not
+                // run a contract-violating formatter again for the same value.
+                rejectedFormatters.Add(candidate.Formatter);
+                continue;
             }
+
+            return formattedOutput;
         }
 
         return null;

--- a/src/Verso/Display/FormatterResolver.cs
+++ b/src/Verso/Display/FormatterResolver.cs
@@ -1,0 +1,46 @@
+using Verso.Abstractions;
+
+namespace Verso.Display;
+
+/// <summary>
+/// Resolves runtime values through the registered formatter pipeline without writing output.
+/// </summary>
+internal static class FormatterResolver
+{
+    public static async Task<CellOutput?> TryFormatAsync(
+        object value,
+        IFormatterContext context,
+        bool includeFallback)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (value is CellOutput output)
+            return output;
+
+        foreach (var formatter in context.ExtensionHost.GetFormatters()
+                     .Where(formatter => includeFallback || !formatter.IsFallback)
+                     .OrderByDescending(formatter => formatter.Priority))
+        {
+            if (!formatter.SupportedTypes.Any(type => type.IsInstanceOfType(value)))
+                continue;
+
+            bool canFormat;
+            try
+            {
+                canFormat = formatter.CanFormat(value, context);
+            }
+            catch
+            {
+                // CanFormat is a probe. A broken formatter must not prevent another
+                // formatter (or the kernel's native fallback) from running.
+                continue;
+            }
+
+            if (canFormat)
+                return await formatter.FormatAsync(value, context).ConfigureAwait(false);
+        }
+
+        return null;
+    }
+}

--- a/src/Verso/Display/FormatterResolver.cs
+++ b/src/Verso/Display/FormatterResolver.cs
@@ -10,7 +10,8 @@ internal static class FormatterResolver
     public static async Task<CellOutput?> TryFormatAsync(
         object value,
         IFormatterContext context,
-        bool includeFallback)
+        bool includeFallback,
+        string? requiredMimeType = null)
     {
         ArgumentNullException.ThrowIfNull(value);
         ArgumentNullException.ThrowIfNull(context);
@@ -38,7 +39,14 @@ internal static class FormatterResolver
             }
 
             if (canFormat)
-                return await formatter.FormatAsync(value, context).ConfigureAwait(false);
+            {
+                var formattedOutput = await formatter.FormatAsync(value, context).ConfigureAwait(false);
+                if (requiredMimeType is null ||
+                    string.Equals(formattedOutput.MimeType, requiredMimeType, StringComparison.OrdinalIgnoreCase))
+                {
+                    return formattedOutput;
+                }
+            }
         }
 
         return null;

--- a/src/Verso/Display/HintedFormatterContext.cs
+++ b/src/Verso/Display/HintedFormatterContext.cs
@@ -1,0 +1,29 @@
+using Verso.Abstractions;
+
+namespace Verso.Display;
+
+/// <summary>
+/// Wraps a formatter context with an overridden MIME type preference.
+/// </summary>
+internal sealed class HintedFormatterContext : IFormatterContext
+{
+    private readonly IFormatterContext _inner;
+
+    public HintedFormatterContext(IFormatterContext inner, string mimeType)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        MimeType = mimeType ?? throw new ArgumentNullException(nameof(mimeType));
+    }
+
+    public string MimeType { get; }
+    public double MaxWidth => _inner.MaxWidth;
+    public double MaxHeight => _inner.MaxHeight;
+    public IVariableStore Variables => _inner.Variables;
+    public CancellationToken CancellationToken => _inner.CancellationToken;
+    public Task WriteOutputAsync(CellOutput output) => _inner.WriteOutputAsync(output);
+    public IThemeContext Theme => _inner.Theme;
+    public LayoutCapabilities LayoutCapabilities => _inner.LayoutCapabilities;
+    public IExtensionHostContext ExtensionHost => _inner.ExtensionHost;
+    public INotebookMetadata NotebookMetadata => _inner.NotebookMetadata;
+    public INotebookOperations Notebook => _inner.Notebook;
+}

--- a/src/Verso/Execution/ExecutionPipeline.cs
+++ b/src/Verso/Execution/ExecutionPipeline.cs
@@ -345,7 +345,7 @@ internal sealed class ExecutionPipeline
 
         // Set up the ambient display handler so user code can call .Display()
         var displayFormatterContext = new DisplayFormatterContext(context);
-        var displayHandler = new DisplayHandler(AppendOutput, _extensionHost, displayFormatterContext);
+        var displayHandler = new DisplayHandler(AppendOutput, displayFormatterContext);
         using var _ = DisplayContext.SetHandler(displayHandler.DisplayAsync);
 
         // Marks this notebook as the one running while the cell is in flight. A background failure

--- a/src/Verso/Extensions/Formatters/CollectionFormatter.cs
+++ b/src/Verso/Extensions/Formatters/CollectionFormatter.cs
@@ -28,7 +28,8 @@ public sealed class CollectionFormatter : IDataFormatter
 
     public bool CanFormat(object value, IFormatterContext context)
     {
-        return value is IEnumerable && value is not string;
+        return string.Equals(context.MimeType, "text/html", StringComparison.OrdinalIgnoreCase) &&
+               value is IEnumerable && value is not string;
     }
 
     public Task<CellOutput> FormatAsync(object value, IFormatterContext context)

--- a/src/Verso/Extensions/Formatters/CollectionFormatter.cs
+++ b/src/Verso/Extensions/Formatters/CollectionFormatter.cs
@@ -21,6 +21,7 @@ public sealed class CollectionFormatter : IDataFormatter
 
     public IReadOnlyList<Type> SupportedTypes { get; } = new[] { typeof(IEnumerable) };
     public int Priority => 10;
+    public bool IsFallback => true;
 
     public Task OnLoadedAsync(IExtensionHostContext context) => Task.CompletedTask;
     public Task OnUnloadedAsync() => Task.CompletedTask;

--- a/src/Verso/Extensions/Formatters/ExceptionFormatter.cs
+++ b/src/Verso/Extensions/Formatters/ExceptionFormatter.cs
@@ -28,7 +28,8 @@ public sealed class ExceptionFormatter : IDataFormatter
 
     public bool CanFormat(object value, IFormatterContext context)
     {
-        return value is Exception;
+        return string.Equals(context.MimeType, "text/html", StringComparison.OrdinalIgnoreCase) &&
+               value is Exception;
     }
 
     public Task<CellOutput> FormatAsync(object value, IFormatterContext context)

--- a/src/Verso/Extensions/Formatters/HtmlFormatter.cs
+++ b/src/Verso/Extensions/Formatters/HtmlFormatter.cs
@@ -27,7 +27,8 @@ public sealed class HtmlFormatter : IDataFormatter
 
     public bool CanFormat(object value, IFormatterContext context)
     {
-        return GetToHtmlMethod(value.GetType()) is not null;
+        return string.Equals(context.MimeType, "text/html", StringComparison.OrdinalIgnoreCase) &&
+               GetToHtmlMethod(value.GetType()) is not null;
     }
 
     public Task<CellOutput> FormatAsync(object value, IFormatterContext context)

--- a/src/Verso/Extensions/Formatters/ImageFormatter.cs
+++ b/src/Verso/Extensions/Formatters/ImageFormatter.cs
@@ -26,7 +26,8 @@ public sealed class ImageFormatter : IDataFormatter
 
     public bool CanFormat(object value, IFormatterContext context)
     {
-        return value is byte[];
+        return string.Equals(context.MimeType, "text/html", StringComparison.OrdinalIgnoreCase) &&
+               value is byte[];
     }
 
     public Task<CellOutput> FormatAsync(object value, IFormatterContext context)

--- a/src/Verso/Extensions/Formatters/ObjectFormatter.cs
+++ b/src/Verso/Extensions/Formatters/ObjectFormatter.cs
@@ -29,6 +29,7 @@ public sealed class ObjectFormatter : IDataFormatter
 
     public IReadOnlyList<Type> SupportedTypes { get; } = new[] { typeof(object) };
     public int Priority => 5;
+    public bool IsFallback => true;
 
     public Task OnLoadedAsync(IExtensionHostContext context) => Task.CompletedTask;
     public Task OnUnloadedAsync() => Task.CompletedTask;

--- a/src/Verso/Extensions/Formatters/ObjectFormatter.cs
+++ b/src/Verso/Extensions/Formatters/ObjectFormatter.cs
@@ -36,6 +36,9 @@ public sealed class ObjectFormatter : IDataFormatter
 
     public bool CanFormat(object value, IFormatterContext context)
     {
+        if (!string.Equals(context.MimeType, "text/html", StringComparison.OrdinalIgnoreCase))
+            return false;
+
         var type = value.GetType();
         if (type.IsPrimitive || type.IsEnum || ExcludedTypes.Contains(type))
             return false;

--- a/src/Verso/Extensions/Formatters/PrimitiveFormatter.cs
+++ b/src/Verso/Extensions/Formatters/PrimitiveFormatter.cs
@@ -35,6 +35,7 @@ public sealed class PrimitiveFormatter : IDataFormatter
 
     public IReadOnlyList<Type> SupportedTypes { get; } = PrimitiveTypes.ToList();
     public int Priority => 0;
+    public bool IsFallback => true;
 
     public Task OnLoadedAsync(IExtensionHostContext context) => Task.CompletedTask;
     public Task OnUnloadedAsync() => Task.CompletedTask;

--- a/src/Verso/Extensions/Formatters/PrimitiveFormatter.cs
+++ b/src/Verso/Extensions/Formatters/PrimitiveFormatter.cs
@@ -42,7 +42,8 @@ public sealed class PrimitiveFormatter : IDataFormatter
 
     public bool CanFormat(object value, IFormatterContext context)
     {
-        return PrimitiveTypes.Contains(value.GetType());
+        return string.Equals(context.MimeType, "text/plain", StringComparison.OrdinalIgnoreCase) &&
+               PrimitiveTypes.Contains(value.GetType());
     }
 
     public Task<CellOutput> FormatAsync(object value, IFormatterContext context)

--- a/src/Verso/Extensions/Formatters/SvgFormatter.cs
+++ b/src/Verso/Extensions/Formatters/SvgFormatter.cs
@@ -26,7 +26,9 @@ public sealed class SvgFormatter : IDataFormatter
 
     public bool CanFormat(object value, IFormatterContext context)
     {
-        return value is string s && s.TrimStart().StartsWith("<svg", StringComparison.OrdinalIgnoreCase);
+        return string.Equals(context.MimeType, "text/html", StringComparison.OrdinalIgnoreCase) &&
+               value is string s &&
+               s.TrimStart().StartsWith("<svg", StringComparison.OrdinalIgnoreCase);
     }
 
     public Task<CellOutput> FormatAsync(object value, IFormatterContext context)

--- a/src/Verso/Stubs/StubExtensionHostContext.cs
+++ b/src/Verso/Stubs/StubExtensionHostContext.cs
@@ -10,13 +10,16 @@ public sealed class StubExtensionHostContext : IExtensionHostContext
 {
     private readonly Func<IReadOnlyList<ILanguageKernel>> _getKernels;
     private readonly Func<IReadOnlyList<ICellRenderer>> _getRenderers;
+    private readonly Func<IReadOnlyList<IDataFormatter>> _getFormatters;
 
     public StubExtensionHostContext(
         Func<IReadOnlyList<ILanguageKernel>> getKernels,
-        Func<IReadOnlyList<ICellRenderer>>? getRenderers = null)
+        Func<IReadOnlyList<ICellRenderer>>? getRenderers = null,
+        Func<IReadOnlyList<IDataFormatter>>? getFormatters = null)
     {
         _getKernels = getKernels ?? throw new ArgumentNullException(nameof(getKernels));
         _getRenderers = getRenderers ?? (() => Array.Empty<ICellRenderer>());
+        _getFormatters = getFormatters ?? (() => Array.Empty<IDataFormatter>());
     }
 
     /// <summary>
@@ -41,7 +44,7 @@ public sealed class StubExtensionHostContext : IExtensionHostContext
     public IReadOnlyList<ICellRenderer> GetRenderers() => _getRenderers();
 
     /// <inheritdoc />
-    public IReadOnlyList<IDataFormatter> GetFormatters() => Array.Empty<IDataFormatter>();
+    public IReadOnlyList<IDataFormatter> GetFormatters() => _getFormatters();
 
     /// <inheritdoc />
     public IReadOnlyList<ICellType> GetCellTypes() => Array.Empty<ICellType>();

--- a/tests/Verso.PowerShell.Tests/Kernel/ExecutionTests.cs
+++ b/tests/Verso.PowerShell.Tests/Kernel/ExecutionTests.cs
@@ -288,4 +288,33 @@ public class ExecutionTests
         Assert.IsTrue(allText.Contains("first"), $"Expected 'first', got: {allText}");
         Assert.IsTrue(allText.Contains("second"), $"Expected 'second', got: {allText}");
     }
+
+    [TestMethod]
+    public async Task ImplicitOutput_UsesSpecializedFormatter()
+    {
+        _context.FormatHandler = (value, _) => Task.FromResult<CellOutput?>(
+            value is Uri ? CellOutput.Html("<strong>formatted URI</strong>") : null);
+
+        var outputs = await _kernel.ExecuteAsync("[uri]'https://example.com'", _context);
+
+        Assert.AreEqual(1, outputs.Count);
+        Assert.AreEqual("text/html", outputs[0].MimeType);
+        Assert.AreEqual("<strong>formatted URI</strong>", outputs[0].Content);
+    }
+
+    [TestMethod]
+    public async Task ImplicitOutput_PreservesNativeAndSpecializedOutputOrder()
+    {
+        _context.FormatHandler = (value, _) => Task.FromResult<CellOutput?>(
+            value is Uri ? CellOutput.Html("<strong>formatted URI</strong>") : null);
+
+        var outputs = await _kernel.ExecuteAsync(
+            "'before'\n[uri]'https://example.com'\n'after'",
+            _context);
+
+        Assert.AreEqual(3, outputs.Count);
+        Assert.AreEqual("before", outputs[0].Content);
+        Assert.AreEqual("<strong>formatted URI</strong>", outputs[1].Content);
+        Assert.AreEqual("after", outputs[2].Content);
+    }
 }

--- a/tests/Verso.Tests/Contexts/ExecutionContextTests.cs
+++ b/tests/Verso.Tests/Contexts/ExecutionContextTests.cs
@@ -60,10 +60,48 @@ public sealed class ExecutionContextTests
         Assert.IsInstanceOfType(context, typeof(Verso.Abstractions.IExecutionContext));
     }
 
+    [TestMethod]
+    public async Task TryFormatAsync_UsesSpecializedFormatter()
+    {
+        var formatter = new TestFormatter(isFallback: false);
+        var host = new StubExtensionHostContext(
+            () => Array.Empty<Verso.Abstractions.ILanguageKernel>(),
+            getFormatters: () => new[] { formatter });
+        var context = CreateContext(
+            Guid.NewGuid(), 1,
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            host);
+
+        var output = await context.TryFormatAsync("value");
+
+        Assert.IsNotNull(output);
+        Assert.AreEqual("specialized", output.Content);
+    }
+
+    [TestMethod]
+    public async Task TryFormatAsync_SkipsFallbackFormatter()
+    {
+        var formatter = new TestFormatter(isFallback: true);
+        var host = new StubExtensionHostContext(
+            () => Array.Empty<Verso.Abstractions.ILanguageKernel>(),
+            getFormatters: () => new[] { formatter });
+        var context = CreateContext(
+            Guid.NewGuid(), 1,
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            host);
+
+        var output = await context.TryFormatAsync("value");
+
+        Assert.IsNull(output);
+    }
+
     private static ExecutionCtx CreateContext(
         Guid cellId, int executionCount,
         Func<CellOutput, Task> writeOutput,
-        Func<CellOutput, Task> display)
+        Func<CellOutput, Task> display,
+        Verso.Abstractions.IExtensionHostContext? extensionHost = null)
     {
         return new ExecutionCtx(
             cellId, executionCount,
@@ -71,9 +109,28 @@ public sealed class ExecutionContextTests
             CancellationToken.None,
             new StubThemeContext(),
             LayoutCapabilities.None,
-            new StubExtensionHostContext(() => Array.Empty<Verso.Abstractions.ILanguageKernel>()),
+            extensionHost ?? new StubExtensionHostContext(() => Array.Empty<Verso.Abstractions.ILanguageKernel>()),
             new NotebookMetadataContext(new NotebookModel()),
             new StubNotebookOperations(),
             writeOutput, display);
+    }
+
+    private sealed class TestFormatter : Verso.Abstractions.IDataFormatter
+    {
+        public TestFormatter(bool isFallback) => IsFallback = isFallback;
+
+        public string ExtensionId => "com.test.execution-context.formatter";
+        public string Name => "Execution Context Formatter";
+        public string Version => "1.0.0";
+        public string? Author => null;
+        public string? Description => null;
+        public IReadOnlyList<Type> SupportedTypes { get; } = new[] { typeof(string) };
+        public int Priority => 10;
+        public bool IsFallback { get; }
+        public Task OnLoadedAsync(Verso.Abstractions.IExtensionHostContext context) => Task.CompletedTask;
+        public Task OnUnloadedAsync() => Task.CompletedTask;
+        public bool CanFormat(object value, Verso.Abstractions.IFormatterContext context) => value is string;
+        public Task<CellOutput> FormatAsync(object value, Verso.Abstractions.IFormatterContext context)
+            => Task.FromResult(CellOutput.Plain("specialized"));
     }
 }

--- a/tests/Verso.Tests/Contexts/ExecutionContextTests.cs
+++ b/tests/Verso.Tests/Contexts/ExecutionContextTests.cs
@@ -97,6 +97,91 @@ public sealed class ExecutionContextTests
         Assert.IsNull(output);
     }
 
+    [TestMethod]
+    public async Task TryFormatAsync_UsesFirstAcceptableMimeTypeAFormatterSupports()
+    {
+        var formatter = new MimeFormatter("image/png", "text/plain");
+        var host = new StubExtensionHostContext(
+            () => Array.Empty<Verso.Abstractions.ILanguageKernel>(),
+            getFormatters: () => new[] { formatter });
+        var context = CreateContext(
+            Guid.NewGuid(), 1,
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            host);
+
+        var output = await context.TryFormatAsync(
+            "value",
+            new[] { "image/svg+xml", "image/png", "text/plain" });
+
+        Assert.IsNotNull(output);
+        Assert.AreEqual("image/png", output.MimeType);
+        CollectionAssert.AreEqual(
+            new[] { "image/svg+xml", "image/png" },
+            formatter.ProbedMimeTypes);
+    }
+
+    [TestMethod]
+    public async Task TryFormatAsync_MimeTypeOrderTakesPrecedenceOverFormatterPriority()
+    {
+        var pngFormatter = new MimeFormatter(priority: 20, "image/png");
+        var svgFormatter = new MimeFormatter(priority: 10, "image/svg+xml");
+        var host = new StubExtensionHostContext(
+            () => Array.Empty<Verso.Abstractions.ILanguageKernel>(),
+            getFormatters: () => new[] { pngFormatter, svgFormatter });
+        var context = CreateContext(
+            Guid.NewGuid(), 1,
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            host);
+
+        var output = await context.TryFormatAsync(
+            "value",
+            new[] { "image/svg+xml", "image/png" });
+
+        Assert.IsNotNull(output);
+        Assert.AreEqual("image/svg+xml", output.MimeType);
+    }
+
+    [TestMethod]
+    public async Task TryFormatAsync_ReturnsNullWhenNoAcceptableMimeTypeIsSupported()
+    {
+        var formatter = new MimeFormatter("text/html");
+        var host = new StubExtensionHostContext(
+            () => Array.Empty<Verso.Abstractions.ILanguageKernel>(),
+            getFormatters: () => new[] { formatter });
+        var context = CreateContext(
+            Guid.NewGuid(), 1,
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            host);
+
+        var output = await context.TryFormatAsync(
+            "value",
+            new[] { "image/svg+xml", "image/png", "text/plain" });
+
+        Assert.IsNull(output);
+    }
+
+    [TestMethod]
+    public async Task TryFormatAsync_EmptyAcceptableMimeTypesReturnsNull()
+    {
+        var formatter = new MimeFormatter("text/html");
+        var host = new StubExtensionHostContext(
+            () => Array.Empty<Verso.Abstractions.ILanguageKernel>(),
+            getFormatters: () => new[] { formatter });
+        var context = CreateContext(
+            Guid.NewGuid(), 1,
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            host);
+
+        var output = await context.TryFormatAsync("value", Array.Empty<string>());
+
+        Assert.IsNull(output);
+        Assert.AreEqual(0, formatter.ProbedMimeTypes.Count);
+    }
+
     private static ExecutionCtx CreateContext(
         Guid cellId, int executionCount,
         Func<CellOutput, Task> writeOutput,
@@ -132,5 +217,44 @@ public sealed class ExecutionContextTests
         public bool CanFormat(object value, Verso.Abstractions.IFormatterContext context) => value is string;
         public Task<CellOutput> FormatAsync(object value, Verso.Abstractions.IFormatterContext context)
             => Task.FromResult(CellOutput.Plain("specialized"));
+    }
+
+    private sealed class MimeFormatter : Verso.Abstractions.IDataFormatter
+    {
+        private readonly HashSet<string> _supportedMimeTypes;
+
+        public MimeFormatter(params string[] supportedMimeTypes)
+            : this(priority: 10, supportedMimeTypes)
+        {
+        }
+
+        public MimeFormatter(int priority, params string[] supportedMimeTypes)
+        {
+            Priority = priority;
+            _supportedMimeTypes = new HashSet<string>(supportedMimeTypes, StringComparer.Ordinal);
+        }
+
+        public string ExtensionId => $"com.test.execution-context.mime-formatter.{Priority}";
+        public string Name => "Execution Context MIME Formatter";
+        public string Version => "1.0.0";
+        public string? Author => null;
+        public string? Description => null;
+        public IReadOnlyList<Type> SupportedTypes { get; } = new[] { typeof(string) };
+        public int Priority { get; }
+        public bool IsFallback => false;
+        public List<string> ProbedMimeTypes { get; } = new();
+        public Task OnLoadedAsync(Verso.Abstractions.IExtensionHostContext context) => Task.CompletedTask;
+        public Task OnUnloadedAsync() => Task.CompletedTask;
+
+        public bool CanFormat(object value, Verso.Abstractions.IFormatterContext context)
+        {
+            ProbedMimeTypes.Add(context.MimeType);
+            return value is string && _supportedMimeTypes.Contains(context.MimeType);
+        }
+
+        public Task<CellOutput> FormatAsync(
+            object value,
+            Verso.Abstractions.IFormatterContext context)
+            => Task.FromResult(new CellOutput(context.MimeType, context.MimeType));
     }
 }

--- a/tests/Verso.Tests/Contexts/ExecutionContextTests.cs
+++ b/tests/Verso.Tests/Contexts/ExecutionContextTests.cs
@@ -117,8 +117,9 @@ public sealed class ExecutionContextTests
         Assert.IsNotNull(output);
         Assert.AreEqual("image/png", output.MimeType);
         CollectionAssert.AreEqual(
-            new[] { "image/svg+xml", "image/png" },
+            new[] { "image/svg+xml", "image/png", "text/plain" },
             formatter.ProbedMimeTypes);
+        Assert.AreEqual(1, formatter.FormatCallCount);
     }
 
     [TestMethod]
@@ -182,6 +183,21 @@ public sealed class ExecutionContextTests
         Assert.AreEqual(0, formatter.ProbedMimeTypes.Count);
     }
 
+    [TestMethod]
+    public async Task TryFormatAsync_CellOutputWithUnacceptableMimeTypeReturnsNull()
+    {
+        var context = CreateContext(
+            Guid.NewGuid(), 1,
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask);
+
+        var output = await context.TryFormatAsync(
+            CellOutput.Html("<strong>value</strong>"),
+            new[] { "image/png" });
+
+        Assert.IsNull(output);
+    }
+
     private static ExecutionCtx CreateContext(
         Guid cellId, int executionCount,
         Func<CellOutput, Task> writeOutput,
@@ -243,6 +259,7 @@ public sealed class ExecutionContextTests
         public int Priority { get; }
         public bool IsFallback => false;
         public List<string> ProbedMimeTypes { get; } = new();
+        public int FormatCallCount { get; private set; }
         public Task OnLoadedAsync(Verso.Abstractions.IExtensionHostContext context) => Task.CompletedTask;
         public Task OnUnloadedAsync() => Task.CompletedTask;
 
@@ -255,6 +272,9 @@ public sealed class ExecutionContextTests
         public Task<CellOutput> FormatAsync(
             object value,
             Verso.Abstractions.IFormatterContext context)
-            => Task.FromResult(new CellOutput(context.MimeType, context.MimeType));
+        {
+            FormatCallCount++;
+            return Task.FromResult(new CellOutput(context.MimeType, context.MimeType));
+        }
     }
 }

--- a/tests/Verso.Tests/Display/FormatterResolverTests.cs
+++ b/tests/Verso.Tests/Display/FormatterResolverTests.cs
@@ -56,21 +56,70 @@ public sealed class FormatterResolverTests
     }
 
     [TestMethod]
-    public async Task TryFormatAsync_ContinuesWhenOutputHasDifferentRequiredMimeType()
+    public async Task TryFormatAsync_ContinuesWhenFormatAsyncThrows()
     {
         var context = CreateContext(
-            new TestFormatter("wrong", priority: 20, mimeType: "text/html"),
-            new TestFormatter("svg", priority: 10, mimeType: "image/svg+xml"));
+            new TestFormatter("broken", priority: 20, throwFromFormat: true),
+            new TestFormatter("healthy", priority: 10));
+
+        var output = await FormatterResolver.TryFormatAsync("value", context, includeFallback: true);
+
+        Assert.IsNotNull(output);
+        Assert.AreEqual("healthy", output.Content);
+    }
+
+    [TestMethod]
+    public async Task TryFormatAsync_DoesNotRetryFormatterThatReturnsWrongMimeType()
+    {
+        var broken = new TestFormatter(
+            "wrong",
+            priority: 20,
+            mimeType: "text/html",
+            supportedMimeTypes: new[] { "image/svg+xml", "text/plain" });
+        var healthy = new TestFormatter(
+            "plain",
+            priority: 10,
+            mimeType: "text/plain",
+            supportedMimeTypes: new[] { "text/plain" });
+        var context = CreateContext(broken, healthy);
 
         var output = await FormatterResolver.TryFormatAsync(
             "value",
             context,
             includeFallback: true,
-            requiredMimeType: "image/svg+xml");
+            acceptableMimeTypes: new[] { "image/svg+xml", "text/plain" });
 
         Assert.IsNotNull(output);
-        Assert.AreEqual("image/svg+xml", output.MimeType);
-        Assert.AreEqual("svg", output.Content);
+        Assert.AreEqual("text/plain", output.MimeType);
+        Assert.AreEqual("plain", output.Content);
+        Assert.AreEqual(1, broken.FormatCallCount);
+        Assert.AreEqual(1, healthy.FormatCallCount);
+    }
+
+    [TestMethod]
+    public async Task TryFormatAsync_PropagatesRequestedCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var context = CreateContext(new TestFormatter("cancelled", throwCancellationFromFormat: true));
+        context.CancellationToken = cts.Token;
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+            () => FormatterResolver.TryFormatAsync("value", context, includeFallback: true));
+    }
+
+    [TestMethod]
+    public async Task TryFormatAsync_CellOutputDoesNotBypassRegisteredFormatters()
+    {
+        var context = CreateContext();
+
+        var output = await FormatterResolver.TryFormatAsync(
+            CellOutput.Html("<strong>value</strong>"),
+            context,
+            includeFallback: false,
+            acceptableMimeTypes: new[] { "image/png" });
+
+        Assert.IsNull(output);
     }
 
     private static StubFormatterContext CreateContext(params IDataFormatter[] formatters)
@@ -87,20 +136,31 @@ public sealed class FormatterResolverTests
     {
         private readonly string _content;
         private readonly bool _throwFromCanFormat;
+        private readonly bool _throwFromFormat;
+        private readonly bool _throwCancellationFromFormat;
         private readonly string _mimeType;
+        private readonly HashSet<string>? _supportedMimeTypes;
 
         public TestFormatter(
             string content,
             int priority = 10,
             bool isFallback = false,
             bool throwFromCanFormat = false,
-            string mimeType = "text/plain")
+            bool throwFromFormat = false,
+            bool throwCancellationFromFormat = false,
+            string mimeType = "text/plain",
+            IEnumerable<string>? supportedMimeTypes = null)
         {
             _content = content;
             Priority = priority;
             IsFallback = isFallback;
             _throwFromCanFormat = throwFromCanFormat;
+            _throwFromFormat = throwFromFormat;
+            _throwCancellationFromFormat = throwCancellationFromFormat;
             _mimeType = mimeType;
+            _supportedMimeTypes = supportedMimeTypes is null
+                ? null
+                : new HashSet<string>(supportedMimeTypes, StringComparer.OrdinalIgnoreCase);
         }
 
         public string ExtensionId => $"com.test.formatter.{_content}";
@@ -111,6 +171,7 @@ public sealed class FormatterResolverTests
         public IReadOnlyList<Type> SupportedTypes { get; } = new[] { typeof(string) };
         public int Priority { get; }
         public bool IsFallback { get; }
+        public int FormatCallCount { get; private set; }
         public Task OnLoadedAsync(IExtensionHostContext context) => Task.CompletedTask;
         public Task OnUnloadedAsync() => Task.CompletedTask;
 
@@ -119,10 +180,20 @@ public sealed class FormatterResolverTests
             if (_throwFromCanFormat)
                 throw new InvalidOperationException("probe failed");
 
-            return value is string;
+            return value is string &&
+                   (_supportedMimeTypes is null || _supportedMimeTypes.Contains(context.MimeType));
         }
 
         public Task<CellOutput> FormatAsync(object value, IFormatterContext context)
-            => Task.FromResult(new CellOutput(_mimeType, _content));
+        {
+            FormatCallCount++;
+
+            if (_throwCancellationFromFormat)
+                throw new OperationCanceledException(context.CancellationToken);
+            if (_throwFromFormat)
+                throw new InvalidOperationException("format failed");
+
+            return Task.FromResult(new CellOutput(_mimeType, _content));
+        }
     }
 }

--- a/tests/Verso.Tests/Display/FormatterResolverTests.cs
+++ b/tests/Verso.Tests/Display/FormatterResolverTests.cs
@@ -55,6 +55,24 @@ public sealed class FormatterResolverTests
         Assert.AreEqual("healthy", output.Content);
     }
 
+    [TestMethod]
+    public async Task TryFormatAsync_ContinuesWhenOutputHasDifferentRequiredMimeType()
+    {
+        var context = CreateContext(
+            new TestFormatter("wrong", priority: 20, mimeType: "text/html"),
+            new TestFormatter("svg", priority: 10, mimeType: "image/svg+xml"));
+
+        var output = await FormatterResolver.TryFormatAsync(
+            "value",
+            context,
+            includeFallback: true,
+            requiredMimeType: "image/svg+xml");
+
+        Assert.IsNotNull(output);
+        Assert.AreEqual("image/svg+xml", output.MimeType);
+        Assert.AreEqual("svg", output.Content);
+    }
+
     private static StubFormatterContext CreateContext(params IDataFormatter[] formatters)
     {
         return new StubFormatterContext
@@ -69,17 +87,20 @@ public sealed class FormatterResolverTests
     {
         private readonly string _content;
         private readonly bool _throwFromCanFormat;
+        private readonly string _mimeType;
 
         public TestFormatter(
             string content,
             int priority = 10,
             bool isFallback = false,
-            bool throwFromCanFormat = false)
+            bool throwFromCanFormat = false,
+            string mimeType = "text/plain")
         {
             _content = content;
             Priority = priority;
             IsFallback = isFallback;
             _throwFromCanFormat = throwFromCanFormat;
+            _mimeType = mimeType;
         }
 
         public string ExtensionId => $"com.test.formatter.{_content}";
@@ -102,6 +123,6 @@ public sealed class FormatterResolverTests
         }
 
         public Task<CellOutput> FormatAsync(object value, IFormatterContext context)
-            => Task.FromResult(CellOutput.Plain(_content));
+            => Task.FromResult(new CellOutput(_mimeType, _content));
     }
 }

--- a/tests/Verso.Tests/Display/FormatterResolverTests.cs
+++ b/tests/Verso.Tests/Display/FormatterResolverTests.cs
@@ -1,0 +1,107 @@
+using Verso.Abstractions;
+using Verso.Display;
+using Verso.Stubs;
+using Verso.Testing.Stubs;
+
+namespace Verso.Tests.Display;
+
+[TestClass]
+public sealed class FormatterResolverTests
+{
+    [TestMethod]
+    public async Task TryFormatAsync_HigherPriorityFormatterWins()
+    {
+        var context = CreateContext(
+            new TestFormatter("low", priority: 10),
+            new TestFormatter("high", priority: 20));
+
+        var output = await FormatterResolver.TryFormatAsync("value", context, includeFallback: true);
+
+        Assert.IsNotNull(output);
+        Assert.AreEqual("high", output.Content);
+    }
+
+    [TestMethod]
+    public async Task TryFormatAsync_ExcludesFallbackFormatterWhenRequested()
+    {
+        var context = CreateContext(new TestFormatter("fallback", isFallback: true));
+
+        var output = await FormatterResolver.TryFormatAsync("value", context, includeFallback: false);
+
+        Assert.IsNull(output);
+    }
+
+    [TestMethod]
+    public async Task TryFormatAsync_IncludesFallbackFormatterForExplicitDisplay()
+    {
+        var context = CreateContext(new TestFormatter("fallback", isFallback: true));
+
+        var output = await FormatterResolver.TryFormatAsync("value", context, includeFallback: true);
+
+        Assert.IsNotNull(output);
+        Assert.AreEqual("fallback", output.Content);
+    }
+
+    [TestMethod]
+    public async Task TryFormatAsync_ContinuesWhenCanFormatThrows()
+    {
+        var context = CreateContext(
+            new TestFormatter("broken", priority: 20, throwFromCanFormat: true),
+            new TestFormatter("healthy", priority: 10));
+
+        var output = await FormatterResolver.TryFormatAsync("value", context, includeFallback: true);
+
+        Assert.IsNotNull(output);
+        Assert.AreEqual("healthy", output.Content);
+    }
+
+    private static StubFormatterContext CreateContext(params IDataFormatter[] formatters)
+    {
+        return new StubFormatterContext
+        {
+            ExtensionHost = new StubExtensionHostContext(
+                () => Array.Empty<ILanguageKernel>(),
+                getFormatters: () => formatters)
+        };
+    }
+
+    private sealed class TestFormatter : IDataFormatter
+    {
+        private readonly string _content;
+        private readonly bool _throwFromCanFormat;
+
+        public TestFormatter(
+            string content,
+            int priority = 10,
+            bool isFallback = false,
+            bool throwFromCanFormat = false)
+        {
+            _content = content;
+            Priority = priority;
+            IsFallback = isFallback;
+            _throwFromCanFormat = throwFromCanFormat;
+        }
+
+        public string ExtensionId => $"com.test.formatter.{_content}";
+        public string Name => _content;
+        public string Version => "1.0.0";
+        public string? Author => null;
+        public string? Description => null;
+        public IReadOnlyList<Type> SupportedTypes { get; } = new[] { typeof(string) };
+        public int Priority { get; }
+        public bool IsFallback { get; }
+        public Task OnLoadedAsync(IExtensionHostContext context) => Task.CompletedTask;
+        public Task OnUnloadedAsync() => Task.CompletedTask;
+
+        public bool CanFormat(object value, IFormatterContext context)
+        {
+            if (_throwFromCanFormat)
+                throw new InvalidOperationException("probe failed");
+
+            return value is string;
+        }
+
+        public Task<CellOutput> FormatAsync(object value, IFormatterContext context)
+            => Task.FromResult(CellOutput.Plain(_content));
+    }
+}

--- a/tests/Verso.Tests/Extensions/CollectionFormatterTests.cs
+++ b/tests/Verso.Tests/Extensions/CollectionFormatterTests.cs
@@ -19,6 +19,10 @@ public sealed class CollectionFormatterTests
         => Assert.AreEqual(10, _formatter.Priority);
 
     [TestMethod]
+    public void IsFallback_IsTrue()
+        => Assert.IsTrue(_formatter.IsFallback);
+
+    [TestMethod]
     public void CanFormat_List_ReturnsTrue()
         => Assert.IsTrue(_formatter.CanFormat(new List<int> { 1, 2, 3 }, _context));
 

--- a/tests/Verso.Tests/Extensions/ObjectFormatterTests.cs
+++ b/tests/Verso.Tests/Extensions/ObjectFormatterTests.cs
@@ -49,6 +49,10 @@ public sealed class ObjectFormatterTests
     public void Priority_Is5()
         => Assert.AreEqual(5, _formatter.Priority);
 
+    [TestMethod]
+    public void IsFallback_IsTrue()
+        => Assert.IsTrue(_formatter.IsFallback);
+
     // --- CanFormat ---
 
     [TestMethod]

--- a/tests/Verso.Tests/Extensions/PrimitiveFormatterTests.cs
+++ b/tests/Verso.Tests/Extensions/PrimitiveFormatterTests.cs
@@ -8,7 +8,7 @@ namespace Verso.Tests.Extensions;
 public sealed class PrimitiveFormatterTests
 {
     private readonly PrimitiveFormatter _formatter = new();
-    private readonly StubFormatterContext _context = new();
+    private readonly StubFormatterContext _context = new() { MimeType = "text/plain" };
 
     [TestMethod]
     public void ExtensionId_IsCorrect()

--- a/tests/Verso.Tests/Extensions/PrimitiveFormatterTests.cs
+++ b/tests/Verso.Tests/Extensions/PrimitiveFormatterTests.cs
@@ -19,6 +19,10 @@ public sealed class PrimitiveFormatterTests
         => Assert.AreEqual(0, _formatter.Priority);
 
     [TestMethod]
+    public void IsFallback_IsTrue()
+        => Assert.IsTrue(_formatter.IsFallback);
+
+    [TestMethod]
     [DataRow(typeof(string))]
     [DataRow(typeof(int))]
     [DataRow(typeof(long))]


### PR DESCRIPTION
## Summary

- expose runtime value formatting through `IExecutionContext.TryFormatAsync`
- centralize formatter selection in `FormatterResolver`, including priority ordering, MIME hints, cancellation, and explicit fallback control
- route PowerShell pipeline objects through registered `IDataFormatter` extensions before using the kernel's native table/text rendering
- mark the built-in primitive, collection, and object formatters as fallbacks so specialized extensions get precedence
- document the expanded formatter contract and add coverage for resolution and PowerShell execution

## Why

Language kernels can return rich runtime objects, but extension formatters previously participated consistently only in explicit display calls. PowerShell therefore formatted results inside the kernel before a specialized extension could handle them.

This change gives kernels a shared formatting entry point while preserving their existing native output as the fallback. It enables extensions for domain-specific runtime types without adding those dependencies to the core or to individual kernels.

## Developer impact

`IDataFormatter.IsFallback` lets generic formatters opt out of implicit kernel result handling while remaining available to explicit `Display` calls. Existing formatter implementations remain source-compatible because the property has a default implementation.

## Validation

- `dotnet test Verso.sln --no-restore`
- formatter resolver tests cover priority, fallback inclusion, MIME hints, cancellation, and formatter failures
- PowerShell execution tests cover specialized formatting and native fallback behavior

The full solution test suite passes. Existing dependency-analysis and documentation warnings are unchanged.

## Follow-up

#94 uses this pipeline to render `Microsoft.Data.Analysis.DataFrame` values returned by PowerShell, providing a concrete end-to-end example of the extension point.
