### PR TITLE
Expose verso_* tools to Copilot agent mode

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -269,10 +269,11 @@
     "languageModelTools": [
       {
         "name": "verso_listCells",
+        "toolReferenceName": "verso_listCells",
         "tags": ["verso", "notebook", "cells"],
         "displayName": "%tool.listCells.displayName%",
         "modelDescription": "List all cells in the active Verso notebook, showing each cell's source code, language, and outputs.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {}
@@ -280,10 +281,11 @@
       },
       {
         "name": "verso_addCell",
+        "toolReferenceName": "verso_addCell",
         "tags": ["verso", "notebook", "cells"],
         "displayName": "%tool.addCell.displayName%",
         "modelDescription": "Add a new cell to the Verso notebook. The 'type' field determines the cell kind. For code cells, also set 'language' to the kernel. For non-code types (markdown, html, mermaid, etc.), only type is needed. Refer to the system prompt for available cell types and languages.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -309,10 +311,11 @@
       },
       {
         "name": "verso_updateCell",
+        "toolReferenceName": "verso_updateCell",
         "tags": ["verso", "notebook", "cells"],
         "displayName": "%tool.updateCell.displayName%",
         "modelDescription": "Update the source code of an existing cell. Use the 1-based cell number (call verso_listCells first to find it).",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -330,10 +333,11 @@
       },
       {
         "name": "verso_removeCell",
+        "toolReferenceName": "verso_removeCell",
         "tags": ["verso", "notebook", "cells"],
         "displayName": "%tool.removeCell.displayName%",
         "modelDescription": "Remove a cell from the notebook by its 1-based cell number.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -347,10 +351,11 @@
       },
       {
         "name": "verso_runCell",
+        "toolReferenceName": "verso_runCell",
         "tags": ["verso", "notebook", "execution"],
         "displayName": "%tool.runCell.displayName%",
         "modelDescription": "Execute a specific cell by its 1-based cell number and return the output.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -364,10 +369,11 @@
       },
       {
         "name": "verso_runAll",
+        "toolReferenceName": "verso_runAll",
         "tags": ["verso", "notebook", "execution"],
         "displayName": "%tool.runAll.displayName%",
         "modelDescription": "Execute all cells in the notebook sequentially and return results.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {}
@@ -375,10 +381,11 @@
       },
       {
         "name": "verso_listVariables",
+        "toolReferenceName": "verso_listVariables",
         "tags": ["verso", "notebook", "variables"],
         "displayName": "%tool.listVariables.displayName%",
         "modelDescription": "List all variables currently in scope in the notebook kernel, showing name, type, and value preview.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {}
@@ -386,10 +393,11 @@
       },
       {
         "name": "verso_inspectVariable",
+        "toolReferenceName": "verso_inspectVariable",
         "tags": ["verso", "notebook", "variables"],
         "displayName": "%tool.inspectVariable.displayName%",
         "modelDescription": "Get the detailed value of a specific variable by name.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -403,10 +411,11 @@
       },
       {
         "name": "verso_getLanguages",
+        "toolReferenceName": "verso_getLanguages",
         "tags": ["verso", "notebook"],
         "displayName": "%tool.getLanguages.displayName%",
         "modelDescription": "List the available languages/kernels for the active notebook.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {}
@@ -414,10 +423,11 @@
       },
       {
         "name": "verso_listParameters",
+        "toolReferenceName": "verso_listParameters",
         "tags": ["verso", "notebook", "parameters"],
         "displayName": "%tool.listParameters.displayName%",
         "modelDescription": "List all parameters defined in the notebook. Parameters are named, typed values (string, int, float, bool, date, datetime) that can be set before execution to control notebook behavior.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {}
@@ -425,10 +435,11 @@
       },
       {
         "name": "verso_addParameter",
+        "toolReferenceName": "verso_addParameter",
         "tags": ["verso", "notebook", "parameters"],
         "displayName": "%tool.addParameter.displayName%",
         "modelDescription": "Add a new parameter to the notebook. Supported types: string, int, float, bool, date (yyyy-MM-dd), datetime (ISO 8601). A parameters cell is automatically created if one does not exist.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -459,10 +470,11 @@
       },
       {
         "name": "verso_updateParameter",
+        "toolReferenceName": "verso_updateParameter",
         "tags": ["verso", "notebook", "parameters"],
         "displayName": "%tool.updateParameter.displayName%",
         "modelDescription": "Update an existing parameter's properties. Only the fields you provide will be changed. Use verso_listParameters first to see current parameters.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -493,10 +505,11 @@
       },
       {
         "name": "verso_removeParameter",
+        "toolReferenceName": "verso_removeParameter",
         "tags": ["verso", "notebook", "parameters"],
         "displayName": "%tool.removeParameter.displayName%",
         "modelDescription": "Remove a parameter from the notebook by name. This also removes the corresponding variable from the kernel.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -510,10 +523,11 @@
       },
       {
         "name": "verso_getCellProperties",
+        "toolReferenceName": "verso_getCellProperties",
         "tags": ["verso", "notebook", "properties"],
         "displayName": "%tool.getCellProperties.displayName%",
         "modelDescription": "Get the configurable properties for a specific cell. Properties are extension-provided settings like visibility, formatting, or tags. Call this before verso_updateCellProperty to discover available properties and their current values. The response includes providerExtensionId values needed for updates.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -527,10 +541,11 @@
       },
       {
         "name": "verso_updateCellProperty",
+        "toolReferenceName": "verso_updateCellProperty",
         "tags": ["verso", "notebook", "properties"],
         "displayName": "%tool.updateCellProperty.displayName%",
         "modelDescription": "Update a property on a cell. Call verso_getCellProperties first to discover the available properties, their field types, and the providerExtensionId needed for this call. For Select fields, use the option value (not display name). For Toggle fields, use 'true' or 'false'.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -556,10 +571,11 @@
       },
       {
         "name": "verso_listLayouts",
+        "toolReferenceName": "verso_listLayouts",
         "tags": ["verso", "notebook", "layout"],
         "displayName": "%tool.listLayouts.displayName%",
         "modelDescription": "List the layouts registered for this notebook (for example Notebook or Dashboard). Each entry includes its displayName, the extensionId and layoutId needed by verso_switchLayout, and whether it is currently active. Call this before verso_switchLayout to discover the qualified identity of the target layout.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {}
@@ -567,10 +583,11 @@
       },
       {
         "name": "verso_switchLayout",
+        "toolReferenceName": "verso_switchLayout",
         "tags": ["verso", "notebook", "layout"],
         "displayName": "%tool.switchLayout.displayName%",
         "modelDescription": "Switch the notebook's active layout. Call verso_listLayouts first to get the extensionId and layoutId of the target layout. The choice is saved with the notebook. Some layouts (such as Dashboard) present cells differently, for example output-only with grid positions.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -588,10 +605,11 @@
       },
       {
         "name": "verso_moveCell",
+        "toolReferenceName": "verso_moveCell",
         "tags": ["verso", "notebook", "cells"],
         "displayName": "%tool.moveCell.displayName%",
         "modelDescription": "Move a cell to a different position in the notebook. Both numbers are 1-based. Call verso_listCells first to confirm the current order.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -609,10 +627,11 @@
       },
       {
         "name": "verso_changeCellType",
+        "toolReferenceName": "verso_changeCellType",
         "tags": ["verso", "notebook", "cells"],
         "displayName": "%tool.changeCellType.displayName%",
         "modelDescription": "Change a cell's type (for example code, markdown, html, mermaid). Call verso_getLanguages or verso_listCells to see available types. Changing the type clears the cell's outputs. For code cells the language is set automatically; use verso_changeCellLanguage to choose a different one.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -630,10 +649,11 @@
       },
       {
         "name": "verso_changeCellLanguage",
+        "toolReferenceName": "verso_changeCellLanguage",
         "tags": ["verso", "notebook", "cells"],
         "displayName": "%tool.changeCellLanguage.displayName%",
         "modelDescription": "Change the kernel language of a code cell (for example csharp, sql, python). Call verso_getLanguages to list valid languages. Changing the language clears the cell's outputs.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
## Problem

The VS Code extension's README states:

> **Agent mode:** Verso registers twenty language model tools, so Copilot can list, add, edit, move, and run cells … without you typing `@verso` at all.

On current VS Code this does not work: none of the `verso_*` tools appear in the agent-mode tool set or the tools picker. They are only reachable through the `@verso` participant, which runs its own tool-calling loop and doesn't share the main agent's conversation context.

## Root cause

All 20 tools in `vscode/package.json` declare `"canBeReferencedInPrompt": false`. VS Code uses this flag to decide which extension tools enter agent mode:

- `src/vs/workbench/contrib/chat/browser/widget/input/chatSelectedTools.ts` — tools included only `if (tool.canBeReferencedInPrompt)`
- `src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts` — same filter in the tools picker
- Docs: https://code.visualstudio.com/api/extension-guides/ai/tools — "Set to true if the tool can be used with agents or referenced in chat."

## The fix (and why `toolReferenceName` is mandatory)

Setting only `canBeReferencedInPrompt: true` breaks the extension: VS Code rejects such tools at scan time (`languageModelToolsContribution.ts`: *"CANNOT register tool with 'canBeReferencedInPrompt' set without a 'toolReferenceName'"*), and every `vscode.lm.registerTool()` call then fails with `Error: Tool "verso_listCells" was not contributed.` — which also breaks `@verso` itself.

This PR sets, for every tool: `"canBeReferencedInPrompt": true` + `"toolReferenceName": "<tool name>"` (pattern `^[\w-]+$` — tool names already qualify).

## Verification

Patched a local v1.2.1 install (VS Code 1.133.0): after reload, all 20 tools appear and work: list/add/update/remove/move cells, change type & language (C#→F#), run cell/run-all (stdout + final-expression values), list/inspect variables, add/update/remove parameters, get/update cell properties, list/switch layouts. `@verso` continues to work unchanged.