### PR TITLE
Fix native library resolution when a same-named DLL exists in a PATH directory

### DIFF
--- a/src/Verso/Kernels/NativeLibraryResolver.cs
+++ b/src/Verso/Kernels/NativeLibraryResolver.cs
@@ -13,12 +13,21 @@ namespace Verso.Kernels;
 ///   <item>Native libraries (e.g. <c>e_sqlite3</c>) extracted from <c>runtimes/{rid}/native/</c>
 ///     can be found at runtime.</item>
 /// </list>
+/// Native resolution also installs a per-assembly <see cref="NativeLibrary.SetDllImportResolver"/>
+/// on every managed assembly loaded from a NuGet package directory. A plain
+/// <see cref="AssemblyLoadContext.ResolvingUnmanagedDll"/> handler only runs after the runtime's
+/// default native probing has failed, and on Windows that default probing searches the PATH via
+/// <c>LoadLibrary</c> — so a copy of a native library that happens to live in any PATH directory
+/// (e.g. another app's <c>libSkiaSharp.dll</c>) would win over the package's own native asset.
+/// A <c>DllImportResolver</c> is consulted before default probing, so it restores the intended
+/// precedence of the extracted NuGet native libraries.
 /// </summary>
 internal static class NuGetRuntimeResolver
 {
     private static readonly object Lock = new();
     private static readonly List<string> NativeSearchDirs = new();
     private static readonly List<string> ManagedSearchDirs = new();
+    private static readonly HashSet<string> AssembliesWithResolver = new(StringComparer.OrdinalIgnoreCase);
     private static bool _registered;
 
     /// <summary>
@@ -67,6 +76,70 @@ internal static class NuGetRuntimeResolver
 
         AssemblyLoadContext.Default.Resolving += OnResolvingManagedAssembly;
         AssemblyLoadContext.Default.ResolvingUnmanagedDll += OnResolvingUnmanagedDll;
+        AppDomain.CurrentDomain.AssemblyLoad += (s, e) => AttachDllImportResolver(e.LoadedAssembly);
+    }
+
+    // --- Per-assembly native resolution (takes precedence over PATH probing) ---
+
+    /// <summary>
+    /// Attaches a <see cref="NativeLibrary.SetDllImportResolver"/> to a managed assembly that
+    /// was loaded from a NuGet package directory. The resolver is consulted by the runtime
+    /// before its default native probing, so package native assets win over unrelated copies
+    /// of the same library found through the PATH.
+    /// </summary>
+    private static void AttachDllImportResolver(Assembly assembly)
+    {
+        string location;
+        try
+        {
+            // Throws for assemblies with no backing file, and returns empty for some others.
+            location = assembly.Location;
+        }
+        catch
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(location))
+            return;
+
+        // Only package-loaded assemblies get the resolver; framework and app assemblies keep
+        // the stock behavior and avoid the per-P/Invoke lookup overhead.
+        if (!IsFromPackageDirectory(location))
+            return;
+
+        lock (Lock)
+        {
+            if (!AssembliesWithResolver.Add(location))
+                return;
+        }
+
+        try
+        {
+            NativeLibrary.SetDllImportResolver(assembly, (libraryName, asm, _) => TryResolveNative(asm, libraryName));
+        }
+        catch
+        {
+            // Best effort — resolution still falls back to the ResolvingUnmanagedDll handler.
+        }
+    }
+
+    /// <summary>
+    /// Returns whether an assembly file was loaded from one of the registered NuGet package
+    /// directories (managed assemblies live directly in <c>.../{packageId}/{version}/</c>).
+    /// </summary>
+    private static bool IsFromPackageDirectory(string location)
+    {
+        lock (Lock)
+        {
+            foreach (var dir in ManagedSearchDirs)
+            {
+                if (location.StartsWith(dir, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+        }
+
+        return false;
     }
 
     // --- Managed assembly resolution ---
@@ -120,7 +193,12 @@ internal static class NuGetRuntimeResolver
         var sawTpaConflict = false;
         foreach (var candidate in candidates)
         {
-            try { return context.LoadFromAssemblyPath(candidate); }
+            try
+            {
+                var assembly = context.LoadFromAssemblyPath(candidate);
+                AttachDllImportResolver(assembly);
+                return assembly;
+            }
             catch (FileLoadException) { sawTpaConflict = true; }
             catch { /* try next */ }
         }
@@ -129,7 +207,12 @@ internal static class NuGetRuntimeResolver
         {
             foreach (var candidate in candidates)
             {
-                try { return IsolationContext.LoadFromAssemblyPath(candidate); }
+                try
+                {
+                    var assembly = IsolationContext.LoadFromAssemblyPath(candidate);
+                    AttachDllImportResolver(assembly);
+                    return assembly;
+                }
                 catch { /* try next */ }
             }
         }
@@ -140,6 +223,15 @@ internal static class NuGetRuntimeResolver
     // --- Native library resolution ---
 
     private static IntPtr OnResolvingUnmanagedDll(Assembly assembly, string libraryName)
+        => TryResolveNative(assembly, libraryName);
+
+    /// <summary>
+    /// Searches the registered native library directories for a library matching
+    /// <paramref name="libraryName"/>. Shared by the <see cref="AssemblyLoadContext.ResolvingUnmanagedDll"/>
+    /// fallback handler and the per-assembly <see cref="DllImportResolver"/> attached by
+    /// <see cref="AttachDllImportResolver"/>.
+    /// </summary>
+    private static IntPtr TryResolveNative(Assembly assembly, string libraryName)
     {
         string[] dirs;
         lock (Lock)


### PR DESCRIPTION
## Summary

Notebooks that load native dependencies via `#r "nuget: ..."` fail with a native library version mismatch if an unrelated copy of the library happens to live in any directory on the `PATH`.

```text
[error] System.TypeInitializationException: The type initializer for 'ScottPlot.Fonts' threw an exception.
  ---> System.TypeInitializationException: The type initializer for 'SkiaSharp.SKTypeface' threw an exception.
  ---> System.TypeInitializationException: The type initializer for 'SkiaSharp.SKObject' threw an exception.
  ---> System.InvalidOperationException: The version of the native libSkiaSharp library (80.2) is incompatible with this version of SkiaSharp. Supported versions of the native libSkiaSharp library are in the range [119.0, 120.0).
```

Issue #91 will be fixed

## Minimal reproduction

1. Create a folder, e.g. `C:\native-pollution`, and add it to your `PATH`.
2. Download [libSkiaSharp.dll](https://github.com/user-attachments/files/30747739/libSkiaSharp.dll.zip) (80.2) and place it in that folder.
3. Run the following in a Verso notebook:




```csharp
#r "nuget:ScottPlot, 5.1.59"
using ScottPlot;

double[] xs = Generate.Consecutive(51);
double[] ys = Generate.Sin(51);
double[] ys2 = Generate.Cos(51);

var plt = new Plot();
plt.Add.Scatter(xs, ys);
plt.Add.Scatter(xs, ys2);
plt.Title("ScottPlot Example: Sine and Cosine");
plt.XLabel("X");
plt.YLabel("Y");

plt.GetSvgHtml(600, 400).Display("text/html")
```

**Before the fix:** the run fails with the `libSkiaSharp (80.2) is incompatible ... [119.0, 120.0)` error shown above.

**After the fix:** all cells succeed; ScottPlot renders using the 3.119.0 native asset from the NuGet cache.

**Control:** remove `libSkiaSharp.dll` from the folder (or drop the folder from `PATH`) and the notebook works both before and after the fix.


## Root cause

Native resolution was handled only through `AssemblyLoadContext.Default.ResolvingUnmanagedDll` (`src/Verso/Kernels/NativeLibraryResolver.cs`). Per the .NET unmanaged loading algorithm, that event fires **last**, only *after* the runtime's default native probing has failed. On Windows the default probing uses `LoadLibrary`, whose search includes the directories listed in `PATH`.

So when a stray `libSkiaSharp.dll` (e.g. version 80.2 shipped inside some other app's folder that is on `PATH`) is found by `LoadLibrary`, the wrong native library is loaded successfully — and Verso's resolver never gets a chance to supply the correct one. The same code works in a csproj because there the matching native asset is copied to the app output directory and is found first by default probing.

## How I fixed it

Install a per-assembly `NativeLibrary.SetDllImportResolver` on every managed assembly loaded from a NuGet package directory. A `DllImportResolver` is consulted **before** the default probing, so the native asset extracted from the referenced NuGet package always wins over unrelated copies found through `PATH`.

The resolver reuses the existing search logic (`TryResolveNative`), including the same-package-version preference, and is attached both when we load an assembly through the `Resolving` handler and for any assembly loaded directly from a package directory (tracked via `AppDomain.AssemblyLoad`). The `ResolvingUnmanagedDll` handler is kept as a fallback for libraries not found by default probing (e.g. `e_sqlite3`).