### PR TITLE
Handle nested imports and prevent cycles in import flow

### DIFF
--- a/src/Verso/MagicCommands/ImportMagicCommand.cs
+++ b/src/Verso/MagicCommands/ImportMagicCommand.cs
@@ -68,6 +68,17 @@ public sealed class ImportMagicCommand : IMagicCommand
     /// </remarks>
     private static readonly AsyncLocal<ImmutableHashSet<string>?> InProgress = new();
 
+    /// <summary>
+    /// The directory holding the file currently being imported, so a path written inside it is
+    /// read the way the two files sit on disk.
+    /// </summary>
+    /// <remarks>
+    /// Carried beside the import rather than written into the directive text. A resolved path
+    /// can hold spaces and the directive would be read back by a parser that splits on them,
+    /// so rewriting the line loses every path under a directory whose name has a space in it.
+    /// </remarks>
+    private static readonly AsyncLocal<string?> ImportingDirectory = new();
+
     public async Task ExecuteAsync(string arguments, IMagicCommandContext context)
     {
         // Deliberately not asking for the rest of the cell to be skipped. An import is a prelude
@@ -87,7 +98,8 @@ public sealed class ImportMagicCommand : IMagicCommand
 
         try
         {
-            var resolvedPath = ResolvePath(path, context.NotebookMetadata.FilePath);
+            var resolvedPath = ResolveImportPath(
+                path, ImportingDirectory.Value, context.NotebookMetadata.FilePath);
 
             if (!File.Exists(resolvedPath))
             {
@@ -104,7 +116,12 @@ public sealed class ImportMagicCommand : IMagicCommand
             if (inProgress.Contains(resolvedPath))
                 return;
 
+            // Both are restored to what the frame above held rather than cleared, so a second
+            // import written under the first still reads from the file that wrote it.
+            var outerDirectory = ImportingDirectory.Value;
+
             InProgress.Value = inProgress.Add(resolvedPath);
+            ImportingDirectory.Value = Path.GetDirectoryName(resolvedPath);
 
             try
             {
@@ -136,6 +153,7 @@ public sealed class ImportMagicCommand : IMagicCommand
             finally
             {
                 InProgress.Value = inProgress;
+                ImportingDirectory.Value = outerDirectory;
             }
         }
         catch (OperationCanceledException)
@@ -281,14 +299,12 @@ public sealed class ImportMagicCommand : IMagicCommand
         var importLines = new List<string>();
         var otherMagicLines = new List<string>();
 
-        var importingDirectory = Path.GetDirectoryName(resolvedPath)!;
-
         foreach (var line in magicLines)
         {
             if (IsPackageDirective(line))
                 packageLines.Add(line);
             else if (line.StartsWith("#!import", StringComparison.OrdinalIgnoreCase))
-                importLines.Add(RebaseImportLine(line, importingDirectory));
+                importLines.Add(line);
             else
                 otherMagicLines.Add(line);
         }
@@ -349,35 +365,39 @@ public sealed class ImportMagicCommand : IMagicCommand
     }
 
     /// <summary>
-    /// Rewrites the path in a nested <c>#!import</c> so it is read relative to the file that
-    /// wrote the directive rather than to the notebook.
+    /// Resolves the path an <c>#!import</c> names, preferring the file beside the one that wrote
+    /// the directive and falling back to the notebook.
     /// </summary>
     /// <remarks>
-    /// A helper that sits beside another helper names it the way it sits on disk, which is what
-    /// somebody editing that file expects and what makes a folder of helpers movable. Only
-    /// rewritten where the sibling is really there, so a path already written relative to the
-    /// notebook keeps working.
+    /// <para>
+    /// A helper sitting beside another helper names it the way the two sit on disk, which is what
+    /// somebody editing that file expects and what keeps a folder of helpers movable. The
+    /// neighbour only wins where it is really there, so a path written relative to the notebook
+    /// goes on meaning what it did.
+    /// </para>
+    /// <para>
+    /// Kept apart from <see cref="ResolvePath"/>, which other commands share and which answers
+    /// for the notebook's directory alone. Widening that one would quietly move where every
+    /// command resolves from, including a <c>#!extension</c> naming a local assembly.
+    /// </para>
     /// </remarks>
-    /// <param name="line">The <c>#!import</c> line as the imported file wrote it.</param>
-    /// <param name="importingFileDirectory">The directory holding the file that wrote it.</param>
-    internal static string RebaseImportLine(string line, string importingFileDirectory)
+    /// <param name="path">The path as the directive wrote it.</param>
+    /// <param name="importingDirectory">
+    /// The directory holding the file being imported, or <c>null</c> at the top level.
+    /// </param>
+    /// <param name="notebookFilePath">The notebook's own path, used when nothing sits beside.</param>
+    internal static string ResolveImportPath(
+        string path, string? importingDirectory, string? notebookFilePath)
     {
-        const string directive = "#!import";
+        if (!string.IsNullOrEmpty(importingDirectory) && !string.IsNullOrEmpty(path)
+            && !Path.IsPathRooted(path))
+        {
+            var beside = Path.GetFullPath(Path.Combine(importingDirectory, path));
+            if (File.Exists(beside))
+                return beside;
+        }
 
-        var arguments = line.Length > directive.Length ? line[directive.Length..] : "";
-        var (path, _, _) = ParseArguments(arguments);
-
-        if (string.IsNullOrEmpty(path) || Path.IsPathRooted(path))
-            return line;
-
-        var sibling = Path.GetFullPath(Path.Combine(importingFileDirectory, path));
-        if (!File.Exists(sibling))
-            return line;
-
-        var start = line.IndexOf(path, directive.Length, StringComparison.Ordinal);
-        return start < 0
-            ? line
-            : string.Concat(line.AsSpan(0, start), sibling, line.AsSpan(start + path.Length));
+        return ResolvePath(path, notebookFilePath);
     }
 
     /// <summary>
@@ -575,6 +595,11 @@ public sealed class ImportMagicCommand : IMagicCommand
     /// Resolves a file path relative to the notebook's directory, or the current working directory
     /// if no notebook path is available.
     /// </summary>
+    /// <remarks>
+    /// Shared with other commands that promise their users the notebook's directory, so it answers
+    /// for that and nothing else. An import prefers whatever sits beside the importing file, and
+    /// asks for that through <see cref="ResolveImportPath"/> instead of widening this.
+    /// </remarks>
     internal static string ResolvePath(string path, string? notebookFilePath)
     {
         if (Path.IsPathRooted(path))

--- a/src/Verso/MagicCommands/ImportMagicCommand.cs
+++ b/src/Verso/MagicCommands/ImportMagicCommand.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using Verso.Abstractions;
 using Verso.Extensions;
@@ -22,10 +23,14 @@ namespace Verso.MagicCommands;
 /// <list type="bullet">
 /// <item>Notebook files (<c>.verso</c>, <c>.ipynb</c>, <c>.dib</c>) -- deserialized and executed cell-by-cell.</item>
 /// <item>Source files (<c>.cs</c>, <c>.csx</c>, <c>.fs</c>, <c>.fsx</c>, <c>.py</c>, <c>.ps1</c>, <c>.psm1</c>,
-/// <c>.js</c>, <c>.mjs</c>, <c>.ts</c>, <c>.tsx</c>, <c>.sql</c>, etc.) -- magic commands are extracted,
-/// sorted by priority (NuGet/pip first, then imports, then remaining directives), and the file is executed
-/// in the kernel that owns the file extension.</item>
+/// <c>.js</c>, <c>.mjs</c>, <c>.ts</c>, <c>.tsx</c>, <c>.sql</c>, etc.) -- magic commands are extracted and run
+/// in priority order (NuGet/pip first, then imports, then remaining directives), and the file's own code is
+/// then run in the kernel that owns the file extension.</item>
 /// </list>
+/// </para>
+/// <para>
+/// An imported file may itself import another, and names it the way the two sit on disk: a path in a
+/// nested <c>#!import</c> is read relative to the file that wrote it, falling back to the notebook.
 /// </para>
 /// </summary>
 [VersoExtension]
@@ -53,9 +58,22 @@ public sealed class ImportMagicCommand : IMagicCommand
     public Task OnLoadedAsync(IExtensionHostContext context) => Task.CompletedTask;
     public Task OnUnloadedAsync() => Task.CompletedTask;
 
+    /// <summary>
+    /// The files part way through being imported on the current path through the notebook, so
+    /// that two that name each other do not import one another forever.
+    /// </summary>
+    /// <remarks>
+    /// Held per execution flow rather than per instance: one command object serves every
+    /// notebook open in a host, and a nested import runs inside the flow of the one above it.
+    /// </remarks>
+    private static readonly AsyncLocal<ImmutableHashSet<string>?> InProgress = new();
+
     public async Task ExecuteAsync(string arguments, IMagicCommandContext context)
     {
-        context.SuppressExecution = true;
+        // Deliberately not asking for the rest of the cell to be skipped. An import is a prelude
+        // to whatever is written under it, not a setup-only cell like a connection or a package
+        // install, so code following the directive still has to run. A cell holding nothing but
+        // the directive is already finished by the caller and never reaches a kernel.
 
         if (string.IsNullOrWhiteSpace(arguments))
         {
@@ -79,30 +97,46 @@ public sealed class ImportMagicCommand : IMagicCommand
                 return;
             }
 
-            var serializer = context.ExtensionHost.GetSerializers()
-                .FirstOrDefault(s => s.CanImport(resolvedPath));
-
-            if (serializer is not null)
-            {
-                await ImportNotebookAsync(resolvedPath, serializer, paramOverrides, showOutput, context)
-                    .ConfigureAwait(false);
+            // A file already part way through being imported is not imported again, or two that
+            // name each other never finish. Passing over it quietly is what an include guard
+            // does: whatever it defines arrives when the import already under way gets there.
+            var inProgress = InProgress.Value ?? ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase);
+            if (inProgress.Contains(resolvedPath))
                 return;
-            }
 
-            // No serializer -- try to match the file extension to a registered kernel.
-            var extension = Path.GetExtension(resolvedPath);
-            var kernel = FindKernelByFileExtension(extension, context.ExtensionHost);
+            InProgress.Value = inProgress.Add(resolvedPath);
 
-            if (kernel is not null)
+            try
             {
-                await ImportSourceFileAsync(resolvedPath, kernel, showOutput, context).ConfigureAwait(false);
-                return;
-            }
+                var serializer = context.ExtensionHost.GetSerializers()
+                    .FirstOrDefault(s => s.CanImport(resolvedPath));
 
-            var supportedExtensions = GetSupportedExtensions(context.ExtensionHost);
-            await context.WriteOutputAsync(CellOutput.Error(
-                string.Format(Strings.Magic_Import_NoSerializer,
-                    Path.GetFileName(resolvedPath), supportedExtensions))).ConfigureAwait(false);
+                if (serializer is not null)
+                {
+                    await ImportNotebookAsync(resolvedPath, serializer, paramOverrides, showOutput, context)
+                        .ConfigureAwait(false);
+                    return;
+                }
+
+                // No serializer -- try to match the file extension to a registered kernel.
+                var extension = Path.GetExtension(resolvedPath);
+                var kernel = FindKernelByFileExtension(extension, context.ExtensionHost);
+
+                if (kernel is not null)
+                {
+                    await ImportSourceFileAsync(resolvedPath, kernel, showOutput, context).ConfigureAwait(false);
+                    return;
+                }
+
+                var supportedExtensions = GetSupportedExtensions(context.ExtensionHost);
+                await context.WriteOutputAsync(CellOutput.Error(
+                    string.Format(Strings.Magic_Import_NoSerializer,
+                        Path.GetFileName(resolvedPath), supportedExtensions))).ConfigureAwait(false);
+            }
+            finally
+            {
+                InProgress.Value = inProgress;
+            }
         }
         catch (OperationCanceledException)
         {
@@ -216,10 +250,18 @@ public sealed class ImportMagicCommand : IMagicCommand
     }
 
     /// <summary>
-    /// Imports a source file by extracting magic commands, sorting them by priority
-    /// (package directives first, then imports, then other directives), and executing the
-    /// reassembled content in the kernel that owns the file extension.
+    /// Imports a source file by extracting its magic commands, running them in priority order
+    /// (package directives first, then imports, then other directives), and then running the
+    /// file's own code in the kernel that owns the file extension.
     /// </summary>
+    /// <remarks>
+    /// Each directive is run on its own, and the code after them separately again, rather than
+    /// the whole file being handed over as one piece. A directive is only acted on where it
+    /// leads what it was given, so sent together the first would run and the rest would reach
+    /// the kernel as code and be ignored. Running the code last is what lets a file both bring
+    /// something in and declare something, because a directive that asks for the rest of its own
+    /// submission to be skipped can no longer take the file's contents with it.
+    /// </remarks>
     private async Task ImportSourceFileAsync(
         string resolvedPath,
         ILanguageKernel kernel,
@@ -239,38 +281,29 @@ public sealed class ImportMagicCommand : IMagicCommand
         var importLines = new List<string>();
         var otherMagicLines = new List<string>();
 
+        var importingDirectory = Path.GetDirectoryName(resolvedPath)!;
+
         foreach (var line in magicLines)
         {
             if (IsPackageDirective(line))
                 packageLines.Add(line);
             else if (line.StartsWith("#!import", StringComparison.OrdinalIgnoreCase))
-                importLines.Add(line);
+                importLines.Add(RebaseImportLine(line, importingDirectory));
             else
                 otherMagicLines.Add(line);
         }
 
-        // Reassemble: magic commands (priority-ordered) followed by remaining code
-        var reassembled = new List<string>();
-        reassembled.AddRange(packageLines);
-        reassembled.AddRange(importLines);
-        reassembled.AddRange(otherMagicLines);
-        reassembled.AddRange(codeLines);
-
-        var code = string.Join(Environment.NewLine, reassembled);
         var failed = false;
 
+        foreach (var directive in packageLines.Concat(importLines).Concat(otherMagicLines))
+        {
+            failed |= await RunAsync(directive, kernel, showOutput, context).ConfigureAwait(false);
+        }
+
+        var code = string.Join(Environment.NewLine, codeLines);
         if (!string.IsNullOrWhiteSpace(code))
         {
-            // Always capture outputs so failures are visible. Without --show-output only
-            // error outputs are surfaced; successful execution stays silent.
-            var outputs = await context.Notebook.ExecuteCodeCaptureOutputsAsync(
-                code, kernel.LanguageId, context.CancellationToken).ConfigureAwait(false);
-            foreach (var output in outputs)
-            {
-                failed |= output.IsError;
-                if (showOutput || output.IsError)
-                    await context.WriteOutputAsync(output).ConfigureAwait(false);
-            }
+            failed |= await RunAsync(code, kernel, showOutput, context).ConfigureAwait(false);
         }
 
         var fileName = Path.GetFileName(resolvedPath);
@@ -285,6 +318,66 @@ public sealed class ImportMagicCommand : IMagicCommand
 
         await context.WriteOutputAsync(new CellOutput("text/plain", summary, IsError: failed))
             .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Runs one piece of an imported source file and surfaces whatever it produced.
+    /// </summary>
+    /// <remarks>
+    /// Outputs are always captured so a failure inside an imported file is visible. Without
+    /// <c>--show-output</c> only errors are surfaced and successful work stays silent.
+    /// </remarks>
+    /// <returns><c>true</c> if anything it produced was an error.</returns>
+    private static async Task<bool> RunAsync(
+        string source,
+        ILanguageKernel kernel,
+        bool showOutput,
+        IMagicCommandContext context)
+    {
+        var outputs = await context.Notebook.ExecuteCodeCaptureOutputsAsync(
+            source, kernel.LanguageId, context.CancellationToken).ConfigureAwait(false);
+
+        var failed = false;
+        foreach (var output in outputs)
+        {
+            failed |= output.IsError;
+            if (showOutput || output.IsError)
+                await context.WriteOutputAsync(output).ConfigureAwait(false);
+        }
+
+        return failed;
+    }
+
+    /// <summary>
+    /// Rewrites the path in a nested <c>#!import</c> so it is read relative to the file that
+    /// wrote the directive rather than to the notebook.
+    /// </summary>
+    /// <remarks>
+    /// A helper that sits beside another helper names it the way it sits on disk, which is what
+    /// somebody editing that file expects and what makes a folder of helpers movable. Only
+    /// rewritten where the sibling is really there, so a path already written relative to the
+    /// notebook keeps working.
+    /// </remarks>
+    /// <param name="line">The <c>#!import</c> line as the imported file wrote it.</param>
+    /// <param name="importingFileDirectory">The directory holding the file that wrote it.</param>
+    internal static string RebaseImportLine(string line, string importingFileDirectory)
+    {
+        const string directive = "#!import";
+
+        var arguments = line.Length > directive.Length ? line[directive.Length..] : "";
+        var (path, _, _) = ParseArguments(arguments);
+
+        if (string.IsNullOrEmpty(path) || Path.IsPathRooted(path))
+            return line;
+
+        var sibling = Path.GetFullPath(Path.Combine(importingFileDirectory, path));
+        if (!File.Exists(sibling))
+            return line;
+
+        var start = line.IndexOf(path, directive.Length, StringComparison.Ordinal);
+        return start < 0
+            ? line
+            : string.Concat(line.AsSpan(0, start), sibling, line.AsSpan(start + path.Length));
     }
 
     /// <summary>

--- a/tests/Verso.Tests/MagicCommands/ImportMagicCommandTests.cs
+++ b/tests/Verso.Tests/MagicCommands/ImportMagicCommandTests.cs
@@ -33,28 +33,28 @@ public sealed class ImportMagicCommandTests
     // --- Argument validation ---
 
     [TestMethod]
-    public async Task EmptyArguments_SuppressesAndWritesError()
+    public async Task EmptyArguments_WritesError()
     {
         var command = new ImportMagicCommand();
         var context = new StubMagicCommandContext();
 
         await command.ExecuteAsync("", context);
 
-        Assert.IsTrue(context.SuppressExecution);
+        Assert.IsFalse(context.SuppressExecution);
         Assert.AreEqual(1, context.WrittenOutputs.Count);
         Assert.IsTrue(context.WrittenOutputs[0].IsError);
         Assert.IsTrue(context.WrittenOutputs[0].Content.Contains("#!import"));
     }
 
     [TestMethod]
-    public async Task WhitespaceArguments_SuppressesAndWritesError()
+    public async Task WhitespaceArguments_WritesError()
     {
         var command = new ImportMagicCommand();
         var context = new StubMagicCommandContext();
 
         await command.ExecuteAsync("   ", context);
 
-        Assert.IsTrue(context.SuppressExecution);
+        Assert.IsFalse(context.SuppressExecution);
         Assert.IsTrue(context.WrittenOutputs[0].IsError);
     }
 
@@ -68,7 +68,7 @@ public sealed class ImportMagicCommandTests
 
         await command.ExecuteAsync("/nonexistent/path/notebook.verso", context);
 
-        Assert.IsTrue(context.SuppressExecution);
+        Assert.IsFalse(context.SuppressExecution);
         Assert.AreEqual(1, context.WrittenOutputs.Count);
         Assert.IsTrue(context.WrittenOutputs[0].IsError);
         Assert.IsTrue(context.WrittenOutputs[0].Content.Contains("File not found"));
@@ -90,7 +90,7 @@ public sealed class ImportMagicCommandTests
 
             await command.ExecuteAsync(tempFile, context);
 
-            Assert.IsTrue(context.SuppressExecution);
+            Assert.IsFalse(context.SuppressExecution);
             Assert.AreEqual(1, context.WrittenOutputs.Count);
             Assert.IsTrue(context.WrittenOutputs[0].IsError);
             Assert.IsTrue(context.WrittenOutputs[0].Content.Contains("No serializer or kernel"));
@@ -127,7 +127,7 @@ public sealed class ImportMagicCommandTests
 
             await command.ExecuteAsync(tempFile, context);
 
-            Assert.IsTrue(context.SuppressExecution);
+            Assert.IsFalse(context.SuppressExecution);
             Assert.AreEqual(2, notebookOps.ExecutedCodeCalls.Count);
             Assert.AreEqual("var x = 1;", notebookOps.ExecutedCodeCalls[0].Code);
             Assert.AreEqual("csharp", notebookOps.ExecutedCodeCalls[0].Language);
@@ -746,7 +746,7 @@ public sealed class ImportMagicCommandTests
 
             await command.ExecuteAsync(tempFile, context);
 
-            Assert.IsTrue(context.SuppressExecution);
+            Assert.IsFalse(context.SuppressExecution);
             Assert.AreEqual(1, notebookOps.ExecutedCodeCalls.Count);
             Assert.AreEqual("csharp", notebookOps.ExecutedCodeCalls[0].Language);
             Assert.IsTrue(notebookOps.ExecutedCodeCalls[0].Code.Contains("var x = 1;"));
@@ -773,7 +773,7 @@ public sealed class ImportMagicCommandTests
 
             await command.ExecuteAsync(tempFile, context);
 
-            Assert.IsTrue(context.SuppressExecution);
+            Assert.IsFalse(context.SuppressExecution);
             Assert.AreEqual(1, notebookOps.ExecutedCodeCalls.Count);
             Assert.AreEqual("python", notebookOps.ExecutedCodeCalls[0].Language);
         }
@@ -798,7 +798,7 @@ public sealed class ImportMagicCommandTests
 
             await command.ExecuteAsync(tempFile, context);
 
-            Assert.IsTrue(context.SuppressExecution);
+            Assert.IsFalse(context.SuppressExecution);
             Assert.AreEqual(1, notebookOps.ExecutedCodeCalls.Count);
             Assert.AreEqual("javascript", notebookOps.ExecutedCodeCalls[0].Language);
         }
@@ -824,19 +824,22 @@ public sealed class ImportMagicCommandTests
 
             await command.ExecuteAsync(tempFile, context);
 
-            Assert.AreEqual(1, notebookOps.ExecutedCodeCalls.Count);
-            var executedCode = notebookOps.ExecutedCodeCalls[0].Code;
+            // Each directive is submitted on its own, and the file's own code last, so that a
+            // directive behind another is still acted on rather than reaching the kernel as code.
+            var submissions = notebookOps.ExecutedCodeCalls.Select(c => c.Code).ToList();
+            Assert.AreEqual(3, submissions.Count);
 
-            // NuGet should come before import
-            var nugetPos = executedCode.IndexOf("#r \"nuget:", StringComparison.Ordinal);
-            var importPos = executedCode.IndexOf("#!import", StringComparison.Ordinal);
-            Assert.IsTrue(nugetPos >= 0, "NuGet directive should be present");
-            Assert.IsTrue(importPos >= 0, "Import directive should be present");
-            Assert.IsTrue(nugetPos < importPos, "NuGet should appear before import");
+            var nugetIndex = submissions.FindIndex(s => s.StartsWith("#r \"nuget:", StringComparison.Ordinal));
+            var importIndex = submissions.FindIndex(s => s.StartsWith("#!import", StringComparison.Ordinal));
+            Assert.IsTrue(nugetIndex >= 0, "NuGet directive should be submitted");
+            Assert.IsTrue(importIndex >= 0, "Import directive should be submitted");
+            Assert.IsTrue(nugetIndex < importIndex, "NuGet should be submitted before import");
 
-            // Code should come after directives
-            var codePos = executedCode.IndexOf("using Microsoft", StringComparison.Ordinal);
-            Assert.IsTrue(codePos > importPos, "Code should appear after directives");
+            // The code follows the directives, and carries none of them.
+            var code = submissions[^1];
+            Assert.IsTrue(code.Contains("using Microsoft", StringComparison.Ordinal));
+            Assert.IsFalse(code.Contains("#!import", StringComparison.Ordinal));
+            Assert.IsFalse(code.Contains("#r \"nuget:", StringComparison.Ordinal));
 
             // Summary should mention extracted directives
             Assert.IsTrue(context.WrittenOutputs.Any(o => o.Content.Contains("2 directives extracted")));
@@ -863,10 +866,12 @@ public sealed class ImportMagicCommandTests
 
             await command.ExecuteAsync(tempFile, context);
 
-            var executedCode = notebookOps.ExecutedCodeCalls[0].Code;
-            var pipPos = executedCode.IndexOf("#!pip", StringComparison.Ordinal);
-            var importPos = executedCode.IndexOf("#!import", StringComparison.Ordinal);
-            Assert.IsTrue(pipPos < importPos, "pip should appear before import");
+            var submissions = notebookOps.ExecutedCodeCalls.Select(c => c.Code).ToList();
+            var pipIndex = submissions.FindIndex(s => s.StartsWith("#!pip", StringComparison.Ordinal));
+            var importIndex = submissions.FindIndex(s => s.StartsWith("#!import", StringComparison.Ordinal));
+            Assert.IsTrue(pipIndex >= 0, "pip directive should be submitted");
+            Assert.IsTrue(importIndex >= 0, "Import directive should be submitted");
+            Assert.IsTrue(pipIndex < importIndex, "pip should be submitted before import");
         }
         finally
         {
@@ -895,6 +900,129 @@ public sealed class ImportMagicCommandTests
         finally
         {
             File.Delete(tempFile);
+        }
+    }
+
+    // --- Nested imports ---
+
+    [TestMethod]
+    public async Task ImportSourceFile_NestedImportBehindPackageDirective_IsStillRun()
+    {
+        var command = new ImportMagicCommand();
+        var notebookOps = new StubNotebookOperations();
+        var csharpKernel = new FakeLanguageKernel("csharp", "C#", fileExtensions: new[] { ".cs" });
+        var context = CreateContextWithSerializer(notebookOps, kernels: new[] { csharpKernel });
+
+        var directory = Directory.CreateTempSubdirectory("verso_import_");
+        try
+        {
+            var nested = Path.Combine(directory.FullName, "Keys.cs");
+            await File.WriteAllTextAsync(nested, "public static class Keys { }");
+
+            var importer = Path.Combine(directory.FullName, "Fetcher.cs");
+            await File.WriteAllTextAsync(importer,
+                "#!import Keys.cs\n#r \"nuget: Newtonsoft.Json, 13.0.3\"\npublic static class Fetcher { }");
+
+            await command.ExecuteAsync(importer, context);
+
+            // The package directive sorts ahead of the import, which is what used to hide the
+            // import from the reader of the reassembled content.
+            var submissions = notebookOps.ExecutedCodeCalls.Select(c => c.Code).ToList();
+            Assert.IsTrue(submissions.Any(s => s.StartsWith("#r \"nuget:", StringComparison.Ordinal)));
+            Assert.IsTrue(
+                submissions.Any(s => s.StartsWith("#!import", StringComparison.Ordinal)),
+                "The nested import must be submitted, not swallowed behind the package directive.");
+            Assert.IsTrue(
+                submissions.Any(s => s.Contains("public static class Fetcher", StringComparison.Ordinal)),
+                "The file's own code must run after its directives.");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void RebaseImportLine_ResolvesAgainstTheImportingFile()
+    {
+        var directory = Directory.CreateTempSubdirectory("verso_import_");
+        try
+        {
+            var sibling = Path.Combine(directory.FullName, "Keys.cs");
+            File.WriteAllText(sibling, "public static class Keys { }");
+
+            var rebased = ImportMagicCommand.RebaseImportLine("#!import Keys.cs", directory.FullName);
+
+            Assert.AreEqual($"#!import {sibling}", rebased);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void RebaseImportLine_LeavesPathAloneWhenNoSiblingExists()
+    {
+        var directory = Directory.CreateTempSubdirectory("verso_import_");
+        try
+        {
+            // Nothing beside the importing file answers to this, so it stays as written and is
+            // resolved against the notebook, which is what it meant before nesting was fixed.
+            var rebased = ImportMagicCommand.RebaseImportLine("#!import helpers/Keys.cs", directory.FullName);
+
+            Assert.AreEqual("#!import helpers/Keys.cs", rebased);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void RebaseImportLine_KeepsFlagsAfterThePath()
+    {
+        var directory = Directory.CreateTempSubdirectory("verso_import_");
+        try
+        {
+            var sibling = Path.Combine(directory.FullName, "Setup.verso");
+            File.WriteAllText(sibling, "{}");
+
+            var rebased = ImportMagicCommand.RebaseImportLine(
+                "#!import Setup.verso --show-output", directory.FullName);
+
+            Assert.AreEqual($"#!import {sibling} --show-output", rebased);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ImportSourceFile_CircularImport_Terminates()
+    {
+        var command = new ImportMagicCommand();
+        var notebookOps = new StubNotebookOperations();
+        var csharpKernel = new FakeLanguageKernel("csharp", "C#", fileExtensions: new[] { ".cs" });
+        var context = CreateContextWithSerializer(notebookOps, kernels: new[] { csharpKernel });
+
+        // The stub does not run the directives it is handed, so drive the cycle directly:
+        // importing the same file from inside itself must be passed over rather than recur.
+        var directory = Directory.CreateTempSubdirectory("verso_import_");
+        try
+        {
+            var first = Path.Combine(directory.FullName, "First.cs");
+            await File.WriteAllTextAsync(first, "#!import First.cs\npublic static class First { }");
+
+            await command.ExecuteAsync(first, context);
+
+            Assert.IsTrue(context.WrittenOutputs.Any(o => o.Content.Contains("Imported")));
+            Assert.IsFalse(context.WrittenOutputs.Any(o => o.IsError));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
         }
     }
 

--- a/tests/Verso.Tests/MagicCommands/ImportMagicCommandTests.cs
+++ b/tests/Verso.Tests/MagicCommands/ImportMagicCommandTests.cs
@@ -943,17 +943,18 @@ public sealed class ImportMagicCommandTests
     }
 
     [TestMethod]
-    public void RebaseImportLine_ResolvesAgainstTheImportingFile()
+    public void ResolveImportPath_PrefersTheFileBesideTheImporter()
     {
         var directory = Directory.CreateTempSubdirectory("verso_import_");
         try
         {
-            var sibling = Path.Combine(directory.FullName, "Keys.cs");
-            File.WriteAllText(sibling, "public static class Keys { }");
+            var beside = Path.Combine(directory.FullName, "Keys.cs");
+            File.WriteAllText(beside, "public static class Keys { }");
 
-            var rebased = ImportMagicCommand.RebaseImportLine("#!import Keys.cs", directory.FullName);
+            var resolved = ImportMagicCommand.ResolveImportPath(
+                "Keys.cs", directory.FullName, "/somewhere/else/notebook.verso");
 
-            Assert.AreEqual($"#!import {sibling}", rebased);
+            Assert.AreEqual(beside, resolved);
         }
         finally
         {
@@ -962,16 +963,67 @@ public sealed class ImportMagicCommandTests
     }
 
     [TestMethod]
-    public void RebaseImportLine_LeavesPathAloneWhenNoSiblingExists()
+    public void ResolveImportPath_UnderADirectoryWhoseNameHasASpace()
+    {
+        // The path a nested import resolves to is never written back into the directive, so a
+        // space in it cannot be read as the end of the path. Rewriting the line lost everything
+        // from the space onward.
+        var root = Directory.CreateTempSubdirectory("verso_import_");
+        try
+        {
+            var spaced = Directory.CreateDirectory(Path.Combine(root.FullName, "my helpers"));
+            var beside = Path.Combine(spaced.FullName, "Keys.cs");
+            File.WriteAllText(beside, "public static class Keys { }");
+
+            var resolved = ImportMagicCommand.ResolveImportPath(
+                "Keys.cs", spaced.FullName, Path.Combine(root.FullName, "notebook.verso"));
+
+            Assert.AreEqual(beside, resolved);
+            Assert.IsTrue(File.Exists(resolved), "The resolved path must still name a real file.");
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ResolveImportPath_FallsBackToTheNotebookWhenNothingSitsBeside()
+    {
+        var root = Directory.CreateTempSubdirectory("verso_import_");
+        try
+        {
+            // The importing file has no shared/Common.cs beside it, but the notebook does, so
+            // a path written against the notebook goes on meaning what it did.
+            var importer = Directory.CreateDirectory(Path.Combine(root.FullName, "helpers"));
+            var shared = Directory.CreateDirectory(Path.Combine(root.FullName, "shared"));
+            var target = Path.Combine(shared.FullName, "Common.cs");
+            File.WriteAllText(target, "public static class Common { }");
+
+            var resolved = ImportMagicCommand.ResolveImportPath(
+                "shared/Common.cs", importer.FullName, Path.Combine(root.FullName, "notebook.verso"));
+
+            Assert.AreEqual(target, resolved);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ResolveImportPath_RootedPathIsTakenAsWritten()
     {
         var directory = Directory.CreateTempSubdirectory("verso_import_");
         try
         {
-            // Nothing beside the importing file answers to this, so it stays as written and is
-            // resolved against the notebook, which is what it meant before nesting was fixed.
-            var rebased = ImportMagicCommand.RebaseImportLine("#!import helpers/Keys.cs", directory.FullName);
+            var rooted = Path.Combine(directory.FullName, "Absolute.cs");
+            File.WriteAllText(rooted, "public static class Absolute { }");
 
-            Assert.AreEqual("#!import helpers/Keys.cs", rebased);
+            var resolved = ImportMagicCommand.ResolveImportPath(
+                rooted, "/some/other/place", "/somewhere/else/notebook.verso");
+
+            Assert.AreEqual(rooted, resolved);
         }
         finally
         {
@@ -980,23 +1032,15 @@ public sealed class ImportMagicCommandTests
     }
 
     [TestMethod]
-    public void RebaseImportLine_KeepsFlagsAfterThePath()
+    public void ResolveImportPath_TopLevelImportResolvesAgainstTheNotebook()
     {
-        var directory = Directory.CreateTempSubdirectory("verso_import_");
-        try
-        {
-            var sibling = Path.Combine(directory.FullName, "Setup.verso");
-            File.WriteAllText(sibling, "{}");
+        // Nothing is being imported yet, so there is no importing directory and the notebook
+        // answers, exactly as it did before nesting was addressed.
+        var resolved = ImportMagicCommand.ResolveImportPath(
+            "helpers/setup.verso", null, "/notebooks/main.verso");
 
-            var rebased = ImportMagicCommand.RebaseImportLine(
-                "#!import Setup.verso --show-output", directory.FullName);
-
-            Assert.AreEqual($"#!import {sibling} --show-output", rebased);
-        }
-        finally
-        {
-            directory.Delete(recursive: true);
-        }
+        Assert.AreEqual(
+            Path.GetFullPath(Path.Combine("/notebooks", "helpers/setup.verso")), resolved);
     }
 
     [TestMethod]

--- a/tests/Verso.Tests/MagicCommands/NestedImportIntegrationTests.cs
+++ b/tests/Verso.Tests/MagicCommands/NestedImportIntegrationTests.cs
@@ -1,0 +1,220 @@
+using Verso.Abstractions;
+using Verso.Extensions;
+using Verso.Kernels;
+
+namespace Verso.Tests.MagicCommands;
+
+/// <summary>
+/// Drives real files through the real pipeline, so that an import written inside an imported
+/// file is actually read back and acted on.
+/// </summary>
+/// <remarks>
+/// The stub notebook operations used elsewhere record the code they are handed and return, which
+/// means a nested directive is never re-read and nothing about nesting is under test. These go
+/// through <see cref="Verso.Scaffold"/> with the built-in commands loaded and a real kernel, which
+/// is the only arrangement where a nested import resolves a path at all.
+/// </remarks>
+[TestClass]
+public sealed class NestedImportIntegrationTests
+{
+    private DirectoryInfo _root = null!;
+
+    [TestInitialize]
+    public void Setup() => _root = Directory.CreateTempSubdirectory("verso_nested_import_");
+
+    [TestCleanup]
+    public void Cleanup() => _root.Delete(recursive: true);
+
+    /// <summary>
+    /// Builds a notebook at <paramref name="notebookPath"/> whose cells are run in order, and
+    /// returns what the last one produced.
+    /// </summary>
+    private static async Task<IReadOnlyList<CellOutput>> RunAsync(
+        string notebookPath, params string[] cellSources)
+    {
+        await using var host = new ExtensionHost();
+        await host.LoadBuiltInExtensionsAsync();
+
+        var notebook = new NotebookModel { DefaultKernelId = "csharp" };
+        await using var scaffold = new Verso.Scaffold(notebook, host, notebookPath);
+        scaffold.RegisterKernel(new CSharpKernel());
+
+        CellModel? last = null;
+        foreach (var source in cellSources)
+        {
+            last = scaffold.AddCell(source: source);
+            await scaffold.ExecuteCellAsync(last.Id);
+        }
+
+        return last?.Outputs.ToList() ?? new List<CellOutput>();
+    }
+
+    private static void AssertProduced(IReadOnlyList<CellOutput> outputs, string expected)
+    {
+        Assert.IsTrue(
+            outputs.Any(o => o.Content.Contains(expected, StringComparison.Ordinal)),
+            $"Expected an output containing '{expected}'. Got: " +
+            string.Join(" | ", outputs.Select(o => $"[{(o.IsError ? "error" : "ok")}] {o.Content}")));
+    }
+
+    [TestMethod]
+    [Timeout(120_000)]
+    public async Task NestedImport_ResolvesBesideTheImportingFile()
+    {
+        var helpers = Directory.CreateDirectory(Path.Combine(_root.FullName, "helpers"));
+        await File.WriteAllTextAsync(Path.Combine(helpers.FullName, "Inner.cs"),
+            "public static class Inner { public static string V => \"inner\"; }");
+        await File.WriteAllTextAsync(Path.Combine(helpers.FullName, "Outer.cs"),
+            "#!import Inner.cs\npublic static class Outer { public static string V => \"outer sees \" + Inner.V; }");
+
+        var outputs = await RunAsync(
+            Path.Combine(_root.FullName, "notebook.verso"),
+            "#!import helpers/Outer.cs",
+            "Outer.V");
+
+        AssertProduced(outputs, "outer sees inner");
+    }
+
+    [TestMethod]
+    [Timeout(120_000)]
+    public async Task NestedImport_UnderADirectoryWhoseNameHasASpace()
+    {
+        // The defect this guards: the resolved path used to be written back into the directive
+        // text, and the parser that reads it back ends a path at the first space.
+        //
+        // The notebook sits inside the directory whose name has the space, so every path anyone
+        // writes is short and space-free. Only the resolved path holds one, which is the whole
+        // point: nobody has to write anything unusual to hit this.
+        //
+        // Inner.cs sits beside Outer.cs and nowhere else, so resolving against the notebook
+        // cannot reach it. Without that, falling back to the notebook would quietly find the
+        // file anyway and this would pass whether the resolved path survived or not.
+        var workspace = Directory.CreateDirectory(Path.Combine(_root.FullName, "my helpers"));
+        var lib = Directory.CreateDirectory(Path.Combine(workspace.FullName, "lib"));
+        await File.WriteAllTextAsync(Path.Combine(lib.FullName, "Inner.cs"),
+            "public static class Inner { public static string V => \"inner\"; }");
+        await File.WriteAllTextAsync(Path.Combine(lib.FullName, "Outer.cs"),
+            "#!import Inner.cs\npublic static class Outer { public static string V => \"outer sees \" + Inner.V; }");
+
+        var outputs = await RunAsync(
+            Path.Combine(workspace.FullName, "notebook.verso"),
+            "#!import lib/Outer.cs",
+            "Outer.V");
+
+        AssertProduced(outputs, "outer sees inner");
+    }
+
+    [TestMethod]
+    [Timeout(120_000)]
+    public async Task NestedImport_FallsBackToTheNotebookWhenNothingSitsBeside()
+    {
+        var shared = Directory.CreateDirectory(Path.Combine(_root.FullName, "shared"));
+        await File.WriteAllTextAsync(Path.Combine(shared.FullName, "Common.cs"),
+            "public static class Common { public static string V => \"common\"; }");
+
+        var helpers = Directory.CreateDirectory(Path.Combine(_root.FullName, "helpers"));
+        // No shared/Common.cs sits beside this file, so the path keeps meaning what it meant
+        // before an importing directory was consulted at all.
+        await File.WriteAllTextAsync(Path.Combine(helpers.FullName, "Uses.cs"),
+            "#!import shared/Common.cs\npublic static class Uses { public static string V => \"uses \" + Common.V; }");
+
+        var outputs = await RunAsync(
+            Path.Combine(_root.FullName, "notebook.verso"),
+            "#!import helpers/Uses.cs",
+            "Uses.V");
+
+        AssertProduced(outputs, "uses common");
+    }
+
+    [TestMethod]
+    [Timeout(120_000)]
+    public async Task NestedImport_BesideWinsOverTheNotebookForTheSameName()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_root.FullName, "Same.cs"),
+            "public static class Same { public static string V => \"notebook copy\"; }");
+
+        var helpers = Directory.CreateDirectory(Path.Combine(_root.FullName, "helpers"));
+        await File.WriteAllTextAsync(Path.Combine(helpers.FullName, "Same.cs"),
+            "public static class Same { public static string V => \"neighbour copy\"; }");
+        await File.WriteAllTextAsync(Path.Combine(helpers.FullName, "Picks.cs"),
+            "#!import Same.cs\npublic static class Picks { public static string V => Same.V; }");
+
+        var outputs = await RunAsync(
+            Path.Combine(_root.FullName, "notebook.verso"),
+            "#!import helpers/Picks.cs",
+            "Picks.V");
+
+        AssertProduced(outputs, "neighbour copy");
+    }
+
+    [TestMethod]
+    [Timeout(120_000)]
+    public async Task NestedImport_TwoFilesNamingEachOther_Terminates()
+    {
+        // Without the guard this recurses until the kernel gives out, which took minutes rather
+        // than failing. The timeout is the assertion that matters here.
+        await File.WriteAllTextAsync(Path.Combine(_root.FullName, "First.cs"),
+            "#!import Second.cs\npublic static class First { public static string V => \"first\"; }");
+        await File.WriteAllTextAsync(Path.Combine(_root.FullName, "Second.cs"),
+            "#!import First.cs\npublic static class Second { public static string V => \"second\"; }");
+
+        var outputs = await RunAsync(
+            Path.Combine(_root.FullName, "notebook.verso"),
+            "#!import First.cs",
+            "\"survived\"");
+
+        AssertProduced(outputs, "survived");
+    }
+
+    [TestMethod]
+    [Timeout(120_000)]
+    public async Task NestedImport_ThreeDeepAcrossDirectories()
+    {
+        var one = Directory.CreateDirectory(Path.Combine(_root.FullName, "one"));
+        var two = Directory.CreateDirectory(Path.Combine(one.FullName, "two"));
+
+        await File.WriteAllTextAsync(Path.Combine(two.FullName, "L3.cs"),
+            "public static class L3 { public static string V => \"L3\"; }");
+        await File.WriteAllTextAsync(Path.Combine(two.FullName, "L2.cs"),
+            "#!import L3.cs\npublic static class L2 { public static string V => \"L2>\" + L3.V; }");
+        // Resolved beside L1, which is one level up from L2 and L3.
+        await File.WriteAllTextAsync(Path.Combine(one.FullName, "L1.cs"),
+            "#!import two/L2.cs\npublic static class L1 { public static string V => \"L1>\" + L2.V; }");
+
+        var outputs = await RunAsync(
+            Path.Combine(_root.FullName, "notebook.verso"),
+            "#!import one/L1.cs",
+            "L1.V");
+
+        AssertProduced(outputs, "L1>L2>L3");
+    }
+
+    [TestMethod]
+    [Timeout(120_000)]
+    public async Task ImportInsideAnImportedNotebook_ResolvesBesideThatNotebook()
+    {
+        // The importing directory is set before either kind of import is dispatched, so a cell
+        // inside an imported notebook reads its own neighbours too.
+        var sub = Directory.CreateDirectory(Path.Combine(_root.FullName, "sub"));
+        await File.WriteAllTextAsync(Path.Combine(sub.FullName, "Helper.cs"),
+            "public static class Helper { public static string V => \"helper\"; }");
+        await File.WriteAllTextAsync(Path.Combine(sub.FullName, "inner.verso"),
+            """
+            {
+              "verso": "1.0",
+              "metadata": { "defaultKernel": "csharp" },
+              "cells": [
+                { "id": "a1000000-0000-0000-0000-000000000001", "type": "code",
+                  "language": "csharp", "source": "#!import Helper.cs" }
+              ]
+            }
+            """);
+
+        var outputs = await RunAsync(
+            Path.Combine(_root.FullName, "notebook.verso"),
+            "#!import sub/inner.verso",
+            "Helper.V");
+
+        AssertProduced(outputs, "helper");
+    }
+}


### PR DESCRIPTION
This pull request improves the behavior and reliability of the `#!import` magic command in the Verso project, focusing on correct handling of nested imports, directive execution ordering, and user expectations regarding code execution. The changes also update related tests to match the new logic and clarify documentation.

**Key improvements and changes:**

### Import logic and execution order

* Refactored the import process so that magic directives in source files are executed individually and in priority order (package directives first, then imports, then others), followed by the file's own code. This ensures each directive is handled correctly and code is not skipped unintentionally. (`ImportMagicCommand.cs`) [[1]](diffhunk://#diff-89585b7ad1a42fcf50aa3823867709a9856fb78f6e58c55655a89db313ccb48eL219-R264) [[2]](diffhunk://#diff-89585b7ad1a42fcf50aa3823867709a9856fb78f6e58c55655a89db313ccb48eR284-R306) [[3]](diffhunk://#diff-89585b7ad1a42fcf50aa3823867709a9856fb78f6e58c55655a89db313ccb48eR323-R382) [[4]](diffhunk://#diff-89585b7ad1a42fcf50aa3823867709a9856fb78f6e58c55655a89db313ccb48eR61-R76)
* Added logic to prevent infinite recursion when files import each other, by tracking files currently being imported and skipping re-imports in the same execution flow. (`ImportMagicCommand.cs`) [[1]](diffhunk://#diff-89585b7ad1a42fcf50aa3823867709a9856fb78f6e58c55655a89db313ccb48eR61-R76) [[2]](diffhunk://#diff-89585b7ad1a42fcf50aa3823867709a9856fb78f6e58c55655a89db313ccb48eR100-R110) [[3]](diffhunk://#diff-89585b7ad1a42fcf50aa3823867709a9856fb78f6e58c55655a89db313ccb48eR136-R140)

### Nested import path handling

* Implemented `RebaseImportLine` to resolve nested import paths relative to the importing file, making helper files and folders more portable and intuitive to use. (`ImportMagicCommand.cs`) [[1]](diffhunk://#diff-89585b7ad1a42fcf50aa3823867709a9856fb78f6e58c55655a89db313ccb48eR284-R306) [[2]](diffhunk://#diff-89585b7ad1a42fcf50aa3823867709a9856fb78f6e58c55655a89db313ccb48eR323-R382)

### Documentation and comments

* Clarified XML documentation to explain the new import behavior, nested import resolution, and the rationale for directive execution order. (`ImportMagicCommand.cs`) [[1]](diffhunk://#diff-89585b7ad1a42fcf50aa3823867709a9856fb78f6e58c55655a89db313ccb48eL25-R34) [[2]](diffhunk://#diff-89585b7ad1a42fcf50aa3823867709a9856fb78f6e58c55655a89db313ccb48eL219-R264)

### Test updates

* Updated tests to reflect the new import logic: assertions now expect that `SuppressExecution` is not set, and that directives and code are executed in the correct order and isolation. (`ImportMagicCommandTests.cs`) [[1]](diffhunk://#diff-54bbd1a23324a4ebe6547c6fc106ee39fe65d1012fb0208409bc4adbc22362f7L36-R57) [[2]](diffhunk://#diff-54bbd1a23324a4ebe6547c6fc106ee39fe65d1012fb0208409bc4adbc22362f7L71-R71) [[3]](diffhunk://#diff-54bbd1a23324a4ebe6547c6fc106ee39fe65d1012fb0208409bc4adbc22362f7L93-R93) [[4]](diffhunk://#diff-54bbd1a23324a4ebe6547c6fc106ee39fe65d1012fb0208409bc4adbc22362f7L130-R130) [[5]](diffhunk://#diff-54bbd1a23324a4ebe6547c6fc106ee39fe65d1012fb0208409bc4adbc22362f7L749-R749) [[6]](diffhunk://#diff-54bbd1a23324a4ebe6547c6fc106ee39fe65d1012fb0208409bc4adbc22362f7L776-R776) [[7]](diffhunk://#diff-54bbd1a23324a4ebe6547c6fc106ee39fe65d1012fb0208409bc4adbc22362f7L801-R801) [[8]](diffhunk://#diff-54bbd1a23324a4ebe6547c6fc106ee39fe65d1012fb0208409bc4adbc22362f7L827-R842) [[9]](diffhunk://#diff-54bbd1a23324a4ebe6547c6fc106ee39fe65d1012fb0208409bc4adbc22362f7L866-R874)

### Code hygiene

* Added missing `System.Collections.Immutable` import for thread-safe tracking of in-progress imports. (`ImportMagicCommand.cs`)

These changes make the import process more robust, predictable, and user-friendly, especially when working with complex, nested, or reusable code files.